### PR TITLE
enable to run a single test on phantomJs using grunt

### DIFF
--- a/views/build/config/phantomjs-bridge.js
+++ b/views/build/config/phantomjs-bridge.js
@@ -10,6 +10,10 @@
 (function() {
   'use strict';
 
+  //little polyfill added  for phantomJS
+  window.console.warning = window.console.warning || window.console.log;
+
+
   // Don't re-order tests.
   QUnit.config.reorder = false;
   // Run tests serially, not in parallel.

--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -1,4 +1,5 @@
 module.exports = function(grunt) {
+    'use strict';
 
     var root        = grunt.option('root');
     var testPort    = grunt.option('testPort');
@@ -60,6 +61,17 @@ module.exports = function(grunt) {
             }
         }
     });
+
+    /*
+     * Single file test
+     */
+    qunit.single = {
+        options : {
+            console : true,
+            urls : [testUrl + grunt.option('test')]
+        }
+    };
+
 
     /*
      * Tao extension tests


### PR DESCRIPTION
This task enables you to run a single unit test from the command line (useful to test directly on PhantomJS)  using for example : 
```
grunt connect qunit:single --test /taoQtiItem/views/js/test/runner/provider/test.html
```