### PR TITLE
Autocomplete: set the cursor style for suggestions, and avoid text selection

### DIFF
--- a/views/scss/inc/_autocomplete.scss
+++ b/views/scss/inc/_autocomplete.scss
@@ -8,6 +8,12 @@ $autocompleter : autocomplete;
     color: $textColor;
     background: $uiGeneralContentBg;
     overflow: auto;
+
+    cursor: default;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 .#{$autocompleter}-suggestion {
     padding: 2px 5px;


### PR DESCRIPTION
Set the cursor style when mouse is over autocomplete suggestions.
Prevent text selection within suggestions

To test the component, use the tao-dac-simple extension (requires https://github.com/oat-sa/extension-tao-dac-simple/pull/15)