### PR TITLE
Allow routes outside of extension names

### DIFF
--- a/models/classes/controllerMap/Factory.php
+++ b/models/classes/controllerMap/Factory.php
@@ -95,7 +95,9 @@ class Factory
         // routes
         $namespaces = array();
         foreach ($extension->getManifest()->getRoutes() as $mapedPath => $ns) {
-            $namespaces[] = trim($ns, '\\');
+            if (is_string($ns)) {
+                $namespaces[] = trim($ns, '\\');
+            }
         }
         if (!empty($namespaces)) {
             common_Logger::t('Namespace found in routes for extension '. $extension->getId() );


### PR DESCRIPTION
Possibility to define complex routes, not restricted by extension name schema, requires performance validation