### PR TITLE
Keep the set state to avoid multi ajax calls

### DIFF
--- a/views/js/serviceApi/StateStorage.js
+++ b/views/js/serviceApi/StateStorage.js
@@ -1,4 +1,22 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013 (original work) Open Assessment Technologies SA ;
+ */
 define(['jquery'], function($){
+    'use strict';
     
     function StateStorage(state, submitUrl) {
         this.state = state;
@@ -19,6 +37,7 @@ define(['jquery'], function($){
                     callback();
             }
         } else {
+            this.state = state;
             $.ajax({
                 url : this.submitUrl,
                 data 		: {


### PR DESCRIPTION
This patch avoid the test runner to send several requests to store the same state each time an item is validated.