### PR TITLE
TAO-435: QTI Item with PCI cannot export

### DIFF
--- a/helpers/class.Export.php
+++ b/helpers/class.Export.php
@@ -62,6 +62,12 @@ class tao_helpers_Export
             $fileName = empty($filename) ? basename($fullpath) : $filename;
             header('Content-Disposition: attachment; fileName="'.$fileName.'"');
             header("Content-Length: " . filesize($fullpath));
+            
+            //Clean all levels of output buffering
+            while (ob_get_level() > 0) { 
+                ob_end_clean();
+            }
+            
             flush();
             $fp = fopen($fullpath, "r");
             if ($fp !== false) {


### PR DESCRIPTION
Before sending archive to the end user should be cleaned all levels of output buffering. Otherwise user may get corrupted file.