### PR TITLE
remove milliseconds from ISO 8601 format

### DIFF
--- a/helpers/dateFormatter/EuropeanFormatter.php
+++ b/helpers/dateFormatter/EuropeanFormatter.php
@@ -53,8 +53,7 @@ class EuropeanFormatter extends Configurable implements Formatter
         	    $formatString = 'F j, Y, g:i:s a';
         	    break;
 			case \tao_helpers_Date::FORMAT_ISO8601:
-				$milliseconds = str_replace('0.', '', sprintf('%0.3f', fmod($timestamp, 1)));
-				$formatString = 'Y-m-d\TH:i:s.'.$milliseconds.'O';
+				$formatString = 'Y-m-d\TH:i:sO';
 				break;
         	default:
         	    common_Logger::w('Unknown date format ' . $format . ' for ' . __FUNCTION__, 'TAO');

--- a/test/helpers/DateHelperTest.php
+++ b/test/helpers/DateHelperTest.php
@@ -30,7 +30,7 @@ class DateHelperTest extends TaoPhpUnitTestRunner
 {
 
     /**
-     * 
+     *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testDisplayDate()
@@ -43,28 +43,28 @@ class DateHelperTest extends TaoPhpUnitTestRunner
         $this->assertEquals('01/02/1980 10:00:00', tao_helpers_Date::displayeDate($mybirthday, tao_helpers_Date::FORMAT_LONG));
         $this->assertEquals('1980-02-01 10:00', tao_helpers_Date::displayeDate($mybirthday, tao_helpers_Date::FORMAT_DATEPICKER));
         $this->assertEquals('February 1, 1980, 10:00:00 am', tao_helpers_Date::displayeDate($mybirthday, tao_helpers_Date::FORMAT_VERBOSE));
-        $this->assertEquals('1980-02-01T10:00:00.012'.$offset, tao_helpers_Date::displayeDate($mybirthday, tao_helpers_Date::FORMAT_ISO8601));
-        
+        $this->assertEquals('1980-02-01T10:00:00'.$offset, tao_helpers_Date::displayeDate($mybirthday, tao_helpers_Date::FORMAT_ISO8601));
+
         $mybirthdayTs = $mybirthday->getTimeStamp();
         $this->assertEquals('01/02/1980 10:00:00', tao_helpers_Date::displayeDate($mybirthdayTs));
         $this->assertEquals('01/02/1980 10:00:00', tao_helpers_Date::displayeDate($mybirthdayTs, tao_helpers_Date::FORMAT_LONG));
         $this->assertEquals('1980-02-01 10:00', tao_helpers_Date::displayeDate($mybirthdayTs, tao_helpers_Date::FORMAT_DATEPICKER));
         $this->assertEquals('February 1, 1980, 10:00:00 am', tao_helpers_Date::displayeDate($mybirthdayTs, tao_helpers_Date::FORMAT_VERBOSE));
-        $this->assertEquals('1980-02-01T10:00:00.000'.$offset, tao_helpers_Date::displayeDate($mybirthdayTs, tao_helpers_Date::FORMAT_ISO8601));
-        
+        $this->assertEquals('1980-02-01T10:00:00'.$offset, tao_helpers_Date::displayeDate($mybirthdayTs, tao_helpers_Date::FORMAT_ISO8601));
+
         $literal = new \core_kernel_classes_Literal($mybirthdayTs);
         $this->assertEquals('01/02/1980 10:00:00', tao_helpers_Date::displayeDate($literal));
         $this->assertEquals('01/02/1980 10:00:00', tao_helpers_Date::displayeDate($literal, tao_helpers_Date::FORMAT_LONG));
         $this->assertEquals('1980-02-01 10:00', tao_helpers_Date::displayeDate($literal, tao_helpers_Date::FORMAT_DATEPICKER));
         $this->assertEquals('February 1, 1980, 10:00:00 am', tao_helpers_Date::displayeDate($literal, tao_helpers_Date::FORMAT_VERBOSE));
-        $this->assertEquals('1980-02-01T10:00:00.000'.$offset, tao_helpers_Date::displayeDate($literal, tao_helpers_Date::FORMAT_ISO8601));
+        $this->assertEquals('1980-02-01T10:00:00'.$offset, tao_helpers_Date::displayeDate($literal, tao_helpers_Date::FORMAT_ISO8601));
 
         $ms = tao_helpers_Date::getTimeStampWithMicroseconds($mybirthday);
         $this->assertEquals('01/02/1980 10:00:00', tao_helpers_Date::displayeDate($ms));
         $this->assertEquals('01/02/1980 10:00:00', tao_helpers_Date::displayeDate($ms, tao_helpers_Date::FORMAT_LONG));
         $this->assertEquals('1980-02-01 10:00', tao_helpers_Date::displayeDate($ms, tao_helpers_Date::FORMAT_DATEPICKER));
         $this->assertEquals('February 1, 1980, 10:00:00 am', tao_helpers_Date::displayeDate($ms, tao_helpers_Date::FORMAT_VERBOSE));
-        $this->assertEquals('1980-02-01T10:00:00.012'.$offset, tao_helpers_Date::displayeDate($ms, tao_helpers_Date::FORMAT_ISO8601));
+        $this->assertEquals('1980-02-01T10:00:00'.$offset, tao_helpers_Date::displayeDate($ms, tao_helpers_Date::FORMAT_ISO8601));
     }
 
     /**


### PR DESCRIPTION
it is no more needed