### PR TITLE
remove JS autofocus

### DIFF
--- a/views/js/controller/login.js
+++ b/views/js/controller/login.js
@@ -33,8 +33,6 @@ define([
 
     versionWarning.init();
 
-    $('input[type="text"]').eq(0).focus();
-
     // empty $fields sent
     if(context.find('.form-error').length){
         conf = {


### PR DESCRIPTION
Login input filed has `autofocus` attribute ([class.Login.php](https://github.com/oat-sa/tao-core/blob/master/actions/form/class.Login.php#L80)) so this method is redundant.