### PR TITLE
Fix/562 filtered tree classes

### DIFF
--- a/models/classes/class.GenerisService.php
+++ b/models/classes/class.GenerisService.php
@@ -1,36 +1,36 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2002-2008 (original work) Public Research Centre Henri Tudor & University of Luxembourg (under the project TAO & TAO2);
  *               2008-2010 (update and modification) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- * 
- * 
+ *
+ *
  */
 
 
 /**
- * The Service class is an abstraction of each service instance. 
+ * The Service class is an abstraction of each service instance.
  * Used to centralize the behavior related to every servcie instances.
  *
  * @abstract
  * @access public
  * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
  * @package tao
- 
+
  */
 abstract class tao_models_classes_GenerisService
     extends tao_models_classes_Service
@@ -45,8 +45,8 @@ abstract class tao_models_classes_GenerisService
      */
     protected function __construct()
     {
-        
-        
+
+
     }
 
 
@@ -203,7 +203,7 @@ abstract class tao_models_classes_GenerisService
     public function cloneInstance( core_kernel_classes_Resource $instance,  core_kernel_classes_Class $clazz = null)
     {
         $returnValue = null;
- 
+
         if (is_null($clazz)) {
             $types = $instance->getTypes();
             $clazz = current($types);
@@ -228,9 +228,9 @@ abstract class tao_models_classes_GenerisService
 
         return $returnValue;
     }
-    
+
     /**
-     * 
+     *
      * @author Lionel Lecaque, lionel@taotesting.com
      * @param core_kernel_classes_Resource $source
      * @param core_kernel_classes_Resource $destination
@@ -251,7 +251,7 @@ abstract class tao_models_classes_GenerisService
             }
         }
     }
-    
+
 
     /**
      * Clone a Class and move it under the newParentClazz
@@ -267,7 +267,7 @@ abstract class tao_models_classes_GenerisService
     {
         $returnValue = null;
 
-        
+
 
     	if(!is_null($sourceClazz) && !is_null($newParentClazz)){
         	if((is_null($topLevelClazz))){
@@ -297,7 +297,7 @@ abstract class tao_models_classes_GenerisService
         	}
         }
 
-        
+
 
         return $returnValue;
     }
@@ -397,7 +397,7 @@ abstract class tao_models_classes_GenerisService
 
 		$returnValue = array_merge($returnValue, $clazz->getProperties(false));
 
-        
+
 
         return (array) $returnValue;
     }
@@ -465,7 +465,7 @@ abstract class tao_models_classes_GenerisService
 			print $e;
 		}
 
-        
+
 
         return (array) $returnValue;
     }
@@ -516,7 +516,7 @@ abstract class tao_models_classes_GenerisService
     {
         $returnValue = array();
 
-        
+
         // show subclasses yes/no, not implemented
         $subclasses = (isset($options['subclasses'])) ? $options['subclasses'] : true;
         // show instances yes/no
@@ -540,21 +540,10 @@ abstract class tao_models_classes_GenerisService
         $propertyFilter = (isset($options['propertyFilter'])) ? $options['propertyFilter'] : array();
         // A unique node URI to be returned from as a tree leaf.
         $uniqueNode = (isset($options['uniqueNode'])) ? $options['uniqueNode'] : null;
-        
+
         $factory = new tao_models_classes_GenerisTreeFactory();
-        
-        if ($uniqueNode !== null) {
-            // A unique node has to be retrieved.
-            $uniqueResource = new core_kernel_classes_Resource($uniqueNode);
-            $returnValue = $factory->buildClassNode($clazz);
-            $returnValue['count'] = 0;
-            $returnValue['children'] = array();
-            
-            if ($uniqueResource->exists() === true) {
-                $returnValue['count'] = 1;
-                $returnValue['children'][] = $factory->buildResourceNode($uniqueResource, $clazz);
-            }
-        } elseif (!empty($labelFilter) && $labelFilter!='*') {
+
+        if (!empty($labelFilter) && $labelFilter!='*') {
             // The result must be a set of filtered nodes.
             $props	= array(RDFS_LABEL => $labelFilter);
             $opts	= array(
@@ -562,7 +551,7 @@ abstract class tao_models_classes_GenerisService
                     'limit'		=> $limit,
                     'offset'	=> $offset,
                     'recursive'	=> true
-            ); 
+            );
             $searchResult = $clazz->searchInstances($props, $opts);
             $results = array();
             foreach ($searchResult as $instance){
@@ -576,6 +565,12 @@ abstract class tao_models_classes_GenerisService
                     $returnValue['children']	= $results;
             }
         } else {
+
+            //if unique node is set, it is the node to be loaded in the tree
+            if(!is_null($uniqueNode)){
+                $browse = array($uniqueNode);
+            }
+
             // Let's walk the tree with super walker! ~~~ p==[w]õ__
             array_walk($browse, function(&$item) {
                 $item = tao_helpers_Uri::decode($item);

--- a/models/classes/class.GenerisService.php
+++ b/models/classes/class.GenerisService.php
@@ -1,36 +1,36 @@
 <?php
-/**
+/**  
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- *
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
+ * 
  * Copyright (c) 2002-2008 (original work) Public Research Centre Henri Tudor & University of Luxembourg (under the project TAO & TAO2);
  *               2008-2010 (update and modification) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- *
- *
+ * 
+ * 
  */
 
 
 /**
- * The Service class is an abstraction of each service instance.
+ * The Service class is an abstraction of each service instance. 
  * Used to centralize the behavior related to every servcie instances.
  *
  * @abstract
  * @access public
  * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
  * @package tao
-
+ 
  */
 abstract class tao_models_classes_GenerisService
     extends tao_models_classes_Service
@@ -45,8 +45,8 @@ abstract class tao_models_classes_GenerisService
      */
     protected function __construct()
     {
-
-
+        
+        
     }
 
 
@@ -203,7 +203,7 @@ abstract class tao_models_classes_GenerisService
     public function cloneInstance( core_kernel_classes_Resource $instance,  core_kernel_classes_Class $clazz = null)
     {
         $returnValue = null;
-
+ 
         if (is_null($clazz)) {
             $types = $instance->getTypes();
             $clazz = current($types);
@@ -228,9 +228,9 @@ abstract class tao_models_classes_GenerisService
 
         return $returnValue;
     }
-
+    
     /**
-     *
+     * 
      * @author Lionel Lecaque, lionel@taotesting.com
      * @param core_kernel_classes_Resource $source
      * @param core_kernel_classes_Resource $destination
@@ -251,7 +251,7 @@ abstract class tao_models_classes_GenerisService
             }
         }
     }
-
+    
 
     /**
      * Clone a Class and move it under the newParentClazz
@@ -267,7 +267,7 @@ abstract class tao_models_classes_GenerisService
     {
         $returnValue = null;
 
-
+        
 
     	if(!is_null($sourceClazz) && !is_null($newParentClazz)){
         	if((is_null($topLevelClazz))){
@@ -297,7 +297,7 @@ abstract class tao_models_classes_GenerisService
         	}
         }
 
-
+        
 
         return $returnValue;
     }
@@ -397,7 +397,7 @@ abstract class tao_models_classes_GenerisService
 
 		$returnValue = array_merge($returnValue, $clazz->getProperties(false));
 
-
+        
 
         return (array) $returnValue;
     }
@@ -465,7 +465,7 @@ abstract class tao_models_classes_GenerisService
 			print $e;
 		}
 
-
+        
 
         return (array) $returnValue;
     }
@@ -516,7 +516,7 @@ abstract class tao_models_classes_GenerisService
     {
         $returnValue = array();
 
-
+        
         // show subclasses yes/no, not implemented
         $subclasses = (isset($options['subclasses'])) ? $options['subclasses'] : true;
         // show instances yes/no
@@ -540,9 +540,9 @@ abstract class tao_models_classes_GenerisService
         $propertyFilter = (isset($options['propertyFilter'])) ? $options['propertyFilter'] : array();
         // A unique node URI to be returned from as a tree leaf.
         $uniqueNode = (isset($options['uniqueNode'])) ? $options['uniqueNode'] : null;
-
+        
         $factory = new tao_models_classes_GenerisTreeFactory();
-
+        
         if (!empty($labelFilter) && $labelFilter!='*') {
             // The result must be a set of filtered nodes.
             $props	= array(RDFS_LABEL => $labelFilter);
@@ -551,7 +551,7 @@ abstract class tao_models_classes_GenerisService
                     'limit'		=> $limit,
                     'offset'	=> $offset,
                     'recursive'	=> true
-            );
+            ); 
             $searchResult = $clazz->searchInstances($props, $opts);
             $results = array();
             foreach ($searchResult as $instance){
@@ -568,7 +568,7 @@ abstract class tao_models_classes_GenerisService
 
             //if unique node is set, it is the node to be loaded in the tree
             if(!is_null($uniqueNode)){
-                $browse = array($uniqueNode);
+                 $browse = array($uniqueNode);
             }
 
             // Let's walk the tree with super walker! ~~~ p==[w]õ__

--- a/views/js/layout/actions/common.js
+++ b/views/js/layout/actions/common.js
@@ -48,7 +48,7 @@ define([
         binder.register('loadClass', function load(actionContext){
             section.current().loadContentBlock(this.url, {classUri: actionContext.classUri, id: uri.decode(actionContext.classUri)});
         });
-        
+
         /**
          * Register the subClass action: creates a sub class
          *
@@ -155,9 +155,9 @@ define([
                 uri: uri.decode(actionContext.uri),
                 classUri: uri.decode(actionContext.classUri),
                 id: actionContext.id
-            }
+            };
             //TODO replace by a nice popup
-            if (confirm(__("Please confirm deletion"))) {
+            if (window.confirm(__("Please confirm deletion"))) {
                 $.ajax({
                     url: this.url,
                     type: "POST",

--- a/views/js/layout/tree.js
+++ b/views/js/layout/tree.js
@@ -2,9 +2,9 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
-    'jquery', 
+    'jquery',
     'lodash',
-    'i18n', 
+    'i18n',
     'context',
     'store',
     'layout/actions',
@@ -19,7 +19,7 @@ define([
     /**
      * The tree factory helps you to intantiate a new tree from the TAO ontology
      * @exports layout/tree
-     * 
+     *
      * @param {jQueryElement} $elt - that will contain the tree
      * @param {String} url - the endpoint to load data
      * @param {Object} [options] - additional configuration options
@@ -31,10 +31,10 @@ define([
      * @param {String} [options.actions.deleteInstance] - the id of the action bound (using actionManager.register) on delete
      * @param {String} [options.selectNode] - the URI of the node to be selected by default, the node must be loaded.
      * @param {String} [options.loadNode] - the URI of a node to be loaded from the server side and selected.
-     * 
+     *
      */
     var treeFactory = function($elt, url, options){
-        
+
         options = options || {};
 
         var lastOpened;
@@ -102,10 +102,10 @@ define([
 
             //theme
             ui: {
-                theme_name : "css",
-                theme_path : context.taobase_www + 'js/lib/jsTree/themes/css/style.css'
+                "theme_name" : "css",
+                "theme_path" : context.taobase_www + 'js/lib/jsTree/themes/css/style.css'
             },
-        
+
             //nodes types
             types: {
                 "default" : {
@@ -137,30 +137,35 @@ define([
 
                     //check for additionnal parameters in tree state
                     if(treeData){
+
+                        //the tree has been loaded/refreshed with the filtering
                         if(_.isString(treeData.filter) && treeData.filter.length){
                             params.filter = treeData.filter;
                             treeData = _.omit(treeData, 'filter');
                         }
+
+                        //the tree has been loaded/refreshed with the loadNode parameter, so it has to be selected
                         if(_.isString(treeData.loadNode) && treeData.loadNode.length){
                             params.loadNode = treeData.loadNode;
+                            treeData.selectNode = uri.encode(params.loadNode);
                             treeData = _.omit(treeData, 'loadNode');
                         }
-                        
+
                         $elt.data('tree-state', treeData);
                     }
                     return params;
                 },
 
                 /**
-                 * Called back once the data are received. 
+                 * Called back once the data are received.
                  * Used to modify them before building the tree.
-                 * 
+                 *
                  * @param {Object} data - the received data
-                 * @param {Object} tree - the tree instance 
+                 * @param {Object} tree - the tree instance
                  * @returns {Object} data the modified data
                  */
                 ondata: function(data, tree) {
-                    
+
                     if(data.error){
                         feedback().error(data.error);
                         return [];
@@ -170,12 +175,12 @@ define([
                     if (data.children) {
                         data.state = 'open';
                     }
-                    
+
                     computeSelectionAccess(data);
-                    
+
                     flattenPermissions(data);
 
-                    needMore(data); 
+                    needMore(data);
 
                     addTitle(data);
 
@@ -185,8 +190,8 @@ define([
                 /**
                  * Once the data are loaded and the tree is ready
                  * Used to modify them before building the tree.
-                 * 
-                 * @param {Object} tree - the tree instance 
+                 *
+                 * @param {Object} tree - the tree instance
                  *
                  * @fires layout/tree#ready.taotree
                  */
@@ -199,7 +204,7 @@ define([
                     var treeState       = $elt.data('tree-state') || {};
                     var selectNode      = treeState.selectNode || options.selectNode;
                     var nodeSelection   = function nodeSelection(){
-                        //the node to select is given 
+                        //the node to select is given
                         if(selectNode){
                              $selectNode = $('#' + selectNode, $elt);
                              if($selectNode.length && !$selectNode.hasClass('private')){
@@ -219,7 +224,7 @@ define([
                         if ($firstInstance.length) {
                             return tree.select_branch($firstInstance);
                         }
-                        //or something 
+                        //or something
                         return tree.select_branch($('.node-class,.node-instance', $elt).get(0));
                     };
 
@@ -231,19 +236,19 @@ define([
                             _.delay(nodeSelection, 10); //delay needed as jstree seems to doesn't know the callbacks right now...,
                         });
                     }
-                    
+
                     //execute initTree action
                     if (options.actions && options.actions.initTree) {
                         actionManager.exec(options.actions.initTree, {
                             uri: $elt.data('rootnode')
                         });
                     }
-                    
+
                     /**
                      * The tree is now ready
                      * @event layout/tree#ready.taotree
                      * @param {Object} [context] - the tree context (uri, classUri)
-                     */       
+                     */
                     $elt.trigger('ready.taotree');
                 },
 
@@ -258,9 +263,9 @@ define([
 
                 /**
                  * A node is selected.
-                 * 
+                 *
                  * @param {HTMLElement} node - the opened node
-                 * @param {Object} tree - the tree instance 
+                 * @param {Object} tree - the tree instance
                  *
                  * @fires layout/tree#change.taotree
                  * @fires layout/tree#select.taotree
@@ -280,7 +285,7 @@ define([
                     $('a.clicked', $elt)
                         .parent('li')
                         .not('[id="' + nodeId + '"]')
-                        .removeClass('clicked'); 
+                        .removeClass('clicked');
 
                     //the more node makes you load more resources
                     if($node.hasClass('more')){
@@ -297,7 +302,7 @@ define([
                         nodeContext.permissions = permissions[nodeId];
                         nodeContext.id = $node.data('uri');
                         nodeContext.context = ['class', 'resource'];
-                        
+
                         executePossibleAction(options.actions, nodeContext, ['delete']);
                     }
 
@@ -307,11 +312,11 @@ define([
                         nodeContext.classUri = $parentNode.attr('id');
                         nodeContext.id = $node.data('uri');
                         nodeContext.context = ['instance', 'resource'];
-                        
+
                         //the last selected node is stored into the browser storage
-                        treeStore.lastSelected = nodeId; 
+                        treeStore.lastSelected = nodeId;
                         store.set('taotree.' + context.section, treeStore);
-                        
+
                         executePossibleAction(options.actions, nodeContext, ['moveInstance', 'delete']);
                     }
 
@@ -319,7 +324,7 @@ define([
                      * A node has been selected
                      * @event layout/tree#select.taotree
                      * @param {Object} [context] - the tree context (uri, classUri)
-                     */       
+                     */
                     $elt
                       .trigger('select.taotree', [nodeContext])
                       .trigger('change.taotree', [nodeContext]);
@@ -337,12 +342,12 @@ define([
                     if ($(refNode).hasClass('node-instance') && type === 'inside') {
                         $.tree.rollback(rollback);
                         return false;
-                    } 
+                    }
 
                     if (type === 'after' || type === 'before') {
                         refNode = tree.parent(refNode);
                     }
-                    
+
                     //set the rollback data
                     $elt.data('tree-state', _.merge($elt.data('tree-state'), {rollback : rollback}));
 
@@ -357,9 +362,9 @@ define([
             }
         };
 
-        //list of events callbacks to be bound to the tree       
+        //list of events callbacks to be bound to the tree
         var events = {
-            
+
             /**
              * Refresh the tree
              *
@@ -383,7 +388,7 @@ define([
             },
 
             /**
-             * Rollback the tree. 
+             * Rollback the tree.
              * The rollback state must have been set in the state previously, otherwise runs a refresh.
              *
              * @event layout/tree#rollback.taotree
@@ -392,7 +397,7 @@ define([
                 var treeState;
                 var tree =  $.tree.reference($elt);
                 if(tree){
-        
+
                     treeState = $elt.data('tree-state');
                     if(treeState.rollback){
                         tree.rollback(treeState.rollback);
@@ -407,21 +412,21 @@ define([
             },
 
             /**
-             * Add a node to the tree. 
+             * Add a node to the tree.
              *
              * @event layout/tree#addnode.taotree
              * @param {Object} data - the data about the node to add
              * @param {String} data.parent - the id/uri of the node that will contain the new node
              * @param {String} data.id - the id of the new node
              * @param {String} data.cssClass - the css class for the new node (node-instance or node-class at least).
-             */       
+             */
             'addnode' : function (data) {
 
                 var tree =  $.tree.reference($elt);
             	var parentNode = tree.get_node($('#' + uri.encode(data.parent), $elt).get(0));
-            	
+
                 var params = _.clone(serverParams);
-                
+
                 params.classUri = data.parent;
                 if (data.cssClass === 'node-class') {
                     params.hideInstances = 1; //load only class nodes
@@ -454,7 +459,7 @@ define([
              * @event layout/tree#removenode.taotree
              * @param {Object} data - the data about the node to remove
              * @param {String} data.id - the id of the node to remove
-             */       
+             */
             'removenode' : function(data){
                 var tree =  $.tree.reference($elt);
                 var node = tree.get_node($('#' + data.id, $elt).get(0));
@@ -467,7 +472,7 @@ define([
              * @event layout/tree#selectnode.taotree
              * @param {Object} data - the data about the node to select
              * @param {String} data.id - the id of the node to select
-             */       
+             */
             'selectnode' : function(data){
                 var tree =  $.tree.reference($elt);
                 var node = tree.get_node($('#' + data.id, $elt).get(0));
@@ -481,7 +486,7 @@ define([
              * @event layout/tree#openbranch.taotree
              * @param {Object} data - the data about the node to remove
              * @param {String} data.id - the id of the node to remove
-             */       
+             */
             'openbranch' : function(data){
                 var tree =  $.tree.reference($elt);
                 var node = tree.get_node($('#' + data.id, $elt).get(0));
@@ -490,13 +495,13 @@ define([
             }
         };
 
-    
+
         /**
-         * Check if a node has access to a type of action regarding it's permissions 
+         * Check if a node has access to a type of action regarding it's permissions
          * @private
          * @param {String} actionType - in selectClass, selectInstance, moveInstance and delete
          * @param {Object} node       - the node data as recevied from the server
-         * @returns {Boolean} true if the action is allowed 
+         * @returns {Boolean} true if the action is allowed
          */
         var hasAccessTo = function hasAccessTo(actionType, node){
             var action = options.actions[actionType];
@@ -507,7 +512,7 @@ define([
         };
 
         /**
-         * Check whether the nodes in a tree are selectable. If not, we add the <strong>private</strong> class. 
+         * Check whether the nodes in a tree are selectable. If not, we add the <strong>private</strong> class.
          * @private
          * @param {Object} node - the tree node as recevied from the server
          */
@@ -516,7 +521,7 @@ define([
             if(_.isArray(node)){
                 _.forEach(node, computeSelectionAccess);
                 return;
-            } 
+            }
             if(node.type && node.permissions){
                 addClassToNode(node, getPermissionClass(node));
              }
@@ -564,7 +569,7 @@ define([
             if(_.isArray(node)){
                 _.forEach(node, addTitle);
                 return;
-            } 
+            }
             if(node.attributes && node.data){
                 node.attributes.title = node.data;
             }
@@ -582,7 +587,7 @@ define([
             if(_.isArray(node)){
                 _.forEach(node, flattenPermissions);
                 return;
-            } 
+            }
             if(node.attributes && node.attributes.id){
                 permissions[node.attributes.id] = node.permissions;
             }
@@ -591,7 +596,7 @@ define([
             }
         };
 
-        
+
 
         var needMore = function needMore(node){
            if(_.isArray(node) && lastOpened && lastOpened.length && lastOpened.data('count') > pageRange){
@@ -599,7 +604,7 @@ define([
            } else {
                 if(node.count){
                     node.attributes['data-count'] = node.count;
-                    
+
                     if(node.count > pageRange && node.children){
                        node.children.push(moreNode);
                     }
@@ -608,7 +613,7 @@ define([
                     _.forEach(node.children, needMore);
                 }
            }
-        }; 
+        };
 
         var loadMore = function loadMore($node, $parentNode, tree){
             var current     = $parentNode.children('ul').children('li.node-instance').length;
@@ -620,7 +625,7 @@ define([
 				'offset'        : current,
 				'limit'         : left < pageRange ? left : pageRange
 			}, serverParams);
-    
+
             $.ajax(tree.settings.data.opts.url, {
                 type        : tree.settings.data.opts.method,
                 dataType    : tree.settings.data.type,
@@ -644,11 +649,11 @@ define([
                 }
             });
         };
-        
+
         /**
          * Function executes first found allowed action for tree node.
          * @param {object} actions - All tree actions
-         * @param {object} [context] - Node context 
+         * @param {object} [context] - Node context
          * @param {object} [context.permissions] - Node permissions
          * @param {object} [context.context] - The context of the action: (class|instance|resource|*)
          * @param {array} exclude - list of actions to be excluded.
@@ -679,7 +684,7 @@ define([
                 self.permissionErrorMessage = feedback().error(__("You don't have sufficient permissions to access"));
             }
         }
-        
+
         return setUpTree();
     };
 
@@ -701,9 +706,9 @@ define([
 
     function addClassToNode(node, clazz){
         if(node && node.attributes){
-            
+
             node.attributes['class'] = node.attributes['class'] || '';
-            
+
             if(node.attributes['class'].length) {
                 node.attributes['class'] = node.attributes['class'] + ' ' + clazz;
             } else {
@@ -712,5 +717,5 @@ define([
         }
     }
 
-    return treeFactory; 
+    return treeFactory;
 });


### PR DESCRIPTION
Instead of displaying the resource alone in the tree after a search, it's displayed within the tree under it's own class (and along with other resources). 
It works only for search, filtering would need also to be implemented be it requires an extra work (by sending the whole _filtered tree data_)