### PR TITLE
Fix/tao 1170 improper unicode

### DIFF
--- a/models/classes/ThemeRegistry.php
+++ b/models/classes/ThemeRegistry.php
@@ -210,6 +210,6 @@ class ThemeRegistry extends AbstractRegistry
 
             $returnValue[$target]['base'] = ROOT_URL . $value['base'];
         }
-        return json_encode($returnValue,JSON_PRETTY_PRINT);
+        return json_encode($returnValue);
     }
 }

--- a/models/classes/import/class.CsvImporter.php
+++ b/models/classes/import/class.CsvImporter.php
@@ -141,6 +141,11 @@ class tao_models_classes_import_CsvImporter implements tao_models_classes_import
 		$options['staticMap'] = array_merge($staticMap, $this->getStaticData());
 		$options = array_merge($options, $this->getAdditionAdapterOptions());
 
+		// Check if we have a proper UTF-8 file.
+		if (@preg_match('//u', file_get_contents($form->getValue('importFile'))) === false) {
+		    return new common_report_Report(common_report_Report::TYPE_ERROR, __("The imported file is not properly UTF-8 encoded."));
+		}
+		
 		$adapter = new tao_helpers_data_GenerisAdapterCsv($options);
 		$adapter->setValidators($this->getValidators());
 


### PR DESCRIPTION
This also prevents the platform to crash on PHP 5.3 :roller_coaster: 