### PR TITLE
Remove problematic htmlentities function for accented characters

### DIFF
--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -148,7 +148,7 @@ class tao_actions_Main extends tao_actions_CommonModule
         $this->setData('messageServiceIsAvailable', MessagingService::singleton()->isAvailable());
         
         if ($this->hasRequestParameter('msg')) {
-            $this->setData('msg', htmlentities($this->getRequestParameter('msg')));
+            $this->setData('msg', $this->getRequestParameter('msg'));
         }
         $this->setData('content-template', array('blocks/login.tpl', 'tao'));
 


### PR DESCRIPTION
This fix removes the display issue that is shown with accented characters when warning about access denied.

Before: "Acc&egrave;s refus&eacute;. Veuillez renouveler votre authentification !"
After: "Accès refusé. Veuillez renouveler votre authentification !"

I don't know if such change couldn't led to a security issue.
