### PR TITLE
Fix modal animate callback when not visible

### DIFF
--- a/views/js/ui/modal.js
+++ b/views/js/ui/modal.js
@@ -71,7 +71,7 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function ($, Plug
                 if ('number' !== typeof options.animate) {
                     options.animate = defaults.animate;
                 } else {
-                    options.animate = Math.min(animateDiff, options.animate);
+                    options.animate = Math.max(animateDiff, options.animate);
                 }
             }
 

--- a/views/js/ui/modal.js
+++ b/views/js/ui/modal.js
@@ -229,7 +229,7 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function ($, Plug
 
                 $overlay = $('#' + options.modalOverlay);
 
-                if (options.animate) {
+                if (options.animate && $element.is(':visible')) {
                     $element.css({
                         'top': '-' + modalHeight + 'px',
                         'display': 'block'
@@ -266,7 +266,7 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function ($, Plug
 
             modal._unBindEvents($element);
 
-            if (options.animate){
+            if (options.animate && $element.is(':visible')){
                 $overlay.fadeOut(options.animate - animateDiff);
                 $element.animate({'opacity': '0', 'top': '-1000px'}, options.animate, onClose);
             } else {

--- a/views/js/ui/modal.js
+++ b/views/js/ui/modal.js
@@ -229,6 +229,8 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function ($, Plug
 
                 $overlay = $('#' + options.modalOverlay);
 
+                $element.show();
+
                 if (options.animate && $element.is(':visible')) {
                     $element.css({
                         'top': '-' + modalHeight + 'px',
@@ -239,7 +241,7 @@ define(['jquery', 'core/pluginifier', 'core/dataattrhandler'], function ($, Plug
                     $element.animate(to, options.animate, onOpen);
                 } else {
                     $overlay.show();
-                    $element.css(to).show();
+                    $element.css(to);
                     onOpen();
                 }
             }


### PR DESCRIPTION
The close and open actions were not called when animate is enabled and the modal is hidden.

Now, when the modal is hidden, the animate is not used.