### PR TITLE
Add init attribute to the structures.dtd

### DIFF
--- a/doc/structures.dtd
+++ b/doc/structures.dtd
@@ -56,6 +56,7 @@
 						moveInstance CDATA #IMPLIED
 						delete CDATA #IMPLIED
 						rootNode CDATA #IMPLIED
+                        init CDATA #IMPLIED
 					>
 	
 				<!-- The list of contextual actions to load in the section panel -->


### PR DESCRIPTION
Init event has been added earlier:
https://github.com/oat-sa/tao-core/blob/develop/views/js/layout/tree.js#L261
but I forgot add init attribute to the `structures.dtd` file