### PR TITLE
fix unit tests

### DIFF
--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
                         return next();
                     });
 
-                    //allow  requests
+                    //allow post requests
                     middlewares.unshift(function(req, res, next) {
                         if (req.method.toLowerCase() === 'post') {
                             var filepath = path.join(options.base[0], req.url);

--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -1,9 +1,13 @@
 module.exports = function(grunt) {
+    'use strict';
+
 
     var root        = grunt.option('root');
     var testPort    = grunt.option('testPort');
     var reportOutput= grunt.option('reports');
     var ext         = require(root + '/tao/views/build/tasks/helpers/extensions')(grunt, root);
+    var fs          = require('fs');
+    var path        = require('path');
     var qunit       = grunt.config('qunit') || {};
     var testUrl     = 'http://127.0.0.1:' + testPort;
 
@@ -54,6 +58,19 @@ module.exports = function(grunt) {
                         }
                         return next();
                     });
+
+                    //allow  requests
+                    middlewares.unshift(function(req, res, next) {
+                        if (req.method.toLowerCase() === 'post') {
+                            var filepath = path.join(options.base[0], req.url);
+                            if (fs.existsSync(filepath)) {
+                                fs.createReadStream(filepath).pipe(res);
+                                return;
+                            }
+                        }
+                        return next();
+                    });
+
 
                     return middlewares;
                 }

--- a/views/js/core/validator/Validator.js
+++ b/views/js/core/validator/Validator.js
@@ -1,5 +1,5 @@
 define(['lodash', 'async', 'core/validator/Report', 'core/validator/validators'], function(_, async, Report, validators){
-
+    'use strict';
 
     var _buildRule = function(rule){
         var ret = null;

--- a/views/js/test/core/databinder/test.js
+++ b/views/js/test/core/databinder/test.js
@@ -2,7 +2,7 @@ define(['jquery', 'core/databinder'], function($, DataBinder){
 
     var model;
 
-    module('2 ways data binding', {
+    QUnit.module('2 ways data binding', {
         setup: function() {
             model = undefined;
             model = {
@@ -31,117 +31,117 @@ define(['jquery', 'core/databinder'], function($, DataBinder){
         }
     });
 
-    test('Simple assignment', function(){
-        expect(5);
+    QUnit.test('Simple assignment', function(assert){
+        QUnit.expect(5);
 
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
-        equal($('h1', $container).text(), '', 'h1 is empty');
-        equal($('h2', $container).text(), '', 'h2 is empty');
+        assert.equal($('h1', $container).text(), '', 'h1 is empty');
+        assert.equal($('h2', $container).text(), '', 'h2 is empty');
 
         new DataBinder($container, model).bind();
 
-        equal($('h1', $container).text(), model.title, 'h1 has value assigned');
-        equal($('h2', $container).text(), model.testParts[0].assessmentSections[0].sectionParts[1].href, 'h2 has value assigned');
+        assert.equal($('h1', $container).text(), model.title, 'h1 has value assigned');
+        assert.equal($('h2', $container).text(), model.testParts[0].assessmentSections[0].sectionParts[1].href, 'h2 has value assigned');
     });
 
-    test('Simple value change', function(){
-        expect(3);
+    QUnit.test('Simple value change', function(assert){
+        QUnit.expect(3);
 
         var $container = $('#container-1');
         var $title = $('h1', $container);
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         new DataBinder($container, model).bind();
 
-        equal($title.text(), model.title, 'h1 has value assigned');
+        assert.equal($title.text(), model.title, 'h1 has value assigned');
 
         $title.text('new title').trigger('change');
 
-        equal(model.title, 'new title', 'model has been updated');
+        assert.equal(model.title, 'new title', 'model has been updated');
     });
 
-    test('Simple value remove', function(){
-        expect(3);
+    QUnit.test('Simple value remove', function(assert){
+        QUnit.expect(3);
 
         var $container = $('#container-1');
         var $title = $('h1', $container);
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         new DataBinder($container, model).bind();
 
-        equal($title.text(), model.title, 'h1 has value assigned');
+        assert.equal($title.text(), model.title, 'h1 has value assigned');
 
         $title.trigger('delete');
 
         strictEqual(model.title, undefined, 'model title has been removed');
     });
 
-    test('Array assignment', function(){
-        expect(4);
+    QUnit.test('Array assignment', function(assert){
+        QUnit.expect(4);
 
         var $container = $('#container-2');
         var $sectionParts = $('ul', $container);
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         new DataBinder($container, model).bind();
 
         strictEqual($sectionParts.find('li').length, model.testParts[0].assessmentSections[0].sectionParts.length, 'the same number of nodes has been inserted');
-        equal($sectionParts.find('li:first').text(), model.testParts[0].assessmentSections[0].sectionParts[0].href, 'the first item contains the value');
-        equal($sectionParts.find('li:last').text(), model.testParts[0].assessmentSections[0].sectionParts[3].href, 'the last item contains the value');
+        assert.equal($sectionParts.find('li:first').text(), model.testParts[0].assessmentSections[0].sectionParts[0].href, 'the first item contains the value');
+        assert.equal($sectionParts.find('li:last').text(), model.testParts[0].assessmentSections[0].sectionParts[3].href, 'the last item contains the value');
     });
 
-    test('Array value change', function(){
-        expect(3);
+    QUnit.test('Array value change', function(assert){
+        QUnit.expect(3);
 
         var $container = $('#container-2');
         var $sectionParts = $('ul', $container);
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         new DataBinder($container, model).bind();
 
         var $firstPart = $sectionParts.find('li:first');
-        equal($firstPart.text(), model.testParts[0].assessmentSections[0].sectionParts[0].href, 'the first item contains the value');
+        assert.equal($firstPart.text(), model.testParts[0].assessmentSections[0].sectionParts[0].href, 'the first item contains the value');
 
         $firstPart.text('new reference').trigger('change');
 
-        equal(model.testParts[0].assessmentSections[0].sectionParts[0].href, 'new reference', 'array model has been updated');
+        assert.equal(model.testParts[0].assessmentSections[0].sectionParts[0].href, 'new reference', 'array model has been updated');
 
     });
 
-    test('Array value re-order', function(){
-        expect(7);
+    QUnit.test('Array value re-order', function(assert){
+        QUnit.expect(7);
 
         var $container = $('#container-3');
         var $sectionParts = $('ul', $container);
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         new DataBinder($container, model).bind();
 
         var $firstPart = $sectionParts.find('li:nth-child(1)');
         var $thirdPart = $sectionParts.find('li:nth-child(3)');
-        equal($firstPart.find('[data-bind="href"]').text(), model.testParts[0].assessmentSections[0].sectionParts[0].href, 'the first item contains the value');
-        equal($thirdPart.find('[data-bind="href"]').text(), model.testParts[0].assessmentSections[0].sectionParts[2].href, 'the third item contains the value');
+        assert.equal($firstPart.find('[data-bind="href"]').text(), model.testParts[0].assessmentSections[0].sectionParts[0].href, 'the first item contains the value');
+        assert.equal($thirdPart.find('[data-bind="href"]').text(), model.testParts[0].assessmentSections[0].sectionParts[2].href, 'the third item contains the value');
 
         //reorder from 0123 to 0213
         $firstPart.after($thirdPart);
         $sectionParts.trigger('change');
 
-        equal(model.testParts[0].assessmentSections[0].sectionParts[1].href, "http:\/\/tao26.localdomain\/bertao.rdf#i138356893768139", 'the model value order has been updated');
-        equal(model.testParts[0].assessmentSections[0].sectionParts[2].href, "http:\/\/tao26.localdomain\/bertao.rdf#i138356893796686", 'the model value order has been updated');
+        assert.equal(model.testParts[0].assessmentSections[0].sectionParts[1].href, "http:\/\/tao26.localdomain\/bertao.rdf#i138356893768139", 'the model value order has been updated');
+        assert.equal(model.testParts[0].assessmentSections[0].sectionParts[2].href, "http:\/\/tao26.localdomain\/bertao.rdf#i138356893796686", 'the model value order has been updated');
 
         $sectionParts.find('li:nth-child(2)').find('[data-bind="href"]').text('toto').trigger('change');
-        equal(model.testParts[0].assessmentSections[0].sectionParts[2].href, "toto", 'the model value order has been updated');
-        equal(model.testParts[0].assessmentSections[0].sectionParts[2].index, "2", 'the model value index has been updated');
+        assert.equal(model.testParts[0].assessmentSections[0].sectionParts[2].href, "toto", 'the model value order has been updated');
+        assert.equal(model.testParts[0].assessmentSections[0].sectionParts[2].index, "2", 'the model value index has been updated');
     });
 
-     test('Array value remove', function(){
-        expect(8);
+     QUnit.test('Array value remove', function(assert){
+        QUnit.expect(8);
 
         var $container = $('#container-3');
         var $sectionParts = $('ul', $container);
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         new DataBinder($container, model).bind();
 
@@ -154,21 +154,21 @@ define(['jquery', 'core/databinder'], function($, DataBinder){
         strictEqual(model.testParts[0].assessmentSections[0].sectionParts.length, 3, 'model length has been updated');
         strictEqual(model.testParts[0].assessmentSections[0].sectionParts[0].index, 0, 'model element has been removed');
         strictEqual($sectionParts.find('li:nth-child(1)').data('bind-index'), '0', 'the node index is up to date');
-        equal($sectionParts.find('li:nth-child(1) [data-bind="href"]').text(), "http:\/\/tao26.localdomain\/bertao.rdf#i138356893796686", 'the model value order has been updated');
+        assert.equal($sectionParts.find('li:nth-child(1) [data-bind="href"]').text(), "http:\/\/tao26.localdomain\/bertao.rdf#i138356893796686", 'the model value order has been updated');
 
          //test rebinding after removal
          $sectionParts.find('li:nth-child(1)  [data-bind="href"]').text('http://new.url').trigger('change');
 
-         equal($sectionParts.find('li:nth-child(1) [data-bind="href"]').text(), 'http://new.url', 'the model value has changed');
-         equal(model.testParts[0].assessmentSections[0].sectionParts[1].href, 'http://new.url', 'the model value has changed');
+         assert.equal($sectionParts.find('li:nth-child(1) [data-bind="href"]').text(), 'http://new.url', 'the model value has changed');
+         assert.equal(model.testParts[0].assessmentSections[0].sectionParts[1].href, 'http://new.url', 'the model value has changed');
      });
 
-    test('Array value add', function(){
-        expect(4);
+    QUnit.test('Array value add', function(assert){
+        QUnit.expect(4);
 
         var $container = $('#container-4');
         var $sectionParts = $('ul', $container);
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         new DataBinder($container, model).bind();
 
@@ -177,12 +177,12 @@ define(['jquery', 'core/databinder'], function($, DataBinder){
         $sectionParts.append($newSection).trigger('add');
 
         strictEqual(model.testParts[0].assessmentSections[0].sectionParts.length, 5, 'model length has been updated');
-        equal(model.testParts[0].assessmentSections[0].sectionParts[4].identifier, 'sectionpart-5', 'model element has been added');
-        equal(model.testParts[0].assessmentSections[0].sectionParts[4].href, 'http://new.rdf#test', 'model element has been added');
+        assert.equal(model.testParts[0].assessmentSections[0].sectionParts[4].identifier, 'sectionpart-5', 'model element has been added');
+        assert.equal(model.testParts[0].assessmentSections[0].sectionParts[4].href, 'http://new.rdf#test', 'model element has been added');
     });
 
-     test('Array value filter', function(){
-        expect(2);
+     QUnit.test('Array value filter', function(assert){
+        QUnit.expect(2);
 
         model.testParts[0].assessmentSections[0].sectionParts[0]['qti-type'] = 'assessmentItemRef';
         model.testParts[0].assessmentSections[0].sectionParts[1]['qti-type'] = 'assessmentSectionRef';
@@ -191,7 +191,7 @@ define(['jquery', 'core/databinder'], function($, DataBinder){
 
         var $container = $('#container-5');
         var $sectionParts = $('ul', $container);
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         new DataBinder($container, model, {
             filters : {
@@ -204,21 +204,21 @@ define(['jquery', 'core/databinder'], function($, DataBinder){
         strictEqual($sectionParts.find('li').length, 2, 'only filtered values has been assigned');
     });
 
-    test('Rm binding', function(){
-        expect(5);
+    QUnit.test('Rm binding', function(assert){
+        QUnit.expect(5);
 
         var $container = $('#container-6');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         new DataBinder($container, model).bind();
 
-        equal(model.title, 'testTitle', 'The title attribute is present');
+        assert.equal(model.title, 'testTitle', 'The title attribute is present');
         $container.find('input:first-child').trigger('change');
-        ok(model.title === undefined, 'The title attribute has been removed');
+        assert.ok(model.title === undefined, 'The title attribute has been removed');
 
-        equal(model.testParts[0].assessmentSections[0].sectionParts.length, 4, 'The section parts contains 4 elements');
+        assert.equal(model.testParts[0].assessmentSections[0].sectionParts.length, 4, 'The section parts contains 4 elements');
         $container.find('input:last-child').trigger('change');
-        equal(model.testParts[0].assessmentSections[0].sectionParts.length, 3, 'A section parts has been remvoved');
+        assert.equal(model.testParts[0].assessmentSections[0].sectionParts.length, 3, 'A section parts has been remvoved');
     });
 
 });

--- a/views/js/test/core/encoder/time/test.js
+++ b/views/js/test/core/encoder/time/test.js
@@ -1,21 +1,21 @@
 define(['jquery', 'core/encoder/time'], function($, TimeEnc){
    
-    test('encode', function(){
-        expect(3);
+    QUnit.test('encode', function(assert){
+        QUnit.expect(3);
         
-        ok(typeof TimeEnc.encode === 'function');
+        assert.ok(typeof TimeEnc.encode === 'function');
         
-        equal(TimeEnc.encode(5400), '01:30:00');
-        equal(TimeEnc.encode(30), '00:00:30');
+        assert.equal(TimeEnc.encode(5400), '01:30:00');
+        assert.equal(TimeEnc.encode(30), '00:00:30');
     });
     
-    test('decode', function(){
-        expect(3);
+    QUnit.test('decode', function(assert){
+        QUnit.expect(3);
         
-         ok(typeof TimeEnc.decode === 'function');
+         assert.ok(typeof TimeEnc.decode === 'function');
         
-         equal(TimeEnc.decode('01:30:00'), 5400);
-         equal(TimeEnc.decode('00:00:30'), 30);
+         assert.equal(TimeEnc.decode('01:30:00'), 5400);
+         assert.equal(TimeEnc.decode('00:00:30'), 30);
     });
 });
 

--- a/views/js/test/core/eventifier/test.js
+++ b/views/js/test/core/eventifier/test.js
@@ -1,4 +1,5 @@
 define(['core/eventifier'], function(eventifier){
+    'use strict';
 
     QUnit.module('eventifier');
 

--- a/views/js/test/core/format/test.js
+++ b/views/js/test/core/format/test.js
@@ -1,23 +1,23 @@
 define(['core/format'], function(format){
     'use strict';
 
-    test('protoype', function(){
-       ok(typeof format === 'function', 'Format is a function');
+    QUnit.test('protoype', function(assert){
+       assert.ok(typeof format === 'function', 'Format is a function');
     });
 
-    test('formating', function(){
-        equal(format('give me a %s', 'string'), 'give me a string' , 'Format with a string replacement');
-        equal(format('give me two %s %s', 'awesome', 'strings'), 'give me two awesome strings' , 'Format with 2 string replacements');
+    QUnit.test('formating', function(assert){
+        assert.equal(format('give me a %s', 'string'), 'give me a string' , 'Format with a string replacement');
+        assert.equal(format('give me two %s %s', 'awesome', 'strings'), 'give me two awesome strings' , 'Format with 2 string replacements');
         
-        equal(format('give me an %d', 11), 'give me an 11' , 'Format with 1 an int');
-        equal(format('give me an %d', '11'), 'give me an 11' , 'Format with 1 an string as number');
-        equal(format('give me an %d', 11.5), 'give me an 11.5' , 'Format with 1 a float');
-        equal(format('give me an %d', '11.5'), 'give me an 11.5' , 'Format with a float in a string');
-        equal(format('give me %d%', 100), 'give me 100%' , 'Format with percent edge case');
+        assert.equal(format('give me an %d', 11), 'give me an 11' , 'Format with 1 an int');
+        assert.equal(format('give me an %d', '11'), 'give me an 11' , 'Format with 1 an string as number');
+        assert.equal(format('give me an %d', 11.5), 'give me an 11.5' , 'Format with 1 a float');
+        assert.equal(format('give me an %d', '11.5'), 'give me an 11.5' , 'Format with a float in a string');
+        assert.equal(format('give me %d%', 100), 'give me 100%' , 'Format with percent edge case');
     
-        equal(format('give me a %j', 100), 'give me a 100' , 'Format with a json number');
-        equal(format('give me a %j', 'kiss'), 'give me a kiss' , 'Format with a json string');
-        equal(format('give me an %j', ['A', 'rr', 'ay']), "give me an [A,rr,ay]" , 'Format with a json array');
-        equal(format('give me %j', { a : 1, b : true, c : null, d : 'test'}), 'give me {a:1,b:true,c:null,d:test}' , 'Format with a json object');
+        assert.equal(format('give me a %j', 100), 'give me a 100' , 'Format with a json number');
+        assert.equal(format('give me a %j', 'kiss'), 'give me a kiss' , 'Format with a json string');
+        assert.equal(format('give me an %j', ['A', 'rr', 'ay']), "give me an [A,rr,ay]" , 'Format with a json array');
+        assert.equal(format('give me %j', { a : 1, b : true, c : null, d : 'test'}), 'give me {a:1,b:true,c:null,d:test}' , 'Format with a json object');
     });
 });

--- a/views/js/test/core/mimetype/test.js
+++ b/views/js/test/core/mimetype/test.js
@@ -1,21 +1,21 @@
 define(['core/mimetype'], function(mimeType){
     'use strict';
 
-    test('protoype', function(){
-       ok(typeof mimeType === 'object', 'The module mimeType expose an object');
-       ok(typeof mimeType.getFileType === 'function', 'The module mimeType has a getFileType method');
+    QUnit.test('protoype', function(assert){
+       assert.ok(typeof mimeType === 'object', 'The module mimeType expose an object');
+       assert.ok(typeof mimeType.getFileType === 'function', 'The module mimeType has a getFileType method');
     });
 
-    test('getFileType', function(){
-        equal(mimeType.getFileType({mime : 'application/ogg'}), 'video', 'Ogg files are video');
-        equal(mimeType.getFileType({mime : 'audio/mp3'}), 'audio', 'Mp3 files are audio');
-        equal(mimeType.getFileType({mime : 'text/css'}), 'css', 'Css mime type');
-        equal(mimeType.getFileType({name : 'style.css'}), 'css', 'Css extension');
-        equal(mimeType.getFileType({mime : 'text/plain'}), 'text', 'Text mime type');
+    QUnit.test('getFileType', function(assert){
+        assert.equal(mimeType.getFileType({mime : 'application/ogg'}), 'video', 'Ogg files are video');
+        assert.equal(mimeType.getFileType({mime : 'audio/mp3'}), 'audio', 'Mp3 files are audio');
+        assert.equal(mimeType.getFileType({mime : 'text/css'}), 'css', 'Css mime type');
+        assert.equal(mimeType.getFileType({name : 'style.css'}), 'css', 'Css extension');
+        assert.equal(mimeType.getFileType({mime : 'text/plain'}), 'text', 'Text mime type');
     });
     
-    test('getCategory', function(){
-        equal(mimeType.getCategory('video'), 'media', 'video files are media');
-        equal(mimeType.getCategory('css'), 'sources', 'css files are sources');
+    QUnit.test('getCategory', function(assert){
+        assert.equal(mimeType.getCategory('video'), 'media', 'video files are media');
+        assert.equal(mimeType.getCategory('css'), 'sources', 'css files are sources');
     });
 });

--- a/views/js/test/core/validator/validate/test.js
+++ b/views/js/test/core/validator/validate/test.js
@@ -1,69 +1,68 @@
 define(['lodash', 'core/validator/Validator'], function(_, Validator){
+    'use strict';
 
-    var CL = console.log, _test = function(){};
-    
-    test('simple validate', function(){
-        
+    QUnit.test('simple validate', function(assert){
+
         var validator = new Validator(['notEmpty', 'numeric']);
 
-        equal(_.size(validator.rules), 2, 'rules set');
+        assert.equal(_.size(validator.rules), 2, 'rules set');
 
         validator.validate('a', function(res){
-            
-            equal(_.size(res), 2, 'validated');
+
+            assert.equal(_.size(res), 2, 'validated');
 
             var report1 = res.shift();
-            equal(report1.type, 'success');
-            equal(report1.data.validator, 'notEmpty');
+            assert.equal(report1.type, 'success');
+            assert.equal(report1.data.validator, 'notEmpty');
 
             var report2 = res.shift();
-            equal(report2.type, 'failure');
-            equal(report2.data.validator, 'numeric');
+            assert.equal(report2.type, 'failure');
+            assert.equal(report2.data.validator, 'numeric');
         });
-        
+
         validator.validate('', function(res){
-            
-            equal(_.size(res), 2, 'validated');
+
+            assert.equal(_.size(res), 2, 'validated');
 
             var report1 = res.shift();
-            equal(report1.type, 'failure');
-            equal(report1.data.validator, 'notEmpty');
+            assert.equal(report1.type, 'failure');
+            assert.equal(report1.data.validator, 'notEmpty');
 
             var report2 = res.shift();
-            equal(report2.type, 'failure');
-            equal(report2.data.validator, 'numeric');
+            assert.equal(report2.type, 'failure');
+            assert.equal(report2.data.validator, 'numeric');
         });
-        
+
         validator.validate(0, function(res){
-            
-            equal(_.size(res), 2, 'validated');
+
+            assert.equal(_.size(res), 2, 'validated');
 
             var report1 = res.shift();
-            equal(report1.type, 'success');
-            equal(report1.data.validator, 'notEmpty');
+            assert.equal(report1.type, 'success');
+            assert.equal(report1.data.validator, 'notEmpty');
 
             var report2 = res.shift();
-            equal(report2.type, 'success');
-            equal(report2.data.validator, 'numeric');
+            assert.equal(report2.type, 'success');
+            assert.equal(report2.data.validator, 'numeric');
         });
-        
+
         validator.validate(3, function(res){
-            
-            equal(_.size(res), 2, 'validated');
+
+            assert.equal(_.size(res), 2, 'validated');
 
             var report1 = res.shift();
-            equal(report1.type, 'success');
-            equal(report1.data.validator, 'notEmpty');
+            assert.equal(report1.type, 'success');
+            assert.equal(report1.data.validator, 'notEmpty');
 
             var report2 = res.shift();
-            equal(report2.type, 'success');
-            equal(report2.data.validator, 'numeric');
+            assert.equal(report2.type, 'success');
+            assert.equal(report2.data.validator, 'numeric');
         });
 
     });
 
-    test('validate with validator options', function(){
-        
+    QUnit.test('validate with validator options', function(assert){
+
         var validator = new Validator([
             {
                 name : 'pattern',
@@ -73,56 +72,52 @@ define(['lodash', 'core/validator/Validator'], function(_, Validator){
                 }
             }
         ]);
-        
+
         validator.validate('York', function(res){
-            
-            equal(_.size(res), 1, 'validated');
+
+            assert.equal(_.size(res), 1, 'validated');
 
             var report1 = res.shift();
-            equal(report1.type, 'success');
-            equal(report1.data.validator, 'pattern');
+            assert.equal(report1.type, 'success');
+            assert.equal(report1.data.validator, 'pattern');
         });
-        
-        validator.validate('Aee', function(res){
-            equal(res.shift().type, 'failure');
-        });
-        
-    });
-    
-    test('validate with validating options', function(){
-        
-        var validator = new Validator(['notEmpty', 'numeric', 'qtiIdentifier']);
 
-        equal(_.size(validator.rules), 3, 'rules set');
-        
+        validator.validate('Aee', function(res){
+            assert.equal(res.shift().type, 'failure');
+        });
+
+    });
+
+    QUnit.test('validate with validating options', function(assert){
+
+        var validator = new Validator(['notEmpty', 'numeric']);
+
+        assert.equal(_.size(validator.rules), 2, 'rules set');
+
         //empty options
         validator.validate('', {}, function(res){
-            
-            equal(_.size(res), 3, 'validated');
+
+            assert.equal(_.size(res), 2, 'validated');
 
             var report1 = res.shift();
-            equal(report1.type, 'failure');
-            equal(report1.data.validator, 'notEmpty');
+            assert.equal(report1.type, 'failure');
+            assert.equal(report1.data.validator, 'notEmpty');
 
             var report2 = res.shift();
-            equal(report2.type, 'failure');
-            equal(report2.data.validator, 'numeric');
-
-            var report3 = res.shift();
-            equal(report3.type, 'failure');
-            equal(report3.data.validator, 'qtiIdentifier');
+            assert.equal(report2.type, 'failure');
+            assert.equal(report2.data.validator, 'numeric');
         });
-        
+
         //test lazy option : stop on first failure
         validator.validate('', {lazy:true}, function(res){
-            
-            equal(_.size(res), 1, 'validated');
+
+            assert.equal(_.size(res), 1, 'validated');
             var report1 = res.shift();
-            equal(report1.type, 'failure');
-            equal(report1.data.validator, 'notEmpty');
+            assert.equal(report1.type, 'failure');
+            assert.equal(report1.data.validator, 'notEmpty');
 
         });
-        
+
     });
 
 });

--- a/views/js/test/core/validator/validateForm/test.js
+++ b/views/js/test/core/validator/validateForm/test.js
@@ -1,85 +1,83 @@
 define(['lodash', 'jquery', 'ui/validator'], function(_, $) {
+    'use strict';
 
-    test('create, destroy', function(){
-        
+    QUnit.test('create, destroy', function(assert){
+
         $('#text1').validator();
-        ok($('#text1').validator('getValidator'), 'validator bound');
-        ok($('#text1').data('validator-instance'), 'validator bound');
-        ok($('#text1').data('validator-config'), 'validator bound');
-        
+        assert.ok($('#text1').validator('getValidator'), 'validator bound');
+        assert.ok($('#text1').data('validator-instance'), 'validator bound');
+        assert.ok($('#text1').data('validator-config'), 'validator bound');
+
         $('#text1').validator('destroy');
-        ok(!$('#text1').data('validator-instance'), 'validator bound');
-        ok(!$('#text1').data('validator-config'), 'validator bound');
+        assert.ok(!$('#text1').data('validator-instance'), 'validator bound');
+        assert.ok(!$('#text1').data('validator-config'), 'validator bound');
     });
-    
-    test('validate empty validator', function(){
-        
-        expect(1);
+
+    QUnit.test('validate empty validator', function(assert){
+
+        QUnit.expect(1);
         $('#text0').validator('validate', function(valid, res){
-            console.log(res);
-            ok(valid, 'valid empty validator');
+            assert.ok(valid, 'valid empty validator');
         });
-        
-        
     });
-        
-    test('validate element', function(){
+
+    QUnit.test('validate element', function(assert){
 
         //set test value;
 
         $('#text1').validator();
-        ok($('#text1').validator('getValidator'), 'validator bound');
+        assert.ok($('#text1').validator('getValidator'), 'validator bound');
 
-        stop();
+        QUnit.stop();
         $('#text1').val('York');
         $('#text1').validator('validate', {}, function(valid, res) {
-            start();
+            QUnit.start();
 
-            ok(valid, 'the element is valid');
-            equal(_.size(res), 2, 'validated');
+            assert.ok(valid, 'the element is valid');
+            assert.equal(_.size(res), 2, 'validated');
 
             var report1 = res.shift();
-            equal(report1.type, 'success');
-            equal(report1.data.validator, 'notEmpty');
+            assert.equal(report1.type, 'success');
+            assert.equal(report1.data.validator, 'notEmpty');
 
             var report2 = res.shift();
-            equal(report2.type, 'success');
-            equal(report2.data.validator, 'pattern');
+            assert.equal(report2.type, 'success');
+            assert.equal(report2.data.validator, 'pattern');
         });
 
 
-        stop();
+        QUnit.stop();
         $('#text1').val('');
         $('#text1').validator('validate', {}, function(valid, res) {
-            start();
+            QUnit.start();
 
-            ok(valid === false, "the element isn't valid");
-            equal(_.size(res), 2, 'validated');
+            assert.ok(valid === false, "the element isn't valid");
+            assert.equal(_.size(res), 2, 'validated');
 
             var report1 = res.shift();
-            equal(report1.type, 'failure');
-            equal(report1.data.validator, 'notEmpty');
+            assert.equal(report1.type, 'failure');
+            assert.equal(report1.data.validator, 'notEmpty');
 
             var report2 = res.shift();
-            equal(report2.type, 'failure');
-            equal(report2.data.validator, 'pattern');
+            assert.equal(report2.type, 'failure');
+            assert.equal(report2.data.validator, 'pattern');
         });
 
-        stop();
+        QUnit.stop();
         $('#text1').val('Yor');
         $('#text1').validator('validate', {}, function(valid, res) {
-            start();
+            QUnit.start();
 
-            ok(valid === false, "the element isn't valid");
-            equal(_.size(res), 2, 'validated');
+            assert.ok(valid === false, "the element isn't valid");
+            assert.equal(_.size(res), 2, 'validated');
 
             var report1 = res.shift();
-            equal(report1.type, 'success');
-            equal(report1.data.validator, 'notEmpty');
+            assert.equal(report1.type, 'success');
+            assert.equal(report1.data.validator, 'notEmpty');
 
             var report2 = res.shift();
-            equal(report2.type, 'failure');
-            equal(report2.data.validator, 'pattern');
+            assert.equal(report2.type, 'failure');
+            assert.equal(report2.data.validator, 'pattern');
         });
 
         //reset test value:
@@ -87,60 +85,60 @@ define(['lodash', 'jquery', 'ui/validator'], function(_, $) {
         $('#text1').validator('destroy');
     });
 
-    test('element event', function() {
+    QUnit.test('element event', function(assert) {
 
-        stop();
+        QUnit.stop();
         $('#text1').on('validated', function(e, data) {
-            start();
-            equal(e.type, 'validated', 'event type ok');
-            equal(data.elt, this, 'validated element ok');
-            equal(_.size(data.results), 2, 'results ok');
+            QUnit.start();
+            assert.equal(e.type, 'validated', 'event type ok');
+            assert.equal(data.elt, this, 'validated element ok');
+            assert.equal(_.size(data.results), 2, 'results ok');
         });
         $('#text1').validator('validate');
-        
+
         $('#text1').validator('destroy').off('validated');
     });
 
-    test('form event', function() {
+    QUnit.test('form event', function(assert) {
 
-        stop();
+        QUnit.stop();
         $('#form1').on('validated', function(e, data) {
-            start();
-            equal(e.type, 'validated', 'event type ok');
-            equal(data.elt, $('#text1')[0], 'validated element ok');
-            equal(_.size(data.results), 2, 'results ok');
+            QUnit.start();
+            assert.equal(e.type, 'validated', 'event type ok');
+            assert.equal(data.elt, $('#text1')[0], 'validated element ok');
+            assert.equal(_.size(data.results), 2, 'results ok');
         });
         $('#text1').validator('validate');
-        
+
         $('#text1').validator('destroy');
         $('#form1').off('validated');
     });
-    
-    test('callback and event binding', function(){
-        
-        expect(5);
-        
+
+    QUnit.test('callback and event binding', function(assert){
+
+        QUnit.expect(5);
+
         //set validators and options in data attributes:
         $('#text2').data('validate', '$notEmpty; $pattern(pattern=[A-Z][a-z]{5,})');
         $('#text2').data('validate-option', '$lazy; $event(type=keyup, length=3);');
-        
+
         //set default callback, and test to results
         $('#text2').validator({
             validated:function(valid, results){
-                equal(this, $('#text2')[0], 'validated element ok');
-                equal(_.size(results), 2, 'results ok');
+                assert.equal(this, $('#text2')[0], 'validated element ok');
+                assert.equal(_.size(results), 2, 'results ok');
             }
         });
-        
+
         //set additonal event "validated" listener and test to results
         $('#text2').on('validated', function(e, data){
-            equal(e.type, 'validated', 'event type ok');
-            equal(data.elt, $('#text2')[0], 'validated element ok');
-            equal(_.size(data.results), 2, 'results ok');
+            assert.equal(e.type, 'validated', 'event type ok');
+            assert.equal(data.elt, $('#text2')[0], 'validated element ok');
+            assert.equal(_.size(data.results), 2, 'results ok');
         });
-        
+
         //set text and validation according to event "keyup" option, then trigger it:
         $('#text2').val('Abcdef').keyup();
     });
-    
+
 });

--- a/views/js/test/iframeResizer/test.html
+++ b/views/js/test/iframeResizer/test.html
@@ -8,16 +8,16 @@
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
         <script  type="text/javascript">
-            
+
             //don't start the test now
             QUnit.config.autostart = false;
-            
+
             //load the config
             require(['/tao/ClientConfig/config'], function(){
-                
+
                 //load the test
                 require(['test/iframeResizer/test'], function(){
-                    
+
                     //Tests loaded, run tests
                     QUnit.start();
                 });
@@ -27,7 +27,7 @@
     <body>
         <div id="qunit"></div>
         <div id="qunit-fixture">
-            
+
             <iframe id="iframe1"></iframe>
             <iframe id="iframe2"></iframe>
             <iframe id="iframe3"></iframe>

--- a/views/js/test/iframeResizer/test.js
+++ b/views/js/test/iframeResizer/test.js
@@ -18,65 +18,62 @@
  *
  */
 define(['jquery', 'iframeResizer'], function($, iframeResizer){
-   
+    'use strict';
+
     var $fixture = $('#qunit-fixture');
-   
-    test('parser structure', function(){
-        expect(2);
-        
-        ok(typeof iframeResizer === 'object');
-        ok(typeof iframeResizer.autoHeight === 'function');
+
+    QUnit.test('parser structure', 2, function(assert){
+        assert.ok(typeof iframeResizer === 'object');
+        assert.ok(typeof iframeResizer.autoHeight === 'function');
     });
-    
-    asyncTest('resize on load', function(){
-        expect(2);
-        
+
+    QUnit.asyncTest('resize on load', 2, function(assert){
+
         var $frame = $('#iframe1', $fixture);
-        equal($frame.length, 1);
-        
+        assert.equal($frame.length, 1);
+
         iframeResizer.autoHeight($frame);
         $frame
             .on('load', function(){
-                equal(parseInt($frame.height(), 10), 500);
-                start();    
-            }).attr('src', 'js/test/iframeResizer/framecontent1.html');
+                assert.equal(parseInt($frame.height(), 10), 500);
+                QUnit.start();
+            })
+            .attr('src', 'js/test/iframeResizer/framecontent1.html');
     });
-    
-    asyncTest('resize after load', function(){
-        expect(3);
-        
+
+    QUnit.asyncTest('resize after load', 3, function(assert){
+
         var $frame = $('#iframe2', $fixture);
-        equal($frame.length, 1);
-        
+        assert.equal($frame.length, 1);
+
         iframeResizer.autoHeight($frame);
         $frame.on('load', function(){
-                equal(parseInt($frame.height(), 10), 200);
+                assert.equal(parseInt($frame.height(), 10), 200);
                 setTimeout(function(){
-                    equal(parseInt($frame.height(), 10), 600);
-                    start();   
+                    assert.equal(parseInt($frame.height(), 10), 600);
+                    QUnit.start();
                 }, 2000);
             }).
             attr('src', 'js/test/iframeResizer/framecontent2.html');
     });
-    
-    asyncTest('nested iframes', function(){
-        expect(2);
-        
+
+    QUnit.asyncTest('nested iframes', 2, function(assert){
+
         var $frame = $('#iframe3', $fixture);
-        equal($frame.length, 1);
-        
+        assert.equal($frame.length, 1);
+
         iframeResizer.autoHeight($frame, 'iframe');
-        
+
         $frame.on('load', function(){
             var $nested = $frame.contents().find('iframe');
-           
+
             iframeResizer
                 .autoHeight($nested)
                 .attr('src', 'framecontent2.html');
-            
+
             setTimeout(function(){
-                ok(parseInt($frame.height(), 10) >= 600);   //the div that contains the iframe has a 604 height!
-                start();   
+                assert.ok(parseInt($frame.height(), 10) >= 600);   //the div that contains the iframe has a 604 height!
+                QUnit.start();
             }, 2500);
         }).
         attr('src', 'js/test/iframeResizer/framecontent3.html');

--- a/views/js/test/layout/section/test.js
+++ b/views/js/test/layout/section/test.js
@@ -1,68 +1,68 @@
 define(['jquery', 'layout/section'], function($, section){
         
-    module('layout/section');
+    QUnit.module('layout/section');
 
-    test('module', function(){
-        ok(typeof section === 'object', 'The module expose an object');
+    QUnit.test('module', function(assert){
+        assert.ok(typeof section === 'object', 'The module expose an object');
     });
 
-    asyncTest('init sections', function(){
-        expect(4);
+    QUnit.asyncTest('init sections', function(assert){
+        QUnit.expect(4);
         var $testScope = $('#qunit-fixture .multiple');
 
-        equal($testScope.length, 1, 'the test scope exists');
+        assert.equal($testScope.length, 1, 'the test scope exists');
 
-        ok(typeof section.init === 'function', 'section has an init function');
+        assert.ok(typeof section.init === 'function', 'section has an init function');
 
         $testScope.on('init.section', function(){
-            ok(true, 'the section triggers an init event on the scope');
-            start();
+            assert.ok(true, 'the section triggers an init event on the scope');
+            QUnit.start();
         });
-        ok(typeof section.init($testScope, { history : false }) === 'object', 'section.init() returns an object');
+        assert.ok(typeof section.init($testScope, { history : false }) === 'object', 'section.init() returns an object');
     });
 
-    asyncTest('init multiple sections', function(){
-        expect(8);
+    QUnit.asyncTest('init multiple sections', function(assert){
+        QUnit.expect(8);
         var $testScope = $('#qunit-fixture .multiple');
 
-        equal($testScope.length, 1, 'the test scope exists');
+        assert.equal($testScope.length, 1, 'the test scope exists');
 
         $testScope.on('activate.section', function(){
-            ok($('.tab-container li:first', $testScope).hasClass('active'), 'the first opener is active');
-            ok(!$('.tab-container li:eq(2)', $testScope).hasClass('active'), 'the 3rd opener is not active');
-            ok(!$('.tab-container li:last', $testScope).hasClass('active'), 'the last opener is not active');
-            ok($('.content-panel:first', $testScope).css('display') !== 'none', 'the first panel is shown');
-            ok($('.content-panel:eq(2)', $testScope).css('display') === 'none', 'the 3rd panel is hidden');
-            ok($('.content-panel:last', $testScope).css('display') === 'none', 'the last panel is hidden');
+            assert.ok($('.tab-container li:first', $testScope).hasClass('active'), 'the first opener is active');
+            assert.ok(!$('.tab-container li:eq(2)', $testScope).hasClass('active'), 'the 3rd opener is not active');
+            assert.ok(!$('.tab-container li:last', $testScope).hasClass('active'), 'the last opener is not active');
+            assert.ok($('.content-panel:first', $testScope).css('display') !== 'none', 'the first panel is shown');
+            assert.ok($('.content-panel:eq(2)', $testScope).css('display') === 'none', 'the 3rd panel is hidden');
+            assert.ok($('.content-panel:last', $testScope).css('display') === 'none', 'the last panel is hidden');
 
-            start();
+            QUnit.start();
         });
-        ok(typeof section.init($testScope, { history : false }) === 'object', 'section.init() returns an object');
+        assert.ok(typeof section.init($testScope, { history : false }) === 'object', 'section.init() returns an object');
     });
 
-    asyncTest('switch from sections', function(){
-        expect(10);
+    QUnit.asyncTest('switch from sections', function(assert){
+        QUnit.expect(10);
         var $testScope = $('#qunit-fixture .multiple');
 
-        equal($testScope.length, 1, 'the test scope exists');
+        assert.equal($testScope.length, 1, 'the test scope exists');
 
-        ok(typeof section.init($testScope, { history : false }) === 'object', 'section.init() returns an object');
+        assert.ok(typeof section.init($testScope, { history : false }) === 'object', 'section.init() returns an object');
 
-        ok($('.tab-container li:first', $testScope).hasClass('active'), 'the first opener is active');
-        ok(!$('.tab-container li:eq(1)', $testScope).hasClass('active'), 'the 2nd opener is not active');
+        assert.ok($('.tab-container li:first', $testScope).hasClass('active'), 'the first opener is active');
+        assert.ok(!$('.tab-container li:eq(1)', $testScope).hasClass('active'), 'the 2nd opener is not active');
         
-        ok($('.content-panel:first', $testScope).css('display') !== 'none', 'the first panel is shown');
-        ok($('.content-panel:eq(1)', $testScope).css('display') === 'none', 'the 2nd panel is hidden');
+        assert.ok($('.content-panel:first', $testScope).css('display') !== 'none', 'the first panel is shown');
+        assert.ok($('.content-panel:eq(1)', $testScope).css('display') === 'none', 'the 2nd panel is hidden');
 
         $testScope.on('activate.section', function(){
 
-            ok(!$('.tab-container li:first', $testScope).hasClass('active'), 'the first opener isn\'t active anymore');
-            ok($('.tab-container li:eq(1)', $testScope).hasClass('active'), 'the 2nd opener is now active');
+            assert.ok(!$('.tab-container li:first', $testScope).hasClass('active'), 'the first opener isn\'t active anymore');
+            assert.ok($('.tab-container li:eq(1)', $testScope).hasClass('active'), 'the 2nd opener is now active');
             
-            ok($('.content-panel:first', $testScope).css('display') === 'none', 'the first panel is now hidden');
-            ok($('.content-panel:eq(1)', $testScope).css('display') !== 'none', 'the 2nd panel is now shown');
+            assert.ok($('.content-panel:first', $testScope).css('display') === 'none', 'the first panel is now hidden');
+            assert.ok($('.content-panel:eq(1)', $testScope).css('display') !== 'none', 'the 2nd panel is now shown');
 
-            start();
+            QUnit.start();
         });
         $('.tab-container li:eq(1)').trigger('click');
     });

--- a/views/js/test/lib/history/test.js
+++ b/views/js/test/lib/history/test.js
@@ -19,6 +19,7 @@
  * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
  */
 define(['lib/history/history'], function(historyLib){
+    'use strict';
 
     var location = window.history.location || window.location;
     var port = location.port;
@@ -66,10 +67,15 @@ define(['lib/history/history'], function(historyLib){
 
     QUnit
         .cases(pushStatesDataProvider)
-        .test('pushState', function(data, assert) {
+        .asyncTest('pushState', function(data, assert) {
             historyLib.pushState(data.state, data.title, data.url);
-            assert.deepEqual(historyLib.state, data.expected.state, 'The current history state must comply to the last pushed state');
-            assert.equal(location.href, data.expected.url, 'The current page URL must comply to the target state');
+            QUnit.expect(2);
+
+            setTimeout(function(){
+                assert.deepEqual(historyLib.state, data.expected.state, 'The current history state must comply to the last pushed state');
+                assert.equal(location.href, data.expected.url, 'The current page URL must comply to the target state');
+                QUnit.start();
+            }, 500);
         });
 
     /** replaceState **/
@@ -93,10 +99,16 @@ define(['lib/history/history'], function(historyLib){
 
     QUnit
         .cases(replaceStatesDataProvider)
-        .test('replaceState', function(data, assert) {
+        .asyncTest('replaceState', function(data, assert) {
+            QUnit.expect(2);
+
             historyLib.replaceState(data.state, data.title, data.url);
-            assert.deepEqual(historyLib.state, data.expected.state, 'The current history state must comply to the last replaced state');
-            assert.equal(location.href, data.expected.url, 'The current page URL must comply to the target state');
+
+            setTimeout(function(){
+                assert.deepEqual(historyLib.state, data.expected.state, 'The current history state must comply to the last replaced state');
+                assert.equal(location.href, data.expected.url, 'The current page URL must comply to the target state');
+                QUnit.start();
+            }, 500);
         });
 
     QUnit.module('Navigation');
@@ -118,11 +130,16 @@ define(['lib/history/history'], function(historyLib){
 
     QUnit
         .cases(backNavigationDataProvider)
-        .test('navigation', function(data, assert) {
+        .asyncTest('navigation', function(data, assert) {
+            QUnit.expect(2);
 
             historyLib.back();
-            assert.deepEqual(historyLib.state, data.expected.state, 'The current history state must comply to the right state after stepping back');
-            assert.equal(location.href, data.expected.url, 'The current page URL must comply to the target state');
+
+            setTimeout(function(){
+                assert.deepEqual(historyLib.state, data.expected.state, 'The current history state must comply to the right state after stepping back');
+                assert.equal(location.href, data.expected.url, 'The current page URL must comply to the target state');
+                QUnit.start();
+            }, 500);
         });
 
     /** forward **/
@@ -142,18 +159,29 @@ define(['lib/history/history'], function(historyLib){
 
     QUnit
         .cases(forwardNavigationDataProvider)
-        .test('navigation', function(data, assert) {
+        .asyncTest('navigation', function(data, assert) {
+            QUnit.expect(2);
 
             historyLib.forward();
-            assert.deepEqual(historyLib.state, data.expected.state, 'The current history state must comply to the right state after stepping forward');
-            assert.equal(location.href, data.expected.url, 'The current page URL must comply to the target state');
+
+            setTimeout(function(){
+                assert.deepEqual(historyLib.state, data.expected.state, 'The current history state must comply to the right state after stepping forward');
+                assert.equal(location.href, data.expected.url, 'The current page URL must comply to the target state');
+                QUnit.start();
+            }, 500);
         });
 
     /** restoreContext **/
     QUnit
-        .test('restoreContext', function(assert) {
+        .asyncTest('restoreContext', function(assert) {
+            QUnit.expect(2);
+
             historyLib.pushState(null, window.title, testerUrl);
-            assert.deepEqual(historyLib.state, null, 'The current history state must comply to the last pushed state');
-            assert.equal(location.href, testerUrl, 'The current page URL must comply to the target state');
+
+            setTimeout(function(){
+                assert.deepEqual(historyLib.state, null, 'The current history state must comply to the last pushed state');
+                assert.equal(location.href, testerUrl, 'The current page URL must comply to the target state');
+                QUnit.start();
+            }, 500);
         });
 });

--- a/views/js/test/ui/adder/test.js
+++ b/views/js/test/ui/adder/test.js
@@ -1,36 +1,36 @@
 define(['jquery', 'ui/adder'], function($, adder){
     
     
-    module('Adder Stand Alone Test');
+    QUnit.module('Adder Stand Alone Test');
    
-    test('plugin', function(){
-       expect(1);
-       ok(typeof $.fn.adder === 'function', 'The Adder plugin is registered');
+    QUnit.test('plugin', function(assert){
+       QUnit.expect(1);
+       assert.ok(typeof $.fn.adder === 'function', 'The Adder plugin is registered');
     });
    
-    asyncTest('Initialization', function(){
-        expect(6);
+    QUnit.asyncTest('Initialization', function(assert){
+        QUnit.expect(6);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $('.adder', $container);
-        ok($elt.length === 1, 'Adder link is available');
+        assert.ok($elt.length === 1, 'Adder link is available');
         
         var $target = $('.content', $container);
-        ok($target.length === 1, 'Target is available');
+        assert.ok($target.length === 1, 'Target is available');
         
         var $tmpl = $('.tmpl', $container);
-        ok($tmpl.length === 1, 'Template is available');
+        assert.ok($tmpl.length === 1, 'Template is available');
         
         $elt.on('create.adder', function(){
             var data = $elt.data('ui.adder'); 
-            ok(typeof data === 'object', 'The element is runing the plugin');
+            assert.ok(typeof data === 'object', 'The element is runing the plugin');
 
             $elt.adder('options', { test : true});
             strictEqual(data.test, true, 'The plugin options methods update the element data');
 
-            start();
+            QUnit.start();
         });
         $elt.adder({
             target : $target,
@@ -38,32 +38,32 @@ define(['jquery', 'ui/adder'], function($, adder){
         });
     });
     
-    asyncTest('Template adding', function(){
-        expect(7);
+    QUnit.asyncTest('Template adding', function(assert){
+        QUnit.expect(7);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $('.adder', $container);
-        ok($elt.length === 1, 'Adder link is available');
+        assert.ok($elt.length === 1, 'Adder link is available');
         
         var $target = $('.content', $container);
-        ok($target.length === 1, 'Target is available');
+        assert.ok($target.length === 1, 'Target is available');
         
         var $tmpl = $('.tmpl', $container);
-        ok($tmpl.length === 1, 'Template is available');
+        assert.ok($tmpl.length === 1, 'Template is available');
         
         $elt.on('create.adder', function(){
             $elt.trigger('click');
         });
          $elt.on('add.adder', function(){
             var $p = $target.find('p');
-            ok($p.length === 1, 'Content is added');
+            assert.ok($p.length === 1, 'Content is added');
             
-            equal($p.attr('id'), 'foo', 'Template data inserted');
-            equal($p.text(), 'bar', 'Template data inserted');
+            assert.equal($p.attr('id'), 'foo', 'Template data inserted');
+            assert.equal($p.text(), 'bar', 'Template data inserted');
              
-            start();
+            QUnit.start();
          });
         $elt.adder({
             target : $target,
@@ -77,20 +77,20 @@ define(['jquery', 'ui/adder'], function($, adder){
         });
     });
     
-    asyncTest('HTML adding', function(){
-        expect(5);
+    QUnit.asyncTest('HTML adding', function(assert){
+        QUnit.expect(5);
         
         var $container = $('#container-2');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $('.adder', $container);
-        ok($elt.length === 1, 'Adder link is available');
+        assert.ok($elt.length === 1, 'Adder link is available');
         
         var $target = $('.list2', $container);
-        ok($target.length === 1, 'Target is available');
+        assert.ok($target.length === 1, 'Target is available');
         
         var $content = $('.list1', $container);
-        ok($content.length === 1, 'DOM content is available');
+        assert.ok($content.length === 1, 'DOM content is available');
         
         $elt.on('create.adder', function(){
             $elt.trigger('click');
@@ -101,8 +101,8 @@ define(['jquery', 'ui/adder'], function($, adder){
         var counter = 0;
          $elt.on('add.adder', function(){
             if(counter >= 1){
-                ok($target.find('li').length === 2, 'HTML content added 2 times');
-                start();
+                assert.ok($target.find('li').length === 2, 'HTML content added 2 times');
+                QUnit.start();
             }
             counter++;
          });
@@ -112,20 +112,20 @@ define(['jquery', 'ui/adder'], function($, adder){
         });
     });
     
-    module('Adder Data Attr Test');
+    QUnit.module('Adder Data Attr Test');
      
-     asyncTest('initialization', function(){
-        expect(3);
+     QUnit.asyncTest('initialization', function(assert){
+        QUnit.expect(3);
         
         var $container = $('#container-3');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $('.adder', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
         
         $elt.on('add.adder', function(){
-            ok($('#c3-list2').find('li').length === 1, 'Content added');
-            start();
+            assert.ok($('#c3-list2').find('li').length === 1, 'Content added');
+            QUnit.start();
         });
        
         adder($container);

--- a/views/js/test/ui/btngrouper/test.js
+++ b/views/js/test/ui/btngrouper/test.js
@@ -1,92 +1,92 @@
 define(['jquery', 'ui', 'ui/btngrouper'], function($, ui, btngrouper){
     'use strict';    
     
-    module('Button Grouper Stand Alone Test');
+    QUnit.module('Button Grouper Stand Alone Test');
    
-    test('plugin', function(){
-       expect(1);
-       ok(typeof $.fn.btngrouper === 'function', 'The Button Grouper plugin is registered');
+    QUnit.test('plugin', function(assert){
+       QUnit.expect(1);
+       assert.ok(typeof $.fn.btngrouper === 'function', 'The Button Grouper plugin is registered');
     });
    
-    asyncTest('Initialization', function(){
-        expect(2);
+    QUnit.asyncTest('Initialization', function(assert){
+        QUnit.expect(2);
         
         var $fixture = $('#qunit-fixture');
         
         var $group = $("[data-button-group='toggle']", $fixture);
-        ok($group.length === 1, 'The Group is available');
+        assert.ok($group.length === 1, 'The Group is available');
         
         $group.on('create.btngrouper', function(){
-            ok(typeof $group.data('ui.btngrouper') === 'object', 'The element is runing the plugin');
-            start();
+            assert.ok(typeof $group.data('ui.btngrouper') === 'object', 'The element is runing the plugin');
+            QUnit.start();
         });
         $group.btngrouper({
             action : 'toggle'
         });
     });
     
-    asyncTest('Toggle', function(){
-        expect(6);
+    QUnit.asyncTest('Toggle', function(assert){
+        QUnit.expect(6);
         
         var $fixture = $('#qunit-fixture');
         
         var $group = $("[data-button-group='toggle']", $fixture);
-        ok($group.length === 1, 'The Group is available');
+        assert.ok($group.length === 1, 'The Group is available');
         
         $group.on('create.btngrouper', function(){
-            equal($group.find('.active').length, 1, 'Only one element is active');
-            equal($group.btngrouper('value'), 'Y', 'The group value is Y');
+            assert.equal($group.find('.active').length, 1, 'Only one element is active');
+            assert.equal($group.btngrouper('value'), 'Y', 'The group value is Y');
             
             $group.find('li:first').trigger('click');
         });
         $group.on('toggle.btngrouper', function(){
-            equal($group.find('.active').length, 1, 'Only one element is active');
-            ok($group.find('li:last').hasClass('active'), 'The active element is toggled');
-            equal($group.btngrouper('value'), 'N', 'The group value is N');
-            start();
+            assert.equal($group.find('.active').length, 1, 'Only one element is active');
+            assert.ok($group.find('li:last').hasClass('active'), 'The active element is toggled');
+            assert.equal($group.btngrouper('value'), 'N', 'The group value is N');
+            QUnit.start();
         });
         $group.btngrouper({
             action : 'toggle'
         });
     });
     
-    asyncTest('switch', function(){
-        expect(5);
+    QUnit.asyncTest('switch', function(assert){
+        QUnit.expect(5);
         
         var $fixture = $('#qunit-fixture');
         
         var $group = $("[data-button-group='switch']", $fixture);
-        ok($group.length === 1, 'The Group is available');
-        ok($group.find('li:first').hasClass('active'), 'The first element is active');
+        assert.ok($group.length === 1, 'The Group is available');
+        assert.ok($group.find('li:first').hasClass('active'), 'The first element is active');
         
         $group.on('create.btngrouper', function(){
-            equal($group.btngrouper('value'), 'B', 'The group value is B');
+            assert.equal($group.btngrouper('value'), 'B', 'The group value is B');
             $group.find('li:first').trigger('click');
         });
         $group.on('switch.btngrouper', function(){
-            equal($group.find('.active').length, 0, 'No more element are active');
-            equal($group.btngrouper('value'), [], 'No values');
-            start();
+            assert.equal($group.find('.active').length, 0, 'No more element are active');
+            assert.equal($group.btngrouper('value'), [], 'No values');
+            QUnit.start();
         });
         $group.btngrouper({
             action : 'switch'
         });
     });
     
-    module('Button Grouper Data Attr Test');
+    QUnit.module('Button Grouper Data Attr Test');
      
-     asyncTest('initialization', function(){
-        expect(3);
+     QUnit.asyncTest('initialization', function(assert){
+        QUnit.expect(3);
         
         var $fixture = $('#qunit-fixture');
         
         var $group = $("[data-button-group='toggle']", $fixture);
-        ok($group.length === 1, 'The Group is available');
+        assert.ok($group.length === 1, 'The Group is available');
         
         $group.on('toggle.btngrouper', function(){
-            equal($group.find('.active').length, 1, 'Only one element is active');
-            ok($group.find('li:last').hasClass('active'), 'The active element is toggled');
-            start();
+            assert.equal($group.find('.active').length, 1, 'Only one element is active');
+            assert.ok($group.find('li:last').hasClass('active'), 'The active element is toggled');
+            QUnit.start();
         });
        
         btngrouper($fixture);

--- a/views/js/test/ui/datatable/test.js
+++ b/views/js/test/ui/datatable/test.js
@@ -1,43 +1,43 @@
 define(['jquery', 'ui/datatable'], function($){
     
     
-    module('DataTable Test');
+    QUnit.module('DataTable Test');
    
-    test('plugin', function(){
-       expect(1);
-       ok(typeof $.fn.datatable === 'function', 'The datatable plugin is registered');
+    QUnit.test('plugin', function(assert){
+       QUnit.expect(1);
+       assert.ok(typeof $.fn.datatable === 'function', 'The datatable plugin is registered');
     });
    
-    asyncTest('Initialization', function(){
-        expect(2);
+    QUnit.asyncTest('Initialization', function(assert){
+        QUnit.expect(2);
         
         var $elt = $('#container-1');
-        ok($elt.length === 1, 'Test the fixture is available');
+        assert.ok($elt.length === 1, 'Test the fixture is available');
         
         
         $elt.on('create.datatable', function(){
-            ok($elt.find('.datatable').length === 1, 'the layout has been inserted');
-            start();
+            assert.ok($elt.find('.datatable').length === 1, 'the layout has been inserted');
+            QUnit.start();
         });
         $elt.datatable({
             url : 'js/test/ui/datatable/data.json'
         });
     });
 
-    asyncTest('Model loading', function(){
-        expect(6);
+    QUnit.asyncTest('Model loading', function(assert){
+        QUnit.expect(6);
         
         var $elt = $('#container-1');
-        ok($elt.length === 1, 'Test the fixture is available');
+        assert.ok($elt.length === 1, 'Test the fixture is available');
         
         
         $elt.on('create.datatable', function(){
-            ok($elt.find('.datatable').length === 1, 'the layout has been inserted');
-            ok($elt.find('.datatable thead th').length === 7, 'the table contains 7 heads elements (id included)');
-            equal($elt.find('.datatable thead th:eq(1)').text(), 'Login', 'the login label is created');
-            equal($elt.find('.datatable thead th:eq(2)').text(), 'Name', 'the name label is created');
-            equal($elt.find('.datatable thead th:eq(1)').data('sort-by'), 'login', 'the login col is sortable');
-            start();
+            assert.ok($elt.find('.datatable').length === 1, 'the layout has been inserted');
+            assert.ok($elt.find('.datatable thead th').length === 7, 'the table contains 7 heads elements (id included)');
+            assert.equal($elt.find('.datatable thead th:eq(1)').text(), 'Login', 'the login label is created');
+            assert.equal($elt.find('.datatable thead th:eq(2)').text(), 'Name', 'the name label is created');
+            assert.equal($elt.find('.datatable thead th:eq(1)').data('sort-by'), 'login', 'the login col is sortable');
+            QUnit.start();
         });
         $elt.datatable({
             url : 'js/test/ui/datatable/data.json',
@@ -69,20 +69,20 @@ define(['jquery', 'ui/datatable'], function($){
         });
     });
 
-    asyncTest('Pagination disabled', function(){
-        expect(6);
+    QUnit.asyncTest('Pagination disabled', function(assert){
+        QUnit.expect(6);
         
         var $elt = $('#container-1');
-        ok($elt.length === 1, 'Test the fixture is available');
+        assert.ok($elt.length === 1, 'Test the fixture is available');
         
         
         $elt.on('create.datatable', function(){
-            ok($elt.find('.datatable').length === 1, 'the layout has been inserted');
-            ok($elt.find('.datatable-backward').length === 2, 'there is 2 backward buttons');
-            ok($elt.find('.datatable-forward').length === 2, 'there is 2 forward buttons');
-            ok($elt.find('.datatable-backward:first').prop('disabled'), 'the backward button is disabled');
-            ok($elt.find('.datatable-forward:last').prop('disabled'), 'the forward button is disabled');
-            start();
+            assert.ok($elt.find('.datatable').length === 1, 'the layout has been inserted');
+            assert.ok($elt.find('.datatable-backward').length === 2, 'there is 2 backward buttons');
+            assert.ok($elt.find('.datatable-forward').length === 2, 'there is 2 forward buttons');
+            assert.ok($elt.find('.datatable-backward:first').prop('disabled'), 'the backward button is disabled');
+            assert.ok($elt.find('.datatable-forward:last').prop('disabled'), 'the forward button is disabled');
+            QUnit.start();
         });
         $elt.datatable({
             url : 'js/test/ui/datatable/data.json',
@@ -114,21 +114,21 @@ define(['jquery', 'ui/datatable'], function($){
         });
     });
 
-    asyncTest('Pagination enabled', function(){
-        expect(7);
+    QUnit.asyncTest('Pagination enabled', function(assert){
+        QUnit.expect(7);
         
         var $elt = $('#container-1');
-        ok($elt.length === 1, 'Test the fixture is available');
+        assert.ok($elt.length === 1, 'Test the fixture is available');
         
         
         $elt.on('create.datatable', function(){
-            ok($elt.find('.datatable').length === 1, 'the layout has been inserted');
-            ok($elt.find('.datatable-backward').length === 2, 'there is 2 backward buttons');
-            ok($elt.find('.datatable-forward').length === 2, 'there is 2 forward buttons');
-            ok($elt.find('.datatable-forward:first').prop('disabled') === false, 'the forward button is enabled');
-            ok($elt.find('.datatable-forward:last').prop('disabled') === false, 'the forward button is disabled');
-            ok($elt.find('.datatable-backward:first').prop('disabled'), 'the backward button is disabled (on the 1st page)');
-            start();
+            assert.ok($elt.find('.datatable').length === 1, 'the layout has been inserted');
+            assert.ok($elt.find('.datatable-backward').length === 2, 'there is 2 backward buttons');
+            assert.ok($elt.find('.datatable-forward').length === 2, 'there is 2 forward buttons');
+            assert.ok($elt.find('.datatable-forward:first').prop('disabled') === false, 'the forward button is enabled');
+            assert.ok($elt.find('.datatable-forward:last').prop('disabled') === false, 'the forward button is disabled');
+            assert.ok($elt.find('.datatable-backward:first').prop('disabled'), 'the backward button is disabled (on the 1st page)');
+            QUnit.start();
         });
         $elt.datatable({
             url : 'js/test/ui/datatable/largedata.json',

--- a/views/js/test/ui/deleter/test.js
+++ b/views/js/test/ui/deleter/test.js
@@ -1,129 +1,127 @@
 define(['jquery', 'ui', 'ui/deleter'], function($, ui, deleter){
-    
-    
-    module('Deleter Stand Alone Test');
-   
-    test('plugin', function(){
-       expect(1);
-       ok(typeof $.fn.deleter === 'function', 'The Deleter plugin is registered');
+    'use strict';
+
+    QUnit.module('Deleter Stand Alone Test');
+
+    QUnit.test('plugin', function(assert){
+       QUnit.expect(1);
+       assert.ok(typeof $.fn.deleter === 'function', 'The Deleter plugin is registered');
     });
-   
-    asyncTest('Initialization', function(){
-        expect(4);
-        
+
+    QUnit.asyncTest('Initialization', function(assert){
+        QUnit.expect(4);
+
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
-        
+        assert.ok($container.length === 1, 'Test the fixture is available');
+
         var $elt = $('.deleter', $container);
-        ok($elt.length === 1, 'Deleter link is available');
-        
+        assert.ok($elt.length === 1, 'Deleter link is available');
+
         var $target = $('.content', $container);
-        ok($target.length === 1, 'Target is available');
-        
+        assert.ok($target.length === 1, 'Target is available');
+
         $elt.on('create.deleter', function(){
-            ok(typeof $elt.data('ui.deleter') === 'object', 'The element is runing the plugin');
-            start();
+            assert.ok(typeof $elt.data('ui.deleter') === 'object', 'The element is runing the plugin');
+            QUnit.start();
         });
-        $elt.deleter({ 
+        $elt.deleter({
             target : $target,
             confirm : false
         });
     });
-    
-    asyncTest('Deleting', function(){
-        expect(4);
-        
+
+    QUnit.asyncTest('Deleting', function(assert){
+        QUnit.expect(4);
+
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
-        
+        assert.ok($container.length === 1, 'Test the fixture is available');
+
         var $elt = $('.deleter', $container);
-        ok($elt.length === 1, 'Deleter link is available');
-        
+        assert.ok($elt.length === 1, 'Deleter link is available');
+
         var $target = $('.content', $container);
-        ok($target.length === 1, 'Target is available');
-        
+        assert.ok($target.length === 1, 'Target is available');
+
         $elt.on('create.deleter', function(){
             $elt.trigger('click');
         });
-        
+
          $elt.on('deleted.deleter', function(e){
             if(e.namespace === 'deleter'){
-                ok($('.content', $container).length === 0, 'Target doesn\'t exists anymore');
-                start();
+                assert.ok($('.content', $container).length === 0, 'Target doesn\'t exists anymore');
+                QUnit.start();
             }
         });
-        $elt.deleter({ 
+        $elt.deleter({
             target : $target,
             confirm : false
         });
     });
-    
-    
-    module('Deleter Data Attr Test');
-     
-     asyncTest('Initialization', function(){
-        expect(4);
-        
+
+
+    QUnit.module('Deleter Data Attr Test');
+
+     QUnit.asyncTest('Initialization', function(assert){
+        QUnit.expect(4);
+
         //prevent the confirm message to lock the test
         window.confirm = function(){
             return true;
         };
-        
+
         var $container = $('#container-2');
-        ok($container.length === 1, 'Test the fixture is available');
-        
+        assert.ok($container.length === 1, 'Test the fixture is available');
+
         var $elt = $('.deleter', $container);
-        ok($elt.length === 1, 'Deleter link is available');
-        
+        assert.ok($elt.length === 1, 'Deleter link is available');
+
         var $target = $('.content', $container);
-        ok($target.length === 1, 'Target is available');
-        
+        assert.ok($target.length === 1, 'Target is available');
+
         $elt.on('deleted.deleter', function(e){
             if(e.namespace === 'deleter'){
-                ok($('.content', $container).length === 0, 'Target doesn\'t exists anymore');
-                start();
+                assert.ok($('.content', $container).length === 0, 'Target doesn\'t exists anymore');
+                QUnit.start();
             }
         });
-        
+
         deleter($container);
         $elt.trigger('click');
     });
- 
-    module('Undo');
- 
-    asyncTest('Undo Delete', function(){
-        expect(5);
-        
+
+    QUnit.module('Undo');
+
+    QUnit.asyncTest('Undo Delete', function(assert){
+        QUnit.expect(5);
+
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
-        
+        assert.ok($container.length === 1, 'Test the fixture is available');
+
         var $elt = $('.deleter', $container);
-        ok($elt.length === 1, 'Deleter link is available');
-        
+        assert.ok($elt.length === 1, 'Deleter link is available');
+
         var $target = $('.content', $container);
-        ok($target.length === 1, 'Target is available');
-        
+        assert.ok($target.length === 1, 'Target is available');
+
         $elt.on('create.deleter', function(){
             $elt.trigger('click');
         });
-        
+
         $elt.on('delete.deleter', function(e){
             if(e.namespace === 'deleter'){
                 setTimeout(function(){
                     var $undo = $('body').find('a.undo');
-                    console.log($undo);
-                    ok( $undo.length === 1, 'the undo link is there');
+                    assert.ok( $undo.length === 1, 'the undo link is there');
                     $undo.trigger('click');
                 }, 100);
             }
         });
         $elt.on('undo.deleter', function(e){
-            console.log('undo triggered');
             var $target = $('.content', $container);
-            ok($target.length === 1, 'Target is available');
-            start();
+            assert.ok($target.length === 1, 'Target is available');
+            QUnit.start();
         });
-        $elt.deleter({ 
+        $elt.deleter({
             target : $target,
             confirm : false,
             undo : true,

--- a/views/js/test/ui/durationer/test.js
+++ b/views/js/test/ui/durationer/test.js
@@ -1,82 +1,82 @@
 define(['jquery', 'ui',  'ui/durationer'], function($, ui, durationer){
     
     
-    module('Durationer Stand Alone Test');
+    QUnit.module('Durationer Stand Alone Test');
    
-    test('plugin', function(){
-       expect(1);
-       ok(typeof $.fn.durationer === 'function', 'The Durationer plugin is registered');
+    QUnit.test('plugin', function(assert){
+       QUnit.expect(1);
+       assert.ok(typeof $.fn.durationer === 'function', 'The Durationer plugin is registered');
     });
    
-    asyncTest('initialization', function(){
-        expect(5);
+    QUnit.asyncTest('initialization', function(assert){
+        QUnit.expect(5);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
         
         $elt.on('create.durationer', function(){
-            ok(typeof $elt.data('ui.durationer') === 'object');
+            assert.ok(typeof $elt.data('ui.durationer') === 'object');
             var $controls = $container.find('.duration-ctrl');
-            equal($controls.length, 3, 'The plugins has created controls');
-            ok(typeof $controls.data('ui.incrementer') === 'object', 'The plugins has initialized incrementer on controls');
+            assert.equal($controls.length, 3, 'The plugins has created controls');
+            assert.ok(typeof $controls.data('ui.incrementer') === 'object', 'The plugins has initialized incrementer on controls');
             
-            start();
+            QUnit.start();
         });
         $elt.durationer();
     });
       
-     asyncTest('update seconds', function(){
-        expect(3);
+     QUnit.asyncTest('update seconds', function(assert){
+        QUnit.expect(3);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
         
         $elt.on('create.durationer', function(){
             var $secCtrl = $container.find("[data-duration-type='seconds']");
-            equal($secCtrl.length, 1, 'The seconds controls exists');
+            assert.equal($secCtrl.length, 1, 'The seconds controls exists');
             $secCtrl.val('10').trigger('change');
         });
         $elt.on('update.durationer', function(){
             
-            equal($elt.val(), '00:00:10', 'The element value has been synchronized');
+            assert.equal($elt.val(), '00:00:10', 'The element value has been synchronized');
             
-            start();
+            QUnit.start();
         });
         $elt.durationer();
     });
     
-    asyncTest('update minutes', function(){
-        expect(3);
+    QUnit.asyncTest('update minutes', function(assert){
+        QUnit.expect(3);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
         
         $elt.on('create.durationer', function(){
             var $minCtrl = $container.find("[data-duration-type='minutes']");
-            equal($minCtrl.length, 1, 'The minutes controls exists');
+            assert.equal($minCtrl.length, 1, 'The minutes controls exists');
             $minCtrl.val('9').trigger('change');
         });
         $elt.on('update.durationer', function(){
             
-            equal($elt.val(), '00:09:00', 'The element value has been synchronized');
+            assert.equal($elt.val(), '00:09:00', 'The element value has been synchronized');
             
-            start();
+            QUnit.start();
         });
         $elt.durationer();
     });
     
-    asyncTest('update hours from incrementer', function(){
-        expect(3);
+    QUnit.asyncTest('update hours from incrementer', function(assert){
+        QUnit.expect(3);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
         
@@ -84,25 +84,25 @@ define(['jquery', 'ui',  'ui/durationer'], function($, ui, durationer){
             var $hourCtrlInc = $container.find("[data-duration-type='hours']").next('.incrementer-ctrl:first').find('.inc');
             
             
-            equal($hourCtrlInc.length, 1, 'The hours incrementer button controls exists');
+            assert.equal($hourCtrlInc.length, 1, 'The hours incrementer button controls exists');
             
             $hourCtrlInc.click();
             
         });
         $elt.on('update.durationer', function(){
             
-            equal($elt.val(), '01:00:00', 'The element value has been synchronized');
+            assert.equal($elt.val(), '01:00:00', 'The element value has been synchronized');
             
-            start();
+            QUnit.start();
         });
         $elt.durationer();
     });
     
-    asyncTest('initialization with value', function(){
-        expect(5);
+    QUnit.asyncTest('initialization with value', function(assert){
+        QUnit.expect(5);
         
         var $container = $('#container-2');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         var $elt = $(':text', $container);
         
         $elt.on('create.durationer', function(){
@@ -111,35 +111,35 @@ define(['jquery', 'ui',  'ui/durationer'], function($, ui, durationer){
             var $minCtrl = $container.find("[data-duration-type='minutes']");
             var $secCtrl = $container.find("[data-duration-type='seconds']");
             
-            equal($hourCtrl.val(), '2');
-            equal($minCtrl.val(), '39');
-            equal($secCtrl.val(), '59');
+            assert.equal($hourCtrl.val(), '2');
+            assert.equal($minCtrl.val(), '39');
+            assert.equal($secCtrl.val(), '59');
             
-            equal($elt.val(), "02:39:59");
+            assert.equal($elt.val(), "02:39:59");
            
-            start();
+            QUnit.start();
         });
         $elt.durationer();
     });
     
-     module('Durationer Data Attr Test');
+     QUnit.module('Durationer Data Attr Test');
      
-     asyncTest('initialization', function(){
-        expect(5);
+     QUnit.asyncTest('initialization', function(assert){
+        QUnit.expect(5);
         
         var $container = $('#container-3');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
         
         $elt.on('create.durationer', function(){
-            ok(typeof $elt.data('ui.durationer') === 'object');
+            assert.ok(typeof $elt.data('ui.durationer') === 'object');
             var $controls = $container.find('.duration-ctrl');
-            equal($controls.length, 3, 'The plugins has created controls');
-            ok(typeof $controls.data('ui.incrementer') === 'object', 'The plugins has initialized incrementer on controls');
+            assert.equal($controls.length, 3, 'The plugins has created controls');
+            assert.ok(typeof $controls.data('ui.incrementer') === 'object', 'The plugins has initialized incrementer on controls');
             
-            start();
+            QUnit.start();
         });
        
         durationer($container);

--- a/views/js/test/ui/feedback/test.js
+++ b/views/js/test/ui/feedback/test.js
@@ -1,189 +1,189 @@
 define(['jquery', 'ui/feedback'], function($, feedback){
         
-    module('feedback');
+    QUnit.module('feedback');
    
-    test('module', function(){
-        expect(1);
+    QUnit.test('module', function(assert){
+        QUnit.expect(1);
 
-        ok(typeof feedback === 'function', 'The module expose a function');
+        assert.ok(typeof feedback === 'function', 'The module expose a function');
     });
 
-    test('api', function(){
-        expect(10);
+    QUnit.test('api', function(assert){
+        QUnit.expect(10);
 
         var fb = feedback();
 
-        ok(typeof fb === 'object'                       , 'The feedback function creates an object');
-        ok(typeof fb._container === 'object'            , 'The feedback instance has a _container member');
-        ok(typeof fb._container.selector === 'string'   , 'The _container is a jquery object');
-        ok(typeof fb.message === 'function'             , 'The feedback instance has a message method');
-        ok(typeof fb.info === 'function'                , 'The feedback instance has a info method');
-        ok(typeof fb.success === 'function'             , 'The feedback instance has a success method');
-        ok(typeof fb.warning === 'function'             , 'The feedback instance has a warning method');
-        ok(typeof fb.error === 'function'               , 'The feedback instance has an error method');
-        ok(typeof fb.open === 'function'                , 'The feedback instance has an open method');
-        ok(typeof fb.close === 'function'               , 'The feedback instance has a close method');
+        assert.ok(typeof fb === 'object'                       , 'The feedback function creates an object');
+        assert.ok(typeof fb._container === 'object'            , 'The feedback instance has a _container member');
+        assert.ok(typeof fb._container.selector === 'string'   , 'The _container is a jquery object');
+        assert.ok(typeof fb.message === 'function'             , 'The feedback instance has a message method');
+        assert.ok(typeof fb.info === 'function'                , 'The feedback instance has a info method');
+        assert.ok(typeof fb.success === 'function'             , 'The feedback instance has a success method');
+        assert.ok(typeof fb.warning === 'function'             , 'The feedback instance has a warning method');
+        assert.ok(typeof fb.error === 'function'               , 'The feedback instance has an error method');
+        assert.ok(typeof fb.open === 'function'                , 'The feedback instance has an open method');
+        assert.ok(typeof fb.close === 'function'               , 'The feedback instance has a close method');
     });
 
-    test('factory', function(){
-        expect(3);
+    QUnit.test('factory', function(assert){
+        QUnit.expect(3);
 
         var fb1 = feedback();
         var fb2 = feedback();
 
-        ok(typeof fb1 === 'object'                       , 'The feedback function creates an object');
-        ok(typeof fb2 === 'object'                       , 'The feedback function creates an object');
+        assert.ok(typeof fb1 === 'object'                       , 'The feedback function creates an object');
+        assert.ok(typeof fb2 === 'object'                       , 'The feedback function creates an object');
         notStrictEqual(fb1, fb2                          , 'The feedback function creates object instances');
     });
 
-    test('wrong container', function(){
-        expect(1);
+    QUnit.test('wrong container', function(assert){
+        QUnit.expect(1);
 
-        throws(function(){
+        assert.throws(function(){
 
             feedback( $('#foofoo'));
 
         }, Error, 'An exception should be thrown if the container is not an existing element');
     });
     
-    test('state', function(){
-        expect(9);
+    QUnit.test('state', function(assert){
+        QUnit.expect(9);
         
         var fb = feedback().message();
         var fb2 = feedback().message();
 
-        ok(typeof fb === 'object'                       , 'The feedback function creates an object');
-        ok(typeof fb._state === 'string'                , 'The feedback contains has a _state member');
-        ok(typeof fb.setState === 'function'            , 'The feedback instance has a setState method');
-        ok(typeof fb.isInState === 'function'           , 'The feedback instance has an isInState method');
-        equal(fb._state, 'created'                      , 'The feedback instance starts with the created state');
-        ok(fb.isInState('created')                      , 'The isInState method verify the currrent state');
-        equal(fb2._state, 'created'                      , 'The 2nd feedback instance starts with the created state');
+        assert.ok(typeof fb === 'object'                       , 'The feedback function creates an object');
+        assert.ok(typeof fb._state === 'string'                , 'The feedback contains has a _state member');
+        assert.ok(typeof fb.setState === 'function'            , 'The feedback instance has a setState method');
+        assert.ok(typeof fb.isInState === 'function'           , 'The feedback instance has an isInState method');
+        assert.equal(fb._state, 'created'                      , 'The feedback instance starts with the created state');
+        assert.ok(fb.isInState('created')                      , 'The isInState method verify the currrent state');
+        assert.equal(fb2._state, 'created'                      , 'The 2nd feedback instance starts with the created state');
 
         fb2.setState('closed');
 
-        equal(fb2._state, 'closed'                      , 'Once changed the current state is changed');
-        equal(fb._state, 'created'                      , 'Once changed it does not interfer with other instances');
+        assert.equal(fb2._state, 'closed'                      , 'Once changed the current state is changed');
+        assert.equal(fb._state, 'created'                      , 'Once changed it does not interfer with other instances');
     });
 
-    test('default message', function(){
-        expect(5);
+    QUnit.test('default message', function(assert){
+        QUnit.expect(5);
         
         var fb = feedback();
         var r2 = fb.message();
 
-        ok(typeof fb === 'object'                       , 'The feedback function creates an object');
+        assert.ok(typeof fb === 'object'                       , 'The feedback function creates an object');
         strictEqual(fb, r2                              , 'The message function is fluent');
-        ok(typeof fb.content === 'string'               , 'The content property has been created');
-        equal(fb.category, 'volatile'                   , 'The category of info is volatile');
-        ok(/feedback-info/m.test(fb.content)            , 'The content property contains the right css class');
+        assert.ok(typeof fb.content === 'string'               , 'The content property has been created');
+        assert.equal(fb.category, 'volatile'                   , 'The category of info is volatile');
+        assert.ok(/feedback-info/m.test(fb.content)            , 'The content property contains the right css class');
     });
 
-    test('parameterized message', function(){
-        expect(5);
+    QUnit.test('parameterized message', function(assert){
+        QUnit.expect(5);
 
         var fb = feedback().message('success', 'AWESOME_MESSAGE');
 
-        ok(typeof fb === 'object'                       , 'The feedback function creates an object');
-        ok(typeof fb.content === 'string'               , 'The content property has been created');
-        equal(fb.level, 'success'                       , 'The level is set to success');
-        ok(/feedback-success/m.test(fb.content)         , 'The content property contains the right css class');
-        ok(/AWESOME_MESSAGE/m.test(fb.content)          , 'The content property contains the message');
+        assert.ok(typeof fb === 'object'                       , 'The feedback function creates an object');
+        assert.ok(typeof fb.content === 'string'               , 'The content property has been created');
+        assert.equal(fb.level, 'success'                       , 'The level is set to success');
+        assert.ok(/feedback-success/m.test(fb.content)         , 'The content property contains the right css class');
+        assert.ok(/AWESOME_MESSAGE/m.test(fb.content)          , 'The content property contains the message');
     });
 
-    test('display message', function(){
-        expect(3);
+    QUnit.test('display message', function(assert){
+        QUnit.expect(3);
         var $container = $('#feedback-box');
 
         var fb = feedback($container).message('warning', 'DANGER_ZONE').display();
 
-        equal(fb.level, 'warning'                               , 'The level is set to warning');
-        ok(/DANGER_ZONE/m.test(fb.content)                      , 'The content property contains the message');
-        equal($('.feedback-warning', $container).length, 1 , 'The feedback content has been appended to the container');
+        assert.equal(fb.level, 'warning'                               , 'The level is set to warning');
+        assert.ok(/DANGER_ZONE/m.test(fb.content)                      , 'The content property contains the message');
+        assert.equal($('.feedback-warning', $container).length, 1 , 'The feedback content has been appended to the container');
     });
     
-    test('close message', function(){
-        expect(2);
+    QUnit.test('close message', function(assert){
+        QUnit.expect(2);
 
         var $container = $('#feedback-box');
         var fb = feedback($container).message('warning', 'DANGER_ZONE').display();
 
-        equal($('.feedback-warning', $container).length, 1 , 'The feedback content has been appended to the container');
+        assert.equal($('.feedback-warning', $container).length, 1 , 'The feedback content has been appended to the container');
 
         fb.close();
-        equal($('.feedback-warning', $container).length, 0, 'The feedback content has been removed from the container');
+        assert.equal($('.feedback-warning', $container).length, 0, 'The feedback content has been removed from the container');
     });
     
-    asyncTest('close event', function(){
+    QUnit.asyncTest('close event', function(assert){
     
-        expect(2);
+        QUnit.expect(2);
 
         var $container = $('#feedback-box');
         var fb = feedback($container).message('warning', 'DANGER_ZONE').display();
 
-        equal($('.feedback-warning', $container).length, 1 , 'The feedback content has been appended to the container');
+        assert.equal($('.feedback-warning', $container).length, 1 , 'The feedback content has been appended to the container');
 
         $container.on('close.feedback', function(e){
-            equal($('.feedback-warning', $container).length, 0, 'The feedback content has been removed from the container');
-            start();
+            assert.equal($('.feedback-warning', $container).length, 0, 'The feedback content has been removed from the container');
+            QUnit.start();
         });
 
         fb.close();
     });
     
-    asyncTest('callbacks', function(){
+    QUnit.asyncTest('callbacks', function(assert){
     
-        expect(3);
+        QUnit.expect(3);
 
         var $container = $('#feedback-box');
         feedback($container)
             .message('warning', 'DANGER_ZONE', {
                 create : function(){
-                    ok(true, 'The create callback is called');
+                    assert.ok(true, 'The create callback is called');
                 },
                 display : function(){
-                    ok(true, 'The close callback is called');
+                    assert.ok(true, 'The close callback is called');
                 },
                 close : function(){
-                    ok(true, 'The close callback is called');
-                    start();
+                    assert.ok(true, 'The close callback is called');
+                    QUnit.start();
                 } 
             })
             .display()
             .close();
     });
 
-    asyncTest('timeout', function(){
+    QUnit.asyncTest('timeout', function(assert){
     
-        expect(4);
+        QUnit.expect(4);
 
         var $container = $('#feedback-box');
         var fb = feedback($container).message('info', 'AWESOME_MESSAGE', { timeout : 10 }).display();
 
-        equal($('.feedback-info', $container).length, 1 , 'The feedback content has been appended to the container');
+        assert.equal($('.feedback-info', $container).length, 1 , 'The feedback content has been appended to the container');
 
         $container.on('close.feedback', function(e){
-            equal($('.feedback-info', $container).length, 0, 'The feedback content has been removed from the container');
-            start();
+            assert.equal($('.feedback-info', $container).length, 0, 'The feedback content has been removed from the container');
+            QUnit.start();
         });
 
         var fbt = feedback($container.clone()).message('info', 'AWESOME_MESSAGE').display();
-        notEqual(fbt._getTimeout(), fbt._getTimeout('error'), 'Different feedback types have different timeouts by default');
-        notEqual(fb._getTimeout(), fbt._getTimeout(), 'It\'s possible to set custom timeout for message');
+        assert.notEqual(fbt._getTimeout(), fbt._getTimeout('error'), 'Different feedback types have different timeouts by default');
+        assert.notEqual(fb._getTimeout(), fbt._getTimeout(), 'It\'s possible to set custom timeout for message');
         fbt.close();
 
     });
     
-    test('volatile messages', function(){
+    QUnit.test('volatile messages', function(assert){
     
-        expect(2);
+        QUnit.expect(2);
 
         var $container = $('#feedback-box');
         var fb1 = feedback($container).message('info', 'AWESOME_MESSAGE_1').open();
         var fb2 = feedback($container).message('info', 'AWESOME_MESSAGE_2').open();
 
-        equal($('.feedback-info', $container).length, 1 , 'The container has only one volatile message');
-        ok(/AWESOME_MESSAGE_2/.test($('.feedback-info div', $container).text()), 'The container has the 2nd message');
+        assert.equal($('.feedback-info', $container).length, 1 , 'The container has only one volatile message');
+        assert.ok(/AWESOME_MESSAGE_2/.test($('.feedback-info div', $container).text()), 'The container has the 2nd message');
     });
 
 });

--- a/views/js/test/ui/incrementer/test.js
+++ b/views/js/test/ui/incrementer/test.js
@@ -1,45 +1,45 @@
 define(['jquery', 'ui',  'ui/incrementer'], function($, ui, incrementer){
     
     
-    module('Incrementer Stand Alone Test');
+    QUnit.module('Incrementer Stand Alone Test');
    
-    test('plugin', function(){
-        expect(1);
-        ok(typeof $.fn.incrementer === 'function', 'The Durationer plugin is registered');
+    QUnit.test('plugin', function(assert){
+        QUnit.expect(1);
+        assert.ok(typeof $.fn.incrementer === 'function', 'The Durationer plugin is registered');
     });
 
-    test('initialization', function(){
-        expect(4);
+    QUnit.test('initialization', function(assert){
+        QUnit.expect(4);
 
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
 
         $elt.on('create.incrementer', function(){
-            ok(typeof $elt.data('ui.incrementer') === 'object');
+            assert.ok(typeof $elt.data('ui.incrementer') === 'object');
 
             var $control = $container.find('.ctrl > a');
-            equal($control.length, 2, 'The plugins has created controls');
+            assert.equal($control.length, 2, 'The plugins has created controls');
         });
         $elt.incrementer();
     });
 
-    test('update seconds', function(){
-        expect(3);
+    QUnit.test('update seconds', function(assert){
+        QUnit.expect(3);
 
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
 
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
 
         $elt.on('create.incrementer', function(){
             $container.find('.ctrl > a.inc').click();
         });
         $elt.on('increment.incrementer', function(){
-            equal($elt.val(), 2, "The value has been incremented");
+            assert.equal($elt.val(), 2, "The value has been incremented");
         });
 
         $elt.incrementer({
@@ -49,21 +49,21 @@ define(['jquery', 'ui',  'ui/incrementer'], function($, ui, incrementer){
         });
     });
     
-    test('increment decimal 0.5 + 1.00 = 1', function(){
-        expect(3);
+    QUnit.test('increment decimal 0.5 + 1.00 = 1', function(assert){
+        QUnit.expect(3);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
         $elt.val(0.5);
         
         $elt.on('create.incrementer', function(){
             $container.find('.ctrl > a.inc').click();
         });
          $elt.on('increment.incrementer', function(){
-            equal($elt.val(), 1, "The value has been incremented");
+            assert.equal($elt.val(), 1, "The value has been incremented");
         });
         
         $elt.incrementer({
@@ -72,21 +72,21 @@ define(['jquery', 'ui',  'ui/incrementer'], function($, ui, incrementer){
         
     });
     
-    test('increment decimal 1.01 + 1.00 = 2', function(){
-        expect(3);
+    QUnit.test('increment decimal 1.01 + 1.00 = 2', function(assert){
+        QUnit.expect(3);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
         $elt.val(1.01);
         
         $elt.on('create.incrementer', function(){
             $container.find('.ctrl > a.inc').click();
         });
          $elt.on('increment.incrementer', function(){
-            equal($elt.val(), 2, "The value has been incremented");
+            assert.equal($elt.val(), 2, "The value has been incremented");
         });
         
         $elt.incrementer({
@@ -94,21 +94,21 @@ define(['jquery', 'ui',  'ui/incrementer'], function($, ui, incrementer){
         });
     });
     
-    test('decrement decimal 0.5 - 1.00 = 0', function(){
-        expect(3);
+    QUnit.test('decrement decimal 0.5 - 1.00 = 0', function(assert){
+        QUnit.expect(3);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
         $elt.val(0.5);
         
         $elt.on('create.incrementer', function(){
             $container.find('.ctrl > a.dec').click();
         });
          $elt.on('decrement.incrementer', function(){
-            equal($elt.val(), 0, "The value has been decremented");
+            assert.equal($elt.val(), 0, "The value has been decremented");
         });
         
         $elt.incrementer({
@@ -116,21 +116,21 @@ define(['jquery', 'ui',  'ui/incrementer'], function($, ui, incrementer){
         });
     });
     
-    test('decrement decimal 0 - 1.00 = -1', function(){
-        expect(3);
+    QUnit.test('decrement decimal 0 - 1.00 = -1', function(assert){
+        QUnit.expect(3);
         
         var $container = $('#container-1');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
         $elt.val(0);
         
         $elt.on('create.incrementer', function(){
             $container.find('.ctrl > a.dec').click();
         });
          $elt.on('decrement.incrementer', function(){
-            equal($elt.val(), -1, "The value has been decremented");
+            assert.equal($elt.val(), -1, "The value has been decremented");
         });
         
         $elt.incrementer({
@@ -138,40 +138,40 @@ define(['jquery', 'ui',  'ui/incrementer'], function($, ui, incrementer){
         });
     });
     
-     module('Incrementer Data Attr Test');
+     QUnit.module('Incrementer Data Attr Test');
      
-     test('initialization', function(){
-        expect(3);
+     QUnit.test('initialization', function(assert){
+        QUnit.expect(3);
         
         var $container = $('#container-2');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
         
         $elt.on('create.incrementer', function(){
             $container.find('.ctrl > a.inc').click();
         });
          $elt.on('increment.incrementer', function(){
-            equal($elt.val(), 5, "The value has been incremented");
+            assert.equal($elt.val(), 5, "The value has been incremented");
         });
        
         incrementer($container);
     });
     
-     test('decimal', function(){
+     QUnit.test('decimal', function(assert){
         
         var $container = $('#container-3');
-        ok($container.length === 1, 'Test the fixture is available');
+        assert.ok($container.length === 1, 'Test the fixture is available');
         
         var $elt = $(':text', $container);
-        ok($elt.length === 1, 'Test input is available');
+        assert.ok($elt.length === 1, 'Test input is available');
         
         incrementer($container);
         var options = $elt.data('ui.incrementer');
         
-        equal(options.decimal, 2, 'option decimal ok');
-        equal(options.step, 1, 'option step ok');
+        assert.equal(options.decimal, 2, 'option decimal ok');
+        assert.equal(options.step, 1, 'option step ok');
     });
 });
 

--- a/views/js/test/ui/lock/test.html
+++ b/views/js/test/ui/lock/test.html
@@ -3,23 +3,22 @@
     <head>
         <meta charset="utf-8">
         <title>Ui Test - Lock</title>
-        <base href="../../../../" />
-        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
-        <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
-        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
-        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flags="branchTracking" data-cover-only="ui/lock.js"></script>
+        <link rel="stylesheet" type="text/css" href="../../../../js/lib/qunit/qunit.css">
+        <link rel="stylesheet" type="text/css" href="../../../../css/tao-main-style.css">
+        <script type="text/javascript" src="../../../../js/lib/require.js"></script>
+        <script type="text/javascript" src="../../../../js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="../../../../js/lib/blanket/blanket.min.js" data-cover-flags="branchTracking" data-cover-only="ui/lock.js"></script>
         <script  type="text/javascript">
-            
+
             //don't start the test now
             QUnit.config.autostart = false;
-            
+
             //load the config
             require(['/tao/ClientConfig/config'], function(){
-                
+
                 //load the test
                 require(['test/ui/lock/test'], function(){
-                    
+
                     //Tests loaded, run tests
                     QUnit.start();
                 });
@@ -32,6 +31,6 @@
             <div id="container-1"></div>
             <div id="lock-box" class="tao-scope"></div>
             <div id="alt-lock-box" class="tao-scope" data-id="123" data-msg="test-msg"></div>
-        </div>  
+        </div>
     </body>
 </html>

--- a/views/js/test/ui/lock/test.js
+++ b/views/js/test/ui/lock/test.js
@@ -1,7 +1,8 @@
 define(['jquery', 'ui/lock'], function($, lock){
     'use strict';
+
     QUnit.module('lock');
-   
+
     QUnit.test('module', function(assert){
         QUnit.expect(1);
 
@@ -47,7 +48,7 @@ define(['jquery', 'ui/lock'], function($, lock){
 
     QUnit.test('state', function(assert){
         QUnit.expect(11);
-        
+
         var lk = lock().message();
         var lock2 = lock().message();
 
@@ -72,7 +73,7 @@ define(['jquery', 'ui/lock'], function($, lock){
 
     QUnit.test('register', function(assert){
         QUnit.expect(6);
-        
+
         var lk = lock($('#alt-lock-box')).register();
 
         assert.ok(typeof lk === 'object'                       , 'The lock function creates an object');
@@ -82,10 +83,10 @@ define(['jquery', 'ui/lock'], function($, lock){
         assert.ok(/test-msg/m.test(lk.content)                 , 'The content property contains the message');
         assert.ok(/feedback-info/m.test(lk.content)            , 'The content property contains the right css class');
     });
-    
+
     QUnit.test('default message', function(assert){
         QUnit.expect(5);
-        
+
         var lk = lock();
         var r2 = lk.message();
 
@@ -152,46 +153,53 @@ define(['jquery', 'ui/lock'], function($, lock){
         QUnit.expect(4);
 
         var $container = $('#lock-box');
-        lock($container)
-            .hasLock('LOCKED_RESOURCE',
-            {
-                failed : function(){
-                    assert.ok(true, 'The release failed and callback is called');
-                },
-                uri: 123,
-                url : ''
-            }).release().close();
-        lock($container)
-            .hasLock('LOCKED_RESOURCE',
-            {
-                failed : function(){
-                    assert.ok(true, 'The release failed and callback is called');
-                },
-                uri: 123,
-                url : 'js/test/ui/lock/error.json'
-            }).release().close();
 
         lock($container)
-            .hasLock('LOCKED_RESOURCE',
-            {
+            .hasLock('LOCKED_RESOURCE', {
                 failed : function(){
                     assert.ok(true, 'The release failed and callback is called');
                 },
                 uri: 123,
-                url : 'js/test/ui/lock/wrong.json'
-            }).release().close();
+                releaseUrl : ''
+            })
+            .release()
+            .close();
 
         lock($container)
-            .hasLock('LOCKED_RESOURCE',
-            {
+            .hasLock('LOCKED_RESOURCE', {
+                failed : function(){
+                    assert.ok(true, 'The release failed and callback is called');
+                },
+                uri: 123,
+                releaseUrl : 'error.json'
+            })
+            .release()
+            .close();
+
+        lock($container)
+            .hasLock('LOCKED_RESOURCE', {
+                failed : function(){
+                    assert.ok(true, 'The release failed and callback is called');
+                },
+                uri: 123,
+                releaseUrl : 'wrong.json'
+            })
+            .release()
+            .close();
+
+        setTimeout(function(){
+            lock($container)
+            .hasLock('LOCKED_RESOURCE', {
                 released : function(){
                     assert.ok(true, 'The release works and callback is called');
                     QUnit.start();
                 },
                 uri: 123,
-                url : 'js/test/ui/lock/success.json'
-            }).release().close();
-
+                releaseUrl : 'success.json'
+            })
+            .release()
+            .close();
+        }, 200);
     });
 
     QUnit.asyncTest('callbacks', function(assert){
@@ -210,7 +218,7 @@ define(['jquery', 'ui/lock'], function($, lock){
                 close : function(){
                     assert.ok(true, 'The close callback is called');
                     QUnit.start();
-                } 
+                }
             })
             .display()
             .close();

--- a/views/js/test/ui/mediasizer/test.js
+++ b/views/js/test/ui/mediasizer/test.js
@@ -5,30 +5,30 @@ define(['jquery', 'ui/mediasizer'], function($) {
 
     $('#_' + mode).show()
 
-    module('MediaSizer Stand Alone Test');
+    QUnit.module('MediaSizer Stand Alone Test');
 
-    test('plugin', function() {
-        expect(1);
-        ok(typeof $.fn.mediasizer === 'function', 'The MediaSizer plugin is registered');
+    QUnit.test('plugin', function(assert) {
+        QUnit.expect(1);
+        assert.ok(typeof $.fn.mediasizer === 'function', 'The MediaSizer plugin is registered');
     });
 
-    asyncTest('Initialization', function() {
-        expect(4);
+    QUnit.asyncTest('Initialization', function(assert) {
+        QUnit.expect(4);
 
         var $container = $('#qunit-fixture-tmp');
-        ok($container.length === 1, 'Fixture is available');
+        assert.ok($container.length === 1, 'Fixture is available');
 
         var $elt = $('#media-sizer-container', $container);
-        ok($elt.length === 1, 'MediaSizer link is available');
+        assert.ok($elt.length === 1, 'MediaSizer link is available');
 
         var $target = $('#_' + mode + ' img', $container);
-        ok($target.length === 1, 'Target is available');
+        assert.ok($target.length === 1, 'Target is available');
 
         $elt.on('create.mediasizer', function() {
             var data = $elt.data('ui.mediasizer');
-            ok(typeof data === 'object', 'The element is running the plugin');
+            assert.ok(typeof data === 'object', 'The element is running the plugin');
 
-            start();
+            QUnit.start();
         });
         $elt.mediasizer({
             target: $target

--- a/views/js/test/ui/previewer/test.js
+++ b/views/js/test/ui/previewer/test.js
@@ -1,29 +1,31 @@
 define(['jquery', 'ui', 'ui/previewer'], function($, ui, previewer){
-      
-    module('Previewer Stand Alone Test');
-    test('plugin', function(){
-       expect(1);
-       ok(typeof $.fn.previewer === 'function', 'The Previewer plugin is registered');
+    'use strict';
+
+    QUnit.module('Previewer Stand Alone Test');
+    QUnit.test('plugin', function(assert){
+       QUnit.expect(1);
+       assert.ok(typeof $.fn.previewer === 'function', 'The Previewer plugin is registered');
     });
-   
-    asyncTest('Initialization', function(){
-        expect(3);
+
+    QUnit.asyncTest('Initialization', function(assert){
+        QUnit.expect(3);
         var $fixture = $('#qunit-fixture');
         var $elt = $('#p1', $fixture);
-        ok($elt.length === 1, 'Test the fixture is available');
-        
+        assert.ok($elt.length === 1, 'Test the fixture is available');
+
         $elt.on('create.previewer', function(){
-            ok(typeof $elt.data('ui.previewer') === 'object', 'The element is runing the plugin');
-            ok($elt.hasClass('previewer'), 'The element has the right css clas');
-            start();
+            assert.ok(typeof $elt.data('ui.previewer') === 'object', 'The element is runing the plugin');
+            assert.ok($elt.hasClass('previewer'), 'The element has the right css clas');
+            QUnit.start();
         });
         $elt.previewer({
             url: 'http://taotesting.com/sites/tao/themes/tao/img/tao_logo.png',
-            type: 'image/png' 
+            type: 'image/png'
         });
     });
-    asyncTest('Image preview', function(){
-        expect(5);
+
+    QUnit.asyncTest('Image preview', function(assert){
+        QUnit.expect(5);
 
         var options     = {
             url    : 'http://taotesting.com/sites/tao/themes/tao/img/tao_logo.png',
@@ -34,40 +36,37 @@ define(['jquery', 'ui', 'ui/previewer'], function($, ui, previewer){
         var $fixture    = $('#qunit-fixture');
         var $elt        = $('#p1', $fixture);
 
-        ok($elt.length === 1, 'Test the fixture is available');
-        
+        assert.ok($elt.length === 1, 'Test the fixture is available');
+
         $elt.on('create.previewer', function(){
-            equal($elt.find('img').length, 1, 'The image element is created');
-            equal($elt.find('img').attr('src'), options.url, 'The image src is set');
-            equal($elt.find('img').width(), options.width, 'The image width is set');
-            equal($elt.find('img').height(), options.height, 'The image height is set');
-            start();
+            assert.equal($elt.find('img').length, 1, 'The image element is created');
+            assert.equal($elt.find('img').attr('src'), options.url, 'The image src is set');
+            assert.equal($elt.find('img').width(), options.width, 'The image width is set');
+            assert.equal($elt.find('img').height(), options.height, 'The image height is set');
+            QUnit.start();
         });
         $elt.previewer(options);
     });
-    asyncTest('Data Attribute', function(){
-        expect(6);
+
+    QUnit.asyncTest('Data Attribute', function(assert){
+        QUnit.expect(4);
 
         var options     = {
             url    : 'http://techslides.com/demos/sample-videos/small.mp4',
-            mime    : 'video/mp4',
-            width   : 200,
-            height  : 150
+            mime    : 'video/mp4'
         };
         var $fixture    = $('body');
-        var $elt        = $('#p2');//, $fixture);
-        $elt.width(options.width);
-        $elt.height(options.height);
+        var $elt        = $('#p2', $fixture);
 
-        ok($elt.length === 1, 'Test the fixture is available');
-        
+        assert.ok($elt.length === 1, 'Test the fixture is available');
+
         $elt.on('create.previewer', function(){
-            equal($elt.find('video').length, 1, 'The video element is created');
-            equal($elt.find('video').attr('src'), options.url, 'The video src is set');
-            equal($elt.find('video').width(), options.width, 'The video width is set');
-            equal($elt.find('video').height(), options.height, 'The video height is set');
-            equal($elt.find('.mejs-container').length, 1, 'The media element player is set up');
-            start();
+            setTimeout(function(){
+                assert.equal($elt.find('video').length, 1, 'The video element is created');
+                assert.equal($elt.find('video').attr('src'), options.url, 'The video src is set');
+                assert.equal($elt.find('.mejs-container').length, 1, 'The media element player is set up');
+                QUnit.start();
+            }, 500);
         });
         previewer($fixture);
     });

--- a/views/js/test/ui/progressbar/test.js
+++ b/views/js/test/ui/progressbar/test.js
@@ -1,22 +1,22 @@
 define(['jquery', 'ui/progressbar'], function($){
-    'use strict';    
+    'use strict';
 
     var containerId ='mypg';
-    
+
     QUnit.module('ProgressBar');
-   
+
     QUnit.test('plugin', function(assert){
        QUnit.expect(1);
        assert.ok(typeof $.fn.progressbar === 'function', 'The progressbar plugin is registered');
     });
-   
+
     QUnit.asyncTest('Initialization', function(assert){
         QUnit.expect(3);
-        
+
         var $elt = $('#' + containerId);
 
         assert.ok($elt.length === 1, 'Test the fixture is available');
-        
+
         $elt.on('create.progressbar', function(){
 
             assert.ok($elt.hasClass('progressbar'), 'the element has the right class');
@@ -29,15 +29,15 @@ define(['jquery', 'ui/progressbar'], function($){
 
     QUnit.asyncTest('Success style', function(assert){
         QUnit.expect(3);
-        
+
         var $elt = $('#' + containerId);
 
         assert.ok($elt.length === 1, 'Test the fixture is available');
-        
+
         $elt.on('create.progressbar', function(){
 
             assert.equal($elt.find('span').length, 1, 'the sub element has been inserted');
-            assert.ok($elt.find('span').hasClass('success'), 'the sub element has the success CSS class');
+            assert.ok($elt.hasClass('success'), 'the sub element has the success CSS class');
 
             QUnit.start();
         });
@@ -50,11 +50,11 @@ define(['jquery', 'ui/progressbar'], function($){
 
     QUnit.asyncTest('Destroy', function(assert){
         QUnit.expect(5);
-        
+
         var $elt = $('#' + containerId);
 
         assert.ok($elt.length === 1, 'Test the fixture is available');
-        
+
         $elt.on('create.progressbar', function(){
 
             assert.ok($elt.hasClass('progressbar'), 'the element has the right class');
@@ -75,11 +75,11 @@ define(['jquery', 'ui/progressbar'], function($){
 
     QUnit.asyncTest('update', function(assert){
         QUnit.expect(3);
-        
+
         var $elt = $('#' + containerId);
 
         assert.ok($elt.length === 1, 'Test the fixture is available');
-        
+
         $elt.on('update.progressbar', function(e, value){
             assert.equal(value, 55, 'the given value matches');
             assert.equal($elt.find('span')[0].style.width, '55%', 'the sub element width matches the value');
@@ -94,11 +94,11 @@ define(['jquery', 'ui/progressbar'], function($){
 
     QUnit.asyncTest('set value', function(assert){
         QUnit.expect(3);
-        
+
         var $elt = $('#' + containerId);
 
         assert.ok($elt.length === 1, 'Test the fixture is available');
-        
+
         $elt.on('update.progressbar', function(e, value){
             assert.equal(value, 42, 'the given value matches');
             assert.equal($elt.find('span')[0].style.width, '42%', 'the sub element width matches the value');
@@ -113,11 +113,11 @@ define(['jquery', 'ui/progressbar'], function($){
 
     QUnit.asyncTest('get value', function(assert){
         QUnit.expect(2);
-        
+
         var $elt = $('#' + containerId);
 
         assert.ok($elt.length === 1, 'Test the fixture is available');
-        
+
         $elt.on('update.progressbar', function(){
 
             assert.equal($elt.progressbar('value'), 66, 'Get the current progress value');
@@ -131,11 +131,11 @@ define(['jquery', 'ui/progressbar'], function($){
 
     QUnit.asyncTest('show progress', function(assert){
         QUnit.expect(2);
-        
+
         var $elt = $('#' + containerId);
 
         assert.ok($elt.length === 1, 'Test the fixture is available');
-        
+
         $elt.on('update.progressbar', function(e, value){
             assert.equal($elt.find('span').text(), '38%', 'the sub element contains the progress text');
 

--- a/views/js/test/ui/resourcemgr/test.js
+++ b/views/js/test/ui/resourcemgr/test.js
@@ -1,9 +1,7 @@
-define([
-    'jquery',
-    'helpers',
-    'ui/resourcemgr'], function($, helpers){
+define(['jquery', 'ui/resourcemgr'], function($){
+    'use strict';
 
-    module('Init');
+    QUnit.module('Init');
 
     QUnit.asyncTest('Resource manager Loading but not open', function(assert){
         QUnit.expect(3);
@@ -61,19 +59,17 @@ define([
 
     });
 
-    module('Loading');
+    QUnit.module('Loading');
 
-    QUnit.asyncTest('Resource manager Loading and open', function(assert){
+    QUnit.asyncTest('Resource manager loading and open', function(assert){
         QUnit.expect(3);
         var $launcher = $('#launcher');
 
         $launcher.on('open.resourcemgr', function(){
             assert.ok($('#outside-container .resourcemgr').length === 1, 'The resource manager modal is created');
             assert.ok($('#outside-container .modal-bg').length === 1, 'The background is set');
-            assert.ok($('#outside-container .resourcemgr').hasClass('opened') === true, 'The modal is shown');
-
+            assert.ok($('#outside-container .resourcemgr').css('display') !== 'none', 'The modal is shown');
             QUnit.start();
-
         });
         $launcher.resourcemgr({
             params          : {
@@ -147,12 +143,15 @@ define([
 
     });
 
-    module('Destroy');
+    QUnit.module('Destroy');
 
     QUnit.asyncTest('ResourceManager destroy', function(assert){
         QUnit.expect(1);
         var $launcher = $('#launcher');
 
+        $launcher.on('open.resourcemgr', function(){
+            $launcher.resourcemgr('destroy');
+        });
         $launcher.on('destroy.resourcemgr', function(){
             assert.ok(true,'resource manager is destoyed');
             QUnit.start();
@@ -164,13 +163,8 @@ define([
                 uri : 'http://myUri',
                 lang : 'en-US'
             },
-            open : true,
+            open : true
         });
-
-        $launcher.resourcemgr('destroy');
-
     });
-
-
 });
 

--- a/views/js/test/ui/uploader/test.js
+++ b/views/js/test/ui/uploader/test.js
@@ -1,12 +1,9 @@
-define(['jquery', 'ui', 'ui/uploader', 'ui/deleter'], function($, ui, uploader, deleter){
+define(['jquery', 'ui/uploader'], function($){
+    'use strict';
 
-    deleter('.tao-scope');
-
-    $('#upload-container').uploader({
-        uploadUrl   : 'http://tao26.localdomain/taoItems/ItemContent/upload?uri=' + encodeURIComponent('http://tao26.localdomain/bertao.rdf#i1404285379397511') + '&lang=en-US&path=/',
-        multiple    : true,
-        upload      : true,
-        read        : false
+    QUnit.test('plugin', function(assert){
+       QUnit.expect(1);
+       assert.ok(typeof $.fn.uploader === 'function', 'The uploader plugin is registered');
     });
- 
+
 });

--- a/views/js/test/ui/waitForMedia/test.js
+++ b/views/js/test/ui/waitForMedia/test.js
@@ -1,45 +1,45 @@
 define(['jquery', 'ui/waitForMedia'], function($){
 
-    module('WaitForMedia Stand Alone Test');
+    QUnit.module('WaitForMedia Stand Alone Test');
 
-    asyncTest('waitForMedia long form', function(){
-        ok(typeof $.fn.waitForMedia === 'function', 'The waitForMedia plugin is registered');
+    QUnit.asyncTest('waitForMedia long form', function(assert){
+        assert.ok(typeof $.fn.waitForMedia === 'function', 'The waitForMedia plugin is registered');
 
         var $fixture = $('#qunit-fixture');
         var $elt = $fixture.find('#div1');
-        ok($elt.length === 1, 'Test the fixture is available');
+        assert.ok($elt.length === 1, 'Test the fixture is available');
 
         $elt.on('loaded.wait', function(){
             //expect this 4 times because there are 4 <img>
-            ok(true, 'an image has been loaded');
+            assert.ok(true, 'an image has been loaded');
         });
         $elt.on('all-loaded.wait', function(){
             //expect this once at the end of the loading chain
-            ok(true, 'all images has been loaded');
-            start();
+            assert.ok(true, 'all images has been loaded');
+            QUnit.start();
         });
         $elt.waitForMedia();
     });
 
-    asyncTest('waitForMedia short form', function(){
-        expect(1);
+    QUnit.asyncTest('waitForMedia short form', function(assert){
+        QUnit.expect(1);
         var $fixture = $('#qunit-fixture');
         var $elt = $fixture.find('#div1');
         $elt.waitForMedia(function(){
             //expect this once at the end of the loading chain
-            ok(true, 'all images has been loaded');
-            start();
+            assert.ok(true, 'all images has been loaded');
+            QUnit.start();
         });
 
     });
     
-    asyncTest('waitForMedia no images', function(){
-        expect(1);
+    QUnit.asyncTest('waitForMedia no images', function(assert){
+        QUnit.expect(1);
         var $fixture = $('#qunit-fixture');
         var $elt = $fixture.find('#div2');
         $elt.waitForMedia(function(){
-            ok(true, 'callback function was executed');
-            start();
+            assert.ok(true, 'callback function was executed');
+            QUnit.start();
         });
 
     });

--- a/views/js/test/urlParser/test.js
+++ b/views/js/test/urlParser/test.js
@@ -24,21 +24,21 @@ define(['urlParser'], function(UrlParser){
    var url3 = "https://example.com/extension/module/action?a=1";
    var url4 = "https://example.com?p=a&c=b";
    
-    test('parser structure', function(){
-        expect(4);
+    QUnit.test('parser structure', function(assert){
+        QUnit.expect(4);
         
-        ok(typeof UrlParser === 'function');
-        ok(typeof UrlParser.prototype.get === 'function');
-        ok(typeof UrlParser.prototype.getPaths === 'function');
-        ok(typeof UrlParser.prototype.getParams === 'function');
+        assert.ok(typeof UrlParser === 'function');
+        assert.ok(typeof UrlParser.prototype.get === 'function');
+        assert.ok(typeof UrlParser.prototype.getPaths === 'function');
+        assert.ok(typeof UrlParser.prototype.getParams === 'function');
     });
     
-    test('parsing', function(){
-        expect(2);
+    QUnit.test('parsing', function(assert){
+        QUnit.expect(2);
         
         
         var parser = new UrlParser(url);
-        equal(parser.url, url);
+        assert.equal(parser.url, url);
         deepEqual(parser.data, {
             hash: "#hash",
             host: "example.com:3000",
@@ -50,21 +50,21 @@ define(['urlParser'], function(UrlParser){
         });
     });
     
-    test('get parts', function(){
-        expect(7);
+    QUnit.test('get parts', function(assert){
+        QUnit.expect(7);
         
         var parser = new UrlParser(url);
-        equal(parser.get('hash'), "#hash");
-        equal(parser.get('host'), "example.com:3000");
-        equal(parser.get('hostname'), "example.com");
-        equal(parser.get('pathname'), "/extension/module/action");
-        equal(parser.get('port'), "3000");
-        equal(parser.get('protocol'), "http:");
-        equal(parser.get('search'), "?p1=v1&p2=v2");
+        assert.equal(parser.get('hash'), "#hash");
+        assert.equal(parser.get('host'), "example.com:3000");
+        assert.equal(parser.get('hostname'), "example.com");
+        assert.equal(parser.get('pathname'), "/extension/module/action");
+        assert.equal(parser.get('port'), "3000");
+        assert.equal(parser.get('protocol'), "http:");
+        assert.equal(parser.get('search'), "?p1=v1&p2=v2");
     });
     
-    test('get params', function(){
-        expect(1);
+    QUnit.test('get params', function(assert){
+        QUnit.expect(1);
         
         var parser = new UrlParser(url);
         deepEqual(parser.getParams(), {
@@ -73,8 +73,8 @@ define(['urlParser'], function(UrlParser){
         });
     });
     
-    test('get paths', function(){
-        expect(1);
+    QUnit.test('get paths', function(assert){
+        QUnit.expect(1);
         
         var parser = new UrlParser(url);
         deepEqual(parser.getPaths(), [
@@ -84,40 +84,40 @@ define(['urlParser'], function(UrlParser){
         ]);
     });
     
-    test('getUrl', function(){
-        expect(4);
+    QUnit.test('getUrl', function(assert){
+        QUnit.expect(4);
         
-        equal(new UrlParser(url).getUrl(), url);
-        equal(new UrlParser(url2).getUrl(), url2);
-        equal(new UrlParser(url3).getUrl(), url3);
-        equal(new UrlParser(url4).getUrl(), "https://example.com/?p=a&c=b"); //slash is added
+        assert.equal(new UrlParser(url).getUrl(), url);
+        assert.equal(new UrlParser(url2).getUrl(), url2);
+        assert.equal(new UrlParser(url3).getUrl(), url3);
+        assert.equal(new UrlParser(url4).getUrl(), "https://example.com/?p=a&c=b"); //slash is added
     });
     
-    test('getShortUrl', function(){
-        expect(2);
+    QUnit.test('getShortUrl', function(assert){
+        QUnit.expect(2);
 
         var parser = new UrlParser(url);
-        equal(parser.getUrl(['host', 'params', 'hash']), '/extension/module/action');
-        equal(parser.getUrl(['params', 'hash']), 'http://example.com:3000/extension/module/action');
+        assert.equal(parser.getUrl(['host', 'params', 'hash']), '/extension/module/action');
+        assert.equal(parser.getUrl(['params', 'hash']), 'http://example.com:3000/extension/module/action');
     });
     
-     test('getBaseUrl', function(){
-        expect(1);
+     QUnit.test('getBaseUrl', function(assert){
+        QUnit.expect(1);
 
         var parser = new UrlParser(url2);
-        equal(parser.getBaseUrl(), 'https://example.com/extension/module/');
+        assert.equal(parser.getBaseUrl(), 'https://example.com/extension/module/');
     });
     
-     test('changeParam', function(){
-        expect(2);
+     QUnit.test('changeParam', function(assert){
+        QUnit.expect(2);
         
          var parsed3 = new UrlParser(url3);
         parsed3.setParams({'b' : '2'});
-        equal(parsed3.getUrl(), "https://example.com/extension/module/action?b=2");
+        assert.equal(parsed3.getUrl(), "https://example.com/extension/module/action?b=2");
         
          var parsed4 = new UrlParser(url4);
         parsed4.addParam('b', '4');
-        equal(parsed4.getUrl(), "https://example.com/?p=a&c=b&b=4");
+        assert.equal(parsed4.getUrl(), "https://example.com/?p=a&c=b&b=4");
     });
 });
 

--- a/views/js/test/util/image/test.js
+++ b/views/js/test/util/image/test.js
@@ -23,41 +23,41 @@ define(['util/image'], function(imageUtil){
     var width = 53;
     var height = 40;  
  
-    test('utilitary structure', function(){
-        expect(2);
+    QUnit.test('utilitary structure', function(assert){
+        QUnit.expect(2);
         
-        ok(typeof imageUtil === 'object');
-        ok(typeof imageUtil.getSize === 'function');
+        assert.ok(typeof imageUtil === 'object');
+        assert.ok(typeof imageUtil.getSize === 'function');
     });
     
-    asyncTest('getSize', function(){
-        expect(3);
+    QUnit.asyncTest('getSize', function(assert){
+        QUnit.expect(3);
         
         imageUtil.getSize(imageUrl, function(size){
-            notEqual(size, null, 'The size is not null');
-            equal(size.width, width, 'Check the image width');
-            equal(size.height, height, 'Check the image height');
-            start(); 
+            assert.notEqual(size, null, 'The size is not null');
+            assert.equal(size.width, width, 'Check the image width');
+            assert.equal(size.height, height, 'Check the image height');
+            QUnit.start(); 
         }); 
     });
     
-    asyncTest('getSize with a short timeout', function(){
-        expect(3);
+    QUnit.asyncTest('getSize with a short timeout', function(assert){
+        QUnit.expect(3);
         
         imageUtil.getSize(imageUrl, 1, function(size){
-            notEqual(size, null, 'The size is not null');
-            equal(size.width, width, 'Check the image width');
-            equal(size.height, height, 'Check the image height');
-            start(); 
+            assert.notEqual(size, null, 'The size is not null');
+            assert.equal(size.width, width, 'Check the image width');
+            assert.equal(size.height, height, 'Check the image height');
+            QUnit.start(); 
         }); 
     });
 
-    asyncTest('wrong url', function(){
-        expect(1);
+    QUnit.asyncTest('wrong url', function(assert){
+        QUnit.expect(1);
         
         imageUtil.getSize("img/a-fake-url.png", function(size){
             strictEqual(size, null, 'The size is null');
-            start(); 
+            QUnit.start(); 
         }); 
     });
 });

--- a/views/js/ui/lock.js
+++ b/views/js/ui/lock.js
@@ -19,7 +19,7 @@
  */
 
 define([
-    'jquery', 
+    'jquery',
     'lodash',
     'i18n',
     'tpl!ui/lock/lock',
@@ -58,10 +58,10 @@ define([
     /**
      * Object delegation. This enables us to separate the instance from Api.
      * An instance can call methods from the API like it was it, so each object will not contain the function definition.
-     * @private 
+     * @private
      * @param {Object} receiver - the object that receive the methods
      * @param {Object} provider - it provides the methods to the receiver
-     * @returns {Object} the receiver augmented by the provider's methods. 
+     * @returns {Object} the receiver augmented by the provider's methods.
      */
     function delegate (receiver, provider) {
         _(provider).functions().forEach(function delegateMethod(methodName) {
@@ -194,8 +194,8 @@ define([
                     .appendTo(self._container);
 
                 self._trigger('display');
-                
-                if (typeof this.options.uri == 'undefined') {
+
+                if (typeof this.options.uri === 'undefined') {
                 	$('.release', self._container).hide();
                 	$('.check-in', self._container).hide();
                 } else {
@@ -290,7 +290,7 @@ define([
             return this;
 
         },
-        
+
         /**
          * Default behaviour
          */
@@ -347,7 +347,7 @@ define([
          * Check if the current state is one of the given values
          * @param {String|Array} verify - the statue to check
          * @returns {Boolean} true if the object is in the state to verify
-         */        
+         */
         isInState : function isInState(verify){
             if(_.isString(verify)){
                 verify = [verify];
@@ -365,7 +365,7 @@ define([
                 throw new Error('Unkown state ' + state );
             }
             this._state = state;
-        } 
+        }
     };
 
     /**
@@ -382,7 +382,7 @@ define([
             $lockBox = $('#lock-box');
         }
         _container = $container || $lockBox;
-       
+
         if(!_container || !_container.length){
             throw new Error('The lock needs to belong to an existing container');
         }
@@ -403,7 +403,7 @@ define([
 
         //delegate the api calls to the new instance
         return delegate(lk, lockApi);
-    }; 
+    };
 
 
     return lockFactory;

--- a/views/js/ui/modal.js
+++ b/views/js/ui/modal.js
@@ -1,17 +1,17 @@
 define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Pluginifier, DataAttrHandler){
     'use strict';
-    
+
     /**
-     * jQuery modal is an easy to use plugin 
+     * jQuery modal is an easy to use plugin
      * which allows you to create modal windows
      * @example $('#modal-window').modal();
-     * 
+     *
      * @require jquery >= 1.7.0 [http://jquery.com/]
      */
 
     var pluginName = 'modal';
     var dataNs = 'ui.' + pluginName;
-    
+
     var defaults = {
         modalCloseClass  : 'modal-close',
         modalOverlayClass: 'modal-bg',
@@ -40,18 +40,18 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Plugi
         * @returns {jQueryElement} for chaining
         */
        init: function(options){
-          
+
           //extend the options using defaults
           options = $.extend(true, {}, defaults, options);
-          
+
           return $(this).each(function() {
             var $modal = $(this);
-            
-            options.modalOverlay = '__modal-bg-' + ($modal.attr('id') || new Date().getTime()); 
-            
+
+            options.modalOverlay = '__modal-bg-' + ($modal.attr('id') || new Date().getTime());
+
             //add data to the element
             $modal.data(dataNs, options);
-            
+
             //Initialize the overlay for the modal dialog
             if ($('#'+options.modalOverlay).length === 0) {
                var $overlay = $('<div/>').attr({'id':options.modalOverlay, 'class': options.modalOverlayClass});
@@ -64,16 +64,16 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Plugi
                    $modal.after($overlay);
                }
             }
-            
+
             //Initialize the close button for the modal dialog
             if ($('.'+options.modalCloseClass, $modal).length === 0 && !options.disableClosing) {
                $('<div class="' + options.modalCloseClass + '"><span class="icon-close"></span></div>').appendTo($modal);
             }
-            
+
             if(!options.startClosed){
                 Modal._open($modal);
             }
-            
+
             /**
              * The plugin have been created.
              * @event Modal#create.modal
@@ -89,31 +89,33 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Plugi
         */
        _bindEvents: function($element){
           var options = $element.data(dataNs);
-         
-          if(options.width === 'responsive'){ 
-              $(window).on('resize.'+pluginName, function(e){
-                 e.preventDefault();
-                 Modal._resize($element);
-              });
-          }
 
-          if(!options.disableClosing){
-                $('.'+options.modalCloseClass, $element).on('click.'+pluginName, function(e){
-                    e.preventDefault();
-                    Modal._close($element);
-                });
+          if(options){
+              if(options.width === 'responsive'){
+                  $(window).on('resize.'+pluginName, function(e){
+                     e.preventDefault();
+                     Modal._resize($element);
+                  });
+              }
 
-                $('#'+options.modalOverlay).on('click.'+pluginName, function(e){
-                    e.preventDefault();
-                    Modal._close($element);
-                });
-
-                $(document).on('keydown.'+pluginName, function(e) {
-                    if(e.keyCode===27){
+              if(!options.disableClosing){
+                    $('.'+options.modalCloseClass, $element).on('click.'+pluginName, function(e){
                         e.preventDefault();
                         Modal._close($element);
-                    }
-                });
+                    });
+
+                    $('#'+options.modalOverlay).on('click.'+pluginName, function(e){
+                        e.preventDefault();
+                        Modal._close($element);
+                    });
+
+                    $(document).on('keydown.'+pluginName, function(e) {
+                        if(e.keyCode===27){
+                            e.preventDefault();
+                            Modal._close($element);
+                        }
+                    });
+              }
           }
        },
 
@@ -124,14 +126,14 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Plugi
         */
        _unBindEvents: function($element){
           var options = $element.data(dataNs);
-          
-          if(options.width === 'responsive'){ 
+
+          if(options && options.width === 'responsive'){
             $(window).off('resize.'+pluginName);
           }
 
           $element.off('click.'+pluginName);
-          
-          if(!options.disableClosing){
+
+          if(options && !options.disableClosing){
               $('.'+options.modalCloseClass, $element).off('click.'+pluginName);
               $('#'+options.modalOverlay).off('click.'+pluginName);
               $(document).off('keydown.'+pluginName);
@@ -147,9 +149,9 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Plugi
           var modalHeight = $element.outerHeight(),
               windowHeight = $(window).height(),
               options = $element.data(dataNs);
-      
+
           if (typeof options !== 'undefined'){
-       
+
             //Calculate the top offset
             var topOffset = (options.vCenter || modalHeight > windowHeight) ? 40: (windowHeight-modalHeight)/2;
 
@@ -163,17 +165,17 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Plugi
             $('#'+options.modalOverlay).fadeIn(300);
 
             $element.animate({'opacity': '1', 'top':topOffset+'px'}, function(){
-                
+
                 $element.addClass('opened');
                 Modal._bindEvents($element);
 
                /**
-                * The target has been opened. 
+                * The target has been opened.
                 * @event Modal#opened.modal
                 */
                 $element.trigger('opened.'+ pluginName);
             });
-            
+
           }
        },
 
@@ -184,22 +186,22 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Plugi
         */
        _close: function($element){
            var options = $element.data(dataNs);
-       
+
            Modal._unBindEvents($element);
-           
+
            $('#'+options.modalOverlay).fadeOut(300);
            $element.animate({'opacity': '0', 'top':'-1000px'}, 500, function(){
                 $element.css('display', 'none');
            });
            $element.removeClass('opened');
-           
+
            /**
-            * The target has been closed/removed. 
+            * The target has been closed/removed.
             * @event Modal#closed.modal
             */
            $element.trigger('closed.'+ pluginName);
        },
-       
+
        /**
         * Resize the modal window
         * @param {jQuery object} $element
@@ -210,7 +212,7 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Plugi
             var options = $element.data(dataNs);
             var windowWidth = parseInt($(window).width(), 10);
             var css = {};
-                
+
             //calculate the final width and height
             var modalWidth = options.width === 'responsive' ? windowWidth * 0.7 : parseInt(options.width, 10);
             css.width = Math.max(modalWidth, options.minWidth);
@@ -228,10 +230,10 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function($, Plugi
     Pluginifier.register(pluginName, Modal, {
         expose : ['open', 'close']
     });
-   
+
    /**
     * The only exposed function is used to start listening on data-attr
-    * 
+    *
     * @public
     * @example define(['ui/modal'], function(modal){ modal($('rootContainer')); });
     * @param {jQueryElement} $container - the root context to listen in


### PR DESCRIPTION
 - Fix the failing tests (except `ui/autocomplete` and `lib/history`)
 - refactor the tests to use the object notation instead of global functions (in order to prepare the migration to QUnit 2)

Test it using 

```
grunt connect taotest
```

You should have 4 assertions failing (5 if develop isn't yet merged).
