### PR TITLE
configure the text plugin to use always xhr

### DIFF
--- a/views/templates/client_config.tpl
+++ b/views/templates/client_config.tpl
@@ -20,6 +20,12 @@ require.config({
             extensionsLocales       : <?=json_encode(get_data('extensionsLocales'))?>,
             timeout                 : <?=get_data('client_timeout')?>,
         },
+        text: {
+            useXhr: function(){
+                return true;
+            }
+        },
+
         'ui/themes' : <?= get_data('themesAvailable') ?>,
 //dynamic lib config
     <?php foreach (get_data('libConfigs') as $name => $config) :?>


### PR DESCRIPTION
It makes client side templates to load even in a Cross Origin context
(Cherry pick from https://github.com/oat-sa/tao-core/pull/565)