### PR TITLE
url util isRelative/Absolute and toString for parsed URL

### DIFF
--- a/views/js/test/util/url/test.js
+++ b/views/js/test/util/url/test.js
@@ -92,15 +92,15 @@ define(['util/url'], function(urlUtil){
     QUnit
         .cases(isAbsoluteDataProvider)
         .test('isAbsolute ', function(data, assert){
-            assert.equal(urlUtil.isAbsolute(data.url), data.absolute, 'The URL ' + data.url + ' ' + (data.url ? 'is' : 'is not') + ' absolute');
-            assert.equal(urlUtil.isAbsolute(urlUtil.parse(data.url)), data.absolute, 'The parsed URL ' + data.url + ' ' + (data.url ? 'is' : 'is not') + ' absolute');
+            assert.equal(urlUtil.isAbsolute(data.url), data.absolute, 'The URL ' + data.url + ' ' + (data.absolute ? 'is' : 'is not') + ' absolute');
+            assert.equal(urlUtil.isAbsolute(urlUtil.parse(data.url)), data.absolute, 'The parsed URL ' + data.url + ' ' + (data.absolute ? 'is' : 'is not') + ' absolute');
         });
 
     QUnit
         .cases(isAbsoluteDataProvider)
         .test('isRelative ', function(data, assert){
-            assert.equal(urlUtil.isRelative(data.url), !data.absolute, 'The URL ' + data.url + ' ' + (data.url ? 'is' : 'is not') + ' relative');
-            assert.equal(urlUtil.isRelative(urlUtil.parse(data.url)), !data.absolute, 'The parsed URL ' + data.url + ' ' + (data.url ? 'is' : 'is not') + ' relative');
+            assert.equal(urlUtil.isRelative(data.url), !data.absolute, 'The URL ' + data.url + ' ' + (!data.absolute ? 'is' : 'is not') + ' relative');
+            assert.equal(urlUtil.isRelative(urlUtil.parse(data.url)), !data.absolute, 'The parsed URL ' + data.url + ' ' + (!data.absolute ? 'is' : 'is not') + ' relative');
         });
 });
 

--- a/views/js/test/util/url/test.js
+++ b/views/js/test/util/url/test.js
@@ -2,9 +2,11 @@ define(['util/url'], function(urlUtil){
 
     QUnit.module('API');
 
-    QUnit.test('util api', 2, function(assert){
+    QUnit.test('util api', 4, function(assert){
         assert.ok(typeof urlUtil === 'object', "The urlUtil module exposes an object");
         assert.ok(typeof urlUtil.parse === 'function', "urlUtil exposes a parse method");
+        assert.ok(typeof urlUtil.isAbsolute === 'function', "urlUtil exposes a isAbsolute method");
+        assert.ok(typeof urlUtil.isRelative === 'function', "urlUtil exposes a isRelative method");
     });
 
     QUnit.module('Parse');
@@ -40,11 +42,65 @@ define(['util/url'], function(urlUtil){
         .test('parse ', function(data, assert){
             var key;
             var result = urlUtil.parse(data.url);
-            console.log(result);
             assert.ok(typeof result === 'object', 'The result is an object');
             for(key in data.expected){
                 assert.equal(result[key], data.expected[key], key + ' has the expected value');
             }
+        });
+
+
+    QUnit.module('isAbsolute/isRelative');
+
+    var isAbsoluteDataProvider = [{
+        title    : 'absolute URL',
+        url      : 'http://tao.localdomain/test/test.html',
+        absolute : true,
+    }, {
+        title    : 'absolute  URL with port and params',
+        url      : 'http://tao.localdomain:8080/test/test.html?coverage=true&run=test1',
+        absolute : true,
+    }, {
+        title    : 'absolute  URL with SSL and a hash',
+        url      : 'https://tao.localdomain/test/test.html#foo',
+        absolute : true,
+    }, {
+        title    : 'absolute URL no protocol',
+        url      : '//tao.localdomain/test/test.html',
+        absolute : true,
+    }, {
+        title    : 'custom protocol resource',
+        url      : 'taomedia://tao.localdomain/getFile.php',
+        absolute : true,
+    }, {
+        title    : 'relative URL from root',
+        url      : '/tao/proxy/getFile.php',
+        absolute : false,
+    }, {
+        title    : 'relative URL from dir',
+        url      : 'css/style.css',
+        absolute : false,
+    }, {
+        title    : 'relative only file name',
+        url      : 'style.css',
+        absolute : false,
+    }, {
+        title    : 'relative URL from ./',
+        url      : './style.css',
+        absolute : false
+    }];
+
+    QUnit
+        .cases(isAbsoluteDataProvider)
+        .test('isAbsolute ', function(data, assert){
+            assert.equal(urlUtil.isAbsolute(data.url), data.absolute, 'The URL ' + data.url + ' ' + (data.url ? 'is' : 'is not') + ' absolute');
+            assert.equal(urlUtil.isAbsolute(urlUtil.parse(data.url)), data.absolute, 'The parsed URL ' + data.url + ' ' + (data.url ? 'is' : 'is not') + ' absolute');
+        });
+
+    QUnit
+        .cases(isAbsoluteDataProvider)
+        .test('isRelative ', function(data, assert){
+            assert.equal(urlUtil.isRelative(data.url), !data.absolute, 'The URL ' + data.url + ' ' + (data.url ? 'is' : 'is not') + ' relative');
+            assert.equal(urlUtil.isRelative(urlUtil.parse(data.url)), !data.absolute, 'The parsed URL ' + data.url + ' ' + (data.url ? 'is' : 'is not') + ' relative');
         });
 });
 

--- a/views/js/util/url.js
+++ b/views/js/util/url.js
@@ -58,7 +58,11 @@ define([], function(){
                     }
                 },
                 m   = o.parser.strict.exec(url),
-                parsed = {},
+                parsed = Object.create({
+                    toString : function(){
+                        return this.source;
+                    }
+                }),
                 i   = o.key.length;
 
             while (i--) {
@@ -73,13 +77,37 @@ define([], function(){
             });
 
             return parsed;
+        },
+
+        /**
+         * Check whether an URL is absolute
+         * @param {String|Object} url - the url to check. It can be a parsed URL (result of {@link util/url#parse})
+         * @returns {Boolean|undefined} true if the url is absolute, or undefined if the URL cannot be checked
+         */
+        isAbsolute : function isAbsolute(url){
+            var absoluteExp = /^(?:[a-z]+:)?\/\//i;
+
+            //url from parse
+            if(typeof url === 'object' && url.hasOwnProperty('source')){
+                return url.source !== url.relative;
+            }
+            if(typeof url === 'string'){
+                return absoluteExp.test(url);
+            }
+        },
+
+        /**
+         * Check whether an URL is relative
+         * @param {String|Object} url - the url to check. It can be a parsed URL (result of {@link util/url#parse})
+         * @returns {Boolean|undefined} true if the url is relative, or undefined if the URL cannot be checked
+         */
+        isRelative : function isRelative(url) {
+            var absolute = this.isAbsolute(url);
+            if(typeof absolute === 'boolean'){
+                return !absolute;
+            }
         }
     };
 
     return urlUtil;
 });
-
-
-
-
-


### PR DESCRIPTION
Add new features to the URL util.
Also parsedUrl object's have now the toString method on their prototype so it can be used in strings