### PR TITLE
Fix/sourcemap urls

### DIFF
--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -43,7 +43,6 @@ module.exports = function(grunt) {
             if(/routes\.js$/.test(srcpath)){
                 return content.replace('routes.js.map', 'controllers.min.js.map');
             }
-
             return content;
         }
     };
@@ -87,7 +86,20 @@ module.exports = function(grunt) {
             { src: [out + '/main.js.map'],              dest: '../js/main.min.js.map' },
             { src: [out + '/controller/routes.js'],     dest: '../js/controllers.min.js' },
             { src: [out + '/controller/routes.js.map'], dest: '../js/controllers.min.js.map' }
-        ]
+        ],
+        options : {
+            process: function (content, srcpath) {
+                //because we change the bundle names during copy
+                if(/main\.js$/.test(srcpath)){
+                    return content.replace('main.js.map', 'main.min.js.map');
+                }
+                if(/routes\.js$/.test(srcpath)){
+                    return content.replace('routes.js.map', 'controllers.min.js.map');
+                }
+
+                return content;
+            }
+        }
     };
 
     grunt.config('clean', clean);

--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -37,6 +37,17 @@ module.exports = function(grunt) {
         force : true
     };
 
+    copy.options = {
+        process: function (content, srcpath) {
+            //because we change the bundle names during copy
+            if(/routes\.js$/.test(srcpath)){
+                return content.replace('routes.js.map', 'controllers.min.js.map');
+            }
+
+            return content;
+        }
+    };
+
     grunt.log.verbose.writeln('libs');
     grunt.log.verbose.writeln(libs);
 


### PR DESCRIPTION
Requires https://github.com/oat-sa/extension-tao-wfauthoring/pull/8
Related to https://github.com/oat-sa/extension-tao-itemqti/pull/265

It fixes https://oat-sa.atlassian.net/browse/TAO-716

The paths of source maps  of the javascript bundles in production mode were not corrects. (it can be seen in chrome's console).