### PR TITLE
Wrong translation when the key contains parameters

### DIFF
--- a/views/js/i18n.js
+++ b/views/js/i18n.js
@@ -12,9 +12,12 @@ define(['lodash', 'json!i18ntr/messages.json', 'context', 'core/format'], functi
      */
     var __ = function __(message){
         var localized =  !translations[message] ? message :  translations[message];
+
         if(arguments.length > 1){
+            arguments[0] = localized;
             localized = format.apply(null, arguments); 
         }
+
         return localized;
     };
 


### PR DESCRIPTION
When a translation contains parameters, the `translate`method was using the source as a translation instead of the localized version...