### PR TITLE
Fix the autocomplete unit test: wrong arguments for event mocks

### DIFF
--- a/views/js/lib/simulator/jquery.keystroker.js
+++ b/views/js/lib/simulator/jquery.keystroker.js
@@ -83,11 +83,11 @@ define([
                 optionsType = 'string';
             } else {
                 keyOptions.key = '[' + options + ']';
-                keyOptions.charCode = 0;
+                keyOptions.charCode = options;
                 keyOptions.keyCode = options;
 
                 strokeOptions.key = '[' + options + ']';
-                strokeOptions.charCode = 0;
+                strokeOptions.charCode = options;
                 strokeOptions.keyCode = options;
             }
         }


### PR DESCRIPTION
Wrong argument given when mocking keyboard events for control keys