### PR TITLE
Improved linear-gradient mixin

### DIFF
--- a/views/scss/inc/_functions.scss
+++ b/views/scss/inc/_functions.scss
@@ -11,6 +11,13 @@
     }
 }
 
+/*
+Usage:
+- linear-gradient((color1, color2, color3)) - returns linear-gradient with evenly distributed colors,
+   if 3 colors used then the position of each will be 33,33%
+- linear-gradient((color1 0%, color2 30%, color3 80%)) - returns linear-gradient with manually distributed colors,
+   first param - color, second - position. Also you can use px or other valid units for set position.
+*/
 @mixin linear-gradient($colorList, $direction: 'to right') {
     $percentage: 0;
     $units: '%';

--- a/views/scss/inc/_functions.scss
+++ b/views/scss/inc/_functions.scss
@@ -13,15 +13,22 @@
 
 @mixin linear-gradient($colorList, $direction: 'to right') {
     $percentage: 0;
+    $units: '%';
     $count: length($colorList);
     $increment: 100 / ($count - 1);
     $css: #{$direction + ', '};
     $sep: ', ';
-    @each $color in $colorList {
-        @if ($percentage >= 100) {
+    @each $colorItem in $colorList {
+        $color: $colorItem;
+        @if (length($colorItem) > 1) {
+            $color: nth($colorItem, 1);
+            $percentage: nth($colorItem, 2);
+            $units: '';
+        }
+        @if ($percentage >= 100 or index($colorList, $colorItem) == $count) {
             $sep: '';
         }
-        $css: #{$css + $color + ' ' + $percentage + '%' + $sep};
+        $css: #{$css + $color + ' ' + $percentage + $units + $sep};
         $percentage: $percentage + $increment;
     }
     background: linear-gradient( #{$css} );


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-1243 and https://github.com/oat-sa/extension-tao-testqti/pull/195

This fix allow use list of color with positions.
In past: 
```sass
@include linear-gradient((color1, color2, color3)) // generates gradient with 33,333% per color
```

Now you can define color and position:
```sass
@include linear-gradient((color1 0px, color2 30px, color3 50px))
```