### PR TITLE
minor components API refactoring and simplifications

### DIFF
--- a/views/js/test/ui/breadcrumbs/test.js
+++ b/views/js/test/ui/breadcrumbs/test.js
@@ -45,6 +45,7 @@ define([
         { name : 'disable', title : 'disable' },
         { name : 'is', title : 'is' },
         { name : 'setState', title : 'setState' },
+        { name : 'getElement', title : 'getElement' },
         { name : 'getContainer', title : 'getContainer' },
         { name : 'getTemplate', title : 'getTemplate' },
         { name : 'setTemplate', title : 'setTemplate' }
@@ -146,42 +147,42 @@ define([
 
         assert.equal($container.find('.dummy').length, 0, 'The container does not contain an element of the class dummy');
         assert.equal(instance.is('rendered'), true, 'The breadcrumbs instance must be rendered');
-        assert.equal(typeof instance.getContainer(), 'object', 'The breadcrumbs instance returns the rendered content as an object');
-        assert.equal(instance.getContainer().length, 1, 'The breadcrumbs instance returns the rendered content');
-        assert.equal(instance.getContainer().parent().get(0), $container.get(0), 'The breadcrumbs instance is rendered inside the right container');
+        assert.equal(typeof instance.getElement(), 'object', 'The breadcrumbs instance returns the rendered content as an object');
+        assert.equal(instance.getElement().length, 1, 'The breadcrumbs instance returns the rendered content');
+        assert.equal(instance.getElement().parent().get(0), $container.get(0), 'The breadcrumbs instance is rendered inside the right container');
 
-        assert.equal(instance.getContainer().find('> li').length, breadcrumbsEntries.length, 'The breadcrumbs instance has rendered the list of entries');
+        assert.equal(instance.getElement().find('> li').length, breadcrumbsEntries.length, 'The breadcrumbs instance has rendered the list of entries');
 
         // 1st
-        assert.equal(instance.getContainer().find('> li').first().data('breadcrumb'), breadcrumbsEntries[0].id, 'The 1st breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').first().find('a').text(), breadcrumbsEntries[0].label, 'The 1st breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').first().find('a').attr('href'), breadcrumbsEntries[0].url, 'The 1st breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').first().data('breadcrumb'), breadcrumbsEntries[0].id, 'The 1st breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').first().find('a').text(), breadcrumbsEntries[0].label, 'The 1st breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').first().find('a').attr('href'), breadcrumbsEntries[0].url, 'The 1st breadcrumb has the right URL');
 
         // 2nd
-        assert.equal(instance.getContainer().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].id, 'The 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').text(), breadcrumbsEntries[1].label, 'The 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries[1].url, 'The 2nd breadcrumb has the right URL');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').length, breadcrumbsEntries[1].entries.length, 'The 2nd breadcrumb has a sub list');
+        assert.equal(instance.getElement().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].id, 'The 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').text(), breadcrumbsEntries[1].label, 'The 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries[1].url, 'The 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').length, breadcrumbsEntries[1].entries.length, 'The 2nd breadcrumb has a sub list');
 
         // 2nd sub 1
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries[1].entries[0].id, 'The 1st list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries[1].entries[0].label, 'The 1st list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries[1].entries[0].url, 'The 1st list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries[1].entries[0].id, 'The 1st list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries[1].entries[0].label, 'The 1st list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries[1].entries[0].url, 'The 1st list entry of the 2nd breadcrumb has the right URL');
 
         // 2nd sub 2
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].entries[1].id, 'The 2nd list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries[1].entries[1].label, 'The 2nd list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries[1].entries[1].url, 'The 2nd list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].entries[1].id, 'The 2nd list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries[1].entries[1].label, 'The 2nd list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries[1].entries[1].url, 'The 2nd list entry of the 2nd breadcrumb has the right URL');
 
         // 3rd
-        assert.equal(instance.getContainer().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries[2].id, 'The 3rd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('.a').text(), breadcrumbsEntries[2].label + ' - ' + breadcrumbsEntries[2].data, 'The 3rd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('a').length, 0, 'The 3rd breadcrumb does not have a link');
+        assert.equal(instance.getElement().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries[2].id, 'The 3rd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(2).find('.a').text(), breadcrumbsEntries[2].label + ' - ' + breadcrumbsEntries[2].data, 'The 3rd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(2).find('a').length, 0, 'The 3rd breadcrumb does not have a link');
 
         instance.destroy();
 
         assert.equal($container.children().length, 0, 'The container is now empty');
-        assert.equal(instance.getContainer(), null, 'The breadcrumbs instance has removed its rendered content');
+        assert.equal(instance.getElement(), null, 'The breadcrumbs instance has removed its rendered content');
     });
 
 
@@ -195,75 +196,75 @@ define([
         var instance = breadcrumbs();
 
         assert.equal(instance.is('rendered'), false, 'The breadcrumbs instance must not be rendered');
-        assert.equal(instance.getContainer(), null, 'The breadcrumbs instance must not have DOM element');
+        assert.equal(instance.getElement(), null, 'The breadcrumbs instance must not have DOM element');
 
         /*** 1ST PASS - WITHOUT CONTAINER - EXPLICIT RENDERING ***/
         instance.update(breadcrumbsEntries);
 
         assert.equal(instance.is('rendered'), true, '[1st pass] The breadcrumbs instance must be rendered');
-        assert.equal(instance.getContainer().length, 1, '[1st pass] The breadcrumbs instance must have DOM element');
+        assert.equal(instance.getElement().length, 1, '[1st pass] The breadcrumbs instance must have DOM element');
 
-        assert.equal(instance.getContainer().find('> li').length, breadcrumbsEntries.length, '[1st pass] The breadcrumbs instance has rendered the list of entries');
+        assert.equal(instance.getElement().find('> li').length, breadcrumbsEntries.length, '[1st pass] The breadcrumbs instance has rendered the list of entries');
 
         // 1st
-        assert.equal(instance.getContainer().find('> li').first().data('breadcrumb'), breadcrumbsEntries[0].id, '[1st pass] The 1st breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').first().find('a').text(), breadcrumbsEntries[0].label, '[1st pass] The 1st breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').first().find('a').attr('href'), breadcrumbsEntries[0].url, '[1st pass] The 1st breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').first().data('breadcrumb'), breadcrumbsEntries[0].id, '[1st pass] The 1st breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').first().find('a').text(), breadcrumbsEntries[0].label, '[1st pass] The 1st breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').first().find('a').attr('href'), breadcrumbsEntries[0].url, '[1st pass] The 1st breadcrumb has the right URL');
 
         // 2nd
-        assert.equal(instance.getContainer().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].id, '[1st pass] The 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').text(), breadcrumbsEntries[1].label, '[1st pass] The 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries[1].url, '[1st pass] The 2nd breadcrumb has the right URL');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').length, breadcrumbsEntries[1].entries.length, '[1st pass] The 2nd breadcrumb has a sub list');
+        assert.equal(instance.getElement().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].id, '[1st pass] The 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').text(), breadcrumbsEntries[1].label, '[1st pass] The 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries[1].url, '[1st pass] The 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').length, breadcrumbsEntries[1].entries.length, '[1st pass] The 2nd breadcrumb has a sub list');
 
         // 2nd sub 1
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries[1].entries[0].id, '[1st pass] The 1st list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries[1].entries[0].label, '[1st pass] The 1st list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries[1].entries[0].url, '[1st pass] The 1st list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries[1].entries[0].id, '[1st pass] The 1st list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries[1].entries[0].label, '[1st pass] The 1st list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries[1].entries[0].url, '[1st pass] The 1st list entry of the 2nd breadcrumb has the right URL');
 
         // 2nd sub 2
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].entries[1].id, '[1st pass] The 2nd list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries[1].entries[1].label, '[1st pass] The 2nd list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries[1].entries[1].url, '[1st pass] The 2nd list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].entries[1].id, '[1st pass] The 2nd list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries[1].entries[1].label, '[1st pass] The 2nd list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries[1].entries[1].url, '[1st pass] The 2nd list entry of the 2nd breadcrumb has the right URL');
 
         // 3rd
-        assert.equal(instance.getContainer().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries[2].id, '[1st pass] The 3rd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('.a').text(), breadcrumbsEntries[2].label + ' - ' + breadcrumbsEntries[2].data, '[1st pass] The 3rd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('a').length, 0, '[1st pass] The 3rd breadcrumb does not have a link');
+        assert.equal(instance.getElement().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries[2].id, '[1st pass] The 3rd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(2).find('.a').text(), breadcrumbsEntries[2].label + ' - ' + breadcrumbsEntries[2].data, '[1st pass] The 3rd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(2).find('a').length, 0, '[1st pass] The 3rd breadcrumb does not have a link');
 
         /*** 2ND PASS - WITHOUT CONTAINER - EXPLICIT RENDERING ***/
         instance.update(breadcrumbsEntries2);
 
         assert.equal(instance.is('rendered'), true, '[2nd pass] The breadcrumbs instance must be rendered');
-        assert.equal(instance.getContainer().length, 1, '[2nd pass] The breadcrumbs instance must have DOM element');
+        assert.equal(instance.getElement().length, 1, '[2nd pass] The breadcrumbs instance must have DOM element');
 
-        assert.equal(instance.getContainer().find('> li').length, breadcrumbsEntries2.length, '[2nd pass] The breadcrumbs instance has rendered the list of entries');
+        assert.equal(instance.getElement().find('> li').length, breadcrumbsEntries2.length, '[2nd pass] The breadcrumbs instance has rendered the list of entries');
 
         // 1st
-        assert.equal(instance.getContainer().find('> li').first().data('breadcrumb'), breadcrumbsEntries2[0].id, '[2nd pass] The 1st breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').first().find('a').text(), breadcrumbsEntries2[0].label, '[2nd pass] The 1st breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').first().find('a').attr('href'), breadcrumbsEntries2[0].url, '[2nd pass] The 1st breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').first().data('breadcrumb'), breadcrumbsEntries2[0].id, '[2nd pass] The 1st breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').first().find('a').text(), breadcrumbsEntries2[0].label, '[2nd pass] The 1st breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').first().find('a').attr('href'), breadcrumbsEntries2[0].url, '[2nd pass] The 1st breadcrumb has the right URL');
 
         // 2nd
-        assert.equal(instance.getContainer().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries2[1].id, '[2nd pass] The 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').text(), breadcrumbsEntries2[1].label, '[2nd pass] The 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries2[1].url, '[2nd pass] The 2nd breadcrumb has the right URL');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').length, breadcrumbsEntries2[1].entries.length, '[2nd pass] The 2nd breadcrumb has a sub list');
+        assert.equal(instance.getElement().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries2[1].id, '[2nd pass] The 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').text(), breadcrumbsEntries2[1].label, '[2nd pass] The 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries2[1].url, '[2nd pass] The 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').length, breadcrumbsEntries2[1].entries.length, '[2nd pass] The 2nd breadcrumb has a sub list');
 
         // 2nd sub 1
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries2[1].entries[0].id, '[2nd pass] The 1st list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries2[1].entries[0].label, '[2nd pass] The 1st list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries2[1].entries[0].url, '[2nd pass] The 1st list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries2[1].entries[0].id, '[2nd pass] The 1st list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries2[1].entries[0].label, '[2nd pass] The 1st list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries2[1].entries[0].url, '[2nd pass] The 1st list entry of the 2nd breadcrumb has the right URL');
 
         // 2nd sub 2
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries2[1].entries[1].id, '[2nd pass] The 2nd list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries2[1].entries[1].label, '[2nd pass] The 2nd list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries2[1].entries[1].url, '[2nd pass] The 2nd list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries2[1].entries[1].id, '[2nd pass] The 2nd list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries2[1].entries[1].label, '[2nd pass] The 2nd list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries2[1].entries[1].url, '[2nd pass] The 2nd list entry of the 2nd breadcrumb has the right URL');
 
         // 3rd
-        assert.equal(instance.getContainer().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries2[2].id, '[2nd pass] The 3rd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('.a').text(), breadcrumbsEntries2[2].label + ' - ' + breadcrumbsEntries2[2].data, '[2nd pass] The 3rd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('a').length, 0, '[2nd pass] The 3rd breadcrumb does not have a link');
+        assert.equal(instance.getElement().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries2[2].id, '[2nd pass] The 3rd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(2).find('.a').text(), breadcrumbsEntries2[2].label + ' - ' + breadcrumbsEntries2[2].data, '[2nd pass] The 3rd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(2).find('a').length, 0, '[2nd pass] The 3rd breadcrumb does not have a link');
 
         instance.destroy();
 
@@ -274,150 +275,153 @@ define([
         instance = breadcrumbs(config);
 
         assert.equal(instance.is('rendered'), true, '[3rd pass] The breadcrumbs instance must be rendered');
-        assert.equal(typeof instance.getContainer(), 'object', '[3rd pass] The breadcrumbs instance returns the rendered content as an object');
-        assert.equal(instance.getContainer().length, 1, '[3rd pass] The breadcrumbs instance returns the rendered content');
-        assert.equal(instance.getContainer().parent().get(0), $container.get(0), '[3rd pass] The breadcrumbs instance is rendered inside the right container');
-        assert.equal(instance.getContainer().get(0), $container.children().get(0), '[3rd pass] The breadcrumbs instance is rendered inside the right container and is the only child');
+        assert.equal(typeof instance.getElement(), 'object', '[3rd pass] The breadcrumbs instance returns the rendered content as an object');
+        assert.equal(instance.getElement().length, 1, '[3rd pass] The breadcrumbs instance returns the rendered content');
+        assert.equal(instance.getElement().parent().get(0), $container.get(0), '[3rd pass] The breadcrumbs instance is rendered inside the right container');
+        assert.equal(instance.getElement().get(0), $container.children().get(0), '[3rd pass] The breadcrumbs instance is rendered inside the right container and is the only child');
 
-        assert.equal(instance.getContainer().find('> li').length, breadcrumbsEntries.length, '[3rd pass] The breadcrumbs instance has rendered the list of entries');
+        assert.equal(instance.getElement().find('> li').length, breadcrumbsEntries.length, '[3rd pass] The breadcrumbs instance has rendered the list of entries');
 
         // 1st
-        assert.equal(instance.getContainer().find('> li').first().data('breadcrumb'), breadcrumbsEntries[0].id, '[3rd pass] The 1st breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').first().find('a').text(), breadcrumbsEntries[0].label, '[3rd pass] The 1st breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').first().find('a').attr('href'), breadcrumbsEntries[0].url, '[3rd pass] The 1st breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').first().data('breadcrumb'), breadcrumbsEntries[0].id, '[3rd pass] The 1st breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').first().find('a').text(), breadcrumbsEntries[0].label, '[3rd pass] The 1st breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').first().find('a').attr('href'), breadcrumbsEntries[0].url, '[3rd pass] The 1st breadcrumb has the right URL');
 
         // 2nd
-        assert.equal(instance.getContainer().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].id, '[3rd pass] The 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').text(), breadcrumbsEntries[1].label, '[3rd pass] The 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries[1].url, '[3rd pass] The 2nd breadcrumb has the right URL');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').length, breadcrumbsEntries[1].entries.length, '[3rd pass] The 2nd breadcrumb has a sub list');
+        assert.equal(instance.getElement().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].id, '[3rd pass] The 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').text(), breadcrumbsEntries[1].label, '[3rd pass] The 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries[1].url, '[3rd pass] The 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').length, breadcrumbsEntries[1].entries.length, '[3rd pass] The 2nd breadcrumb has a sub list');
 
         // 2nd sub 1
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries[1].entries[0].id, '[3rd pass] The 1st list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries[1].entries[0].label, '[3rd pass] The 1st list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries[1].entries[0].url, '[3rd pass] The 1st list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries[1].entries[0].id, '[3rd pass] The 1st list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries[1].entries[0].label, '[3rd pass] The 1st list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries[1].entries[0].url, '[3rd pass] The 1st list entry of the 2nd breadcrumb has the right URL');
 
         // 2nd sub 2
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].entries[1].id, '[3rd pass] The 2nd list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries[1].entries[1].label, '[3rd pass] The 2nd list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries[1].entries[1].url, '[3rd pass] The 2nd list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries[1].entries[1].id, '[3rd pass] The 2nd list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries[1].entries[1].label, '[3rd pass] The 2nd list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries[1].entries[1].url, '[3rd pass] The 2nd list entry of the 2nd breadcrumb has the right URL');
 
         // 3rd
-        assert.equal(instance.getContainer().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries[2].id, '[3rd pass] The 3rd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('.a').text(), breadcrumbsEntries[2].label + ' - ' + breadcrumbsEntries[2].data, '[3rd pass] The 3rd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('a').length, 0, '[3rd pass] The 3rd breadcrumb does not have a link');
+        assert.equal(instance.getElement().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries[2].id, '[3rd pass] The 3rd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(2).find('.a').text(), breadcrumbsEntries[2].label + ' - ' + breadcrumbsEntries[2].data, '[3rd pass] The 3rd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(2).find('a').length, 0, '[3rd pass] The 3rd breadcrumb does not have a link');
 
         /*** 4TH PASS - INSIDE CONTAINER - EXPLICIT RENDERING ***/
         instance.update(breadcrumbsEntries2);
 
         assert.equal(instance.is('rendered'), true, '[4th pass] The breadcrumbs instance must be rendered');
-        assert.equal(typeof instance.getContainer(), 'object', '[4th pass] The breadcrumbs instance returns the rendered content as an object');
-        assert.equal(instance.getContainer().length, 1, '[4th pass] The breadcrumbs instance returns the rendered content');
-        assert.equal(instance.getContainer().parent().get(0), $container.get(0), '[4th pass] The breadcrumbs instance is rendered inside the right container');
-        assert.equal(instance.getContainer().get(0), $container.children().get(0), '[3rd pass] The breadcrumbs instance is rendered inside the right container and is the only child');
+        assert.equal(typeof instance.getElement(), 'object', '[4th pass] The breadcrumbs instance returns the rendered content as an object');
+        assert.equal(instance.getElement().length, 1, '[4th pass] The breadcrumbs instance returns the rendered content');
+        assert.equal(instance.getElement().parent().get(0), $container.get(0), '[4th pass] The breadcrumbs instance is rendered inside the right container');
+        assert.equal(instance.getElement().get(0), $container.children().get(0), '[3rd pass] The breadcrumbs instance is rendered inside the right container and is the only child');
 
-        assert.equal(instance.getContainer().find('> li').length, breadcrumbsEntries2.length, '[4th pass] The breadcrumbs instance has rendered the list of entries');
+        assert.equal(instance.getElement().find('> li').length, breadcrumbsEntries2.length, '[4th pass] The breadcrumbs instance has rendered the list of entries');
 
         // 1st
-        assert.equal(instance.getContainer().find('> li').first().data('breadcrumb'), breadcrumbsEntries2[0].id, '[4th pass] The 1st breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').first().find('a').text(), breadcrumbsEntries2[0].label, '[4th pass] The 1st breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').first().find('a').attr('href'), breadcrumbsEntries2[0].url, '[4th pass] The 1st breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').first().data('breadcrumb'), breadcrumbsEntries2[0].id, '[4th pass] The 1st breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').first().find('a').text(), breadcrumbsEntries2[0].label, '[4th pass] The 1st breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').first().find('a').attr('href'), breadcrumbsEntries2[0].url, '[4th pass] The 1st breadcrumb has the right URL');
 
         // 2nd
-        assert.equal(instance.getContainer().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries2[1].id, '[4th pass] The 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').text(), breadcrumbsEntries2[1].label, '[4th pass] The 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries2[1].url, '[4th pass] The 2nd breadcrumb has the right URL');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').length, breadcrumbsEntries2[1].entries.length, '[4th pass] The 2nd breadcrumb has a sub list');
+        assert.equal(instance.getElement().find('> li').eq(1).data('breadcrumb'), breadcrumbsEntries2[1].id, '[4th pass] The 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').text(), breadcrumbsEntries2[1].label, '[4th pass] The 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('> a').attr('href'), breadcrumbsEntries2[1].url, '[4th pass] The 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').length, breadcrumbsEntries2[1].entries.length, '[4th pass] The 2nd breadcrumb has a sub list');
 
         // 2nd sub 1
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries2[1].entries[0].id, '[4th pass] The 1st list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries2[1].entries[0].label, '[4th pass] The 1st list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries2[1].entries[0].url, '[4th pass] The 1st list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).data('breadcrumb'), breadcrumbsEntries2[1].entries[0].id, '[4th pass] The 1st list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').text(), breadcrumbsEntries2[1].entries[0].label, '[4th pass] The 1st list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(0).find('a').attr('href'), breadcrumbsEntries2[1].entries[0].url, '[4th pass] The 1st list entry of the 2nd breadcrumb has the right URL');
 
         // 2nd sub 2
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries2[1].entries[1].id, '[4th pass] The 2nd list entry of the 2nd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries2[1].entries[1].label, '[4th pass] The 2nd list entry of the 2nd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries2[1].entries[1].url, '[4th pass] The 2nd list entry of the 2nd breadcrumb has the right URL');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).data('breadcrumb'), breadcrumbsEntries2[1].entries[1].id, '[4th pass] The 2nd list entry of the 2nd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').text(), breadcrumbsEntries2[1].entries[1].label, '[4th pass] The 2nd list entry of the 2nd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(1).find('li').eq(1).find('a').attr('href'), breadcrumbsEntries2[1].entries[1].url, '[4th pass] The 2nd list entry of the 2nd breadcrumb has the right URL');
 
         // 3rd
-        assert.equal(instance.getContainer().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries2[2].id, '[4th pass] The 3rd breadcrumb has the right identifier');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('.a').text(), breadcrumbsEntries2[2].label + ' - ' + breadcrumbsEntries2[2].data, '[4th pass] The 3rd breadcrumb has the right label');
-        assert.equal(instance.getContainer().find('> li').eq(2).find('a').length, 0, '[4th pass] The 3rd breadcrumb does not have a link');
+        assert.equal(instance.getElement().find('> li').eq(2).data('breadcrumb'), breadcrumbsEntries2[2].id, '[4th pass] The 3rd breadcrumb has the right identifier');
+        assert.equal(instance.getElement().find('> li').eq(2).find('.a').text(), breadcrumbsEntries2[2].label + ' - ' + breadcrumbsEntries2[2].data, '[4th pass] The 3rd breadcrumb has the right label');
+        assert.equal(instance.getElement().find('> li').eq(2).find('a').length, 0, '[4th pass] The 3rd breadcrumb does not have a link');
 
         instance.destroy();
 
         assert.equal($container.children().length, 0, '[4th pass] The container is now empty');
-        assert.equal(instance.getContainer(), null, '[4th pass] The breadcrumbs instance has removed its rendered content');
+        assert.equal(instance.getElement(), null, '[4th pass] The breadcrumbs instance has removed its rendered content');
     });
 
 
     QUnit.test('show/hide', function(assert) {
-        var instance = breadcrumbs();
-        var $component = instance.render();
+        var instance = breadcrumbs()
+                        .render();
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The breadcrumbs instance must be rendered');
         assert.equal($component.length, 1, 'The breadcrumbs instance returns the rendered content');
 
         assert.equal(instance.is('hidden'), false, 'The breadcrumbs instance is visible');
-        assert.equal(instance.getContainer().hasClass('hidden'), false, 'The breadcrumbs instance does not have the hidden class');
+        assert.equal(instance.getElement().hasClass('hidden'), false, 'The breadcrumbs instance does not have the hidden class');
 
         instance.hide();
 
         assert.equal(instance.is('hidden'), true, 'The breadcrumbs instance is hidden');
-        assert.equal(instance.getContainer().hasClass('hidden'), true, 'The breadcrumbs instance has the hidden class');
+        assert.equal(instance.getElement().hasClass('hidden'), true, 'The breadcrumbs instance has the hidden class');
 
         instance.show();
 
         assert.equal(instance.is('hidden'), false, 'The breadcrumbs instance is visible');
-        assert.equal(instance.getContainer().hasClass('hidden'), false, 'The breadcrumbs instance does not have the hidden class');
+        assert.equal(instance.getElement().hasClass('hidden'), false, 'The breadcrumbs instance does not have the hidden class');
 
         instance.destroy();
     });
 
 
     QUnit.test('enable/disable', function(assert) {
-        var instance = breadcrumbs();
-        var $component = instance.render();
+        var instance = breadcrumbs()
+                        .render();
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The breadcrumbs instance must be rendered');
         assert.equal($component.length, 1, 'The breadcrumbs instance returns the rendered content');
 
         assert.equal(instance.is('disabled'), false, 'The breadcrumbs instance is enabled');
-        assert.equal(instance.getContainer().hasClass('disabled'), false, 'The breadcrumbs instance does not have the disabled class');
+        assert.equal(instance.getElement().hasClass('disabled'), false, 'The breadcrumbs instance does not have the disabled class');
 
         instance.disable();
 
         assert.equal(instance.is('disabled'), true, 'The breadcrumbs instance is disabled');
-        assert.equal(instance.getContainer().hasClass('disabled'), true, 'The breadcrumbs instance has the disabled class');
+        assert.equal(instance.getElement().hasClass('disabled'), true, 'The breadcrumbs instance has the disabled class');
 
         instance.enable();
 
         assert.equal(instance.is('disabled'), false, 'The breadcrumbs instance is enabled');
-        assert.equal(instance.getContainer().hasClass('disabled'), false, 'The breadcrumbs instance does not have the disabled class');
+        assert.equal(instance.getElement().hasClass('disabled'), false, 'The breadcrumbs instance does not have the disabled class');
 
         instance.destroy();
     });
 
 
     QUnit.test('state', function(assert) {
-        var instance = breadcrumbs();
-        var $component = instance.render();
+        var instance = breadcrumbs()
+                        .render();
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The breadcrumbs instance must be rendered');
         assert.equal($component.length, 1, 'The breadcrumbs instance returns the rendered content');
 
         assert.equal(instance.is('customState'), false, 'The breadcrumbs instance does not have the customState state');
-        assert.equal(instance.getContainer().hasClass('customState'), false, 'The breadcrumbs instance does not have the customState class');
+        assert.equal(instance.getElement().hasClass('customState'), false, 'The breadcrumbs instance does not have the customState class');
 
         instance.setState('customState', true);
 
         assert.equal(instance.is('customState'), true, 'The breadcrumbs instance has the customState state');
-        assert.equal(instance.getContainer().hasClass('customState'), true, 'The breadcrumbs instance has the customState class');
+        assert.equal(instance.getElement().hasClass('customState'), true, 'The breadcrumbs instance has the customState class');
 
         instance.setState('customState', false);
 
         assert.equal(instance.is('customState'), false, 'The breadcrumbs instance does not have the customState state');
-        assert.equal(instance.getContainer().hasClass('customState'), false, 'The breadcrumbs instance does not have the customState class');
+        assert.equal(instance.getElement().hasClass('customState'), false, 'The breadcrumbs instance does not have the customState class');
 
         instance.destroy();
     });

--- a/views/js/test/ui/component/test.js
+++ b/views/js/test/ui/component/test.js
@@ -46,6 +46,7 @@ define([
         { name : 'is', title : 'is' },
         { name : 'setState', title : 'setState' },
         { name : 'getContainer', title : 'getContainer' },
+        { name : 'getElement', title : 'getElement' },
         { name : 'getTemplate', title : 'getTemplate' },
         { name : 'setTemplate', title : 'setTemplate' }
     ];
@@ -112,14 +113,14 @@ define([
 
         assert.equal($container1.find('.dummy').length, 0, 'The container1 does not contain an element of the class dummy');
         assert.equal(instance.is('rendered'), true, 'The component instance must be rendered');
-        assert.equal(typeof instance.getContainer(), 'object', 'The component instance returns the rendered content as an object');
-        assert.equal(instance.getContainer().length, 1, 'The component instance returns the rendered content');
-        assert.equal(instance.getContainer().parent().get(0), $container1.get(0), 'The component instance is rendered inside the right container');
+        assert.equal(typeof instance.getElement(), 'object', 'The component instance returns the rendered content as an object');
+        assert.equal(instance.getElement().length, 1, 'The component instance returns the rendered content');
+        assert.equal(instance.getElement().parent().get(0), $container1.get(0), 'The component instance is rendered inside the right container');
 
         instance.destroy();
 
         assert.equal($container1.children().length, 0, 'The container1 is now empty');
-        assert.equal(instance.getContainer(), null, 'The component instance has removed its rendered content');
+        assert.equal(instance.getElement(), null, 'The component instance has removed its rendered content');
 
         // explicit render
         assert.equal($container2.children().length, 1, 'The container2 already contains an element');
@@ -131,15 +132,15 @@ define([
 
         assert.equal($container2.find('.dummy').length, 1, 'The container2 contains an element of the class dummy');
         assert.equal(instance.is('rendered'), true, 'The component instance must be rendered');
-        assert.equal(typeof instance.getContainer(), 'object', 'The component instance returns the rendered content as an object');
-        assert.equal(instance.getContainer().length, 1, 'The component instance returns the rendered content');
-        assert.equal(instance.getContainer().parent().get(0), $container2.get(0), 'The component instance is rendered inside the right container');
+        assert.equal(typeof instance.getElement(), 'object', 'The component instance returns the rendered content as an object');
+        assert.equal(instance.getElement().length, 1, 'The component instance returns the rendered content');
+        assert.equal(instance.getElement().parent().get(0), $container2.get(0), 'The component instance is rendered inside the right container');
 
         instance.destroy();
 
         assert.equal($container2.children().length, 1, 'The component has beend removed from the container2');
         assert.equal($container2.find('.dummy').length, 1, 'The container2 contains an element of the class dummy');
-        assert.equal(instance.getContainer(), null, 'The component instance has removed its rendered content');
+        assert.equal(instance.getElement(), null, 'The component instance has removed its rendered content');
 
         instance = component().init();
         instance.setTemplate(template);
@@ -150,85 +151,92 @@ define([
         instance.render($container3);
 
         assert.equal(instance.is('rendered'), true, 'The component instance must be rendered');
-        assert.equal(typeof instance.getContainer(), 'object', 'The component instance returns the rendered content as an object');
-        assert.equal(instance.getContainer().length, 1, 'The component instance returns the rendered content');
-        assert.equal(instance.getContainer().parent().get(0), $container3.get(0), 'The component instance is rendered inside the right container');
+        assert.equal(typeof instance.getElement(), 'object', 'The component instance returns the rendered content as an object');
+        assert.equal(instance.getElement().length, 1, 'The component instance returns the rendered content');
+        assert.equal(instance.getElement().parent().get(0), $container3.get(0), 'The component instance is rendered inside the right container');
         assert.equal($container3.html(), renderedTemplate, 'The component instance has rendered the right content');
 
         instance.destroy();
 
         assert.equal($container3.children().length, 0, 'The container1 is now empty');
-        assert.equal(instance.getContainer(), null, 'The component instance has removed its rendered content');
+        assert.equal(instance.getElement(), null, 'The component instance has removed its rendered content');
     });
 
 
     QUnit.test('show/hide', function(assert) {
-        var instance = component().init();
-        var $component = instance.render();
+        var instance = component()
+                        .init()
+                        .render();
+
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The component instance must be rendered');
         assert.equal($component.length, 1, 'The component instance returns the rendered content');
 
         assert.equal(instance.is('hidden'), false, 'The component instance is visible');
-        assert.equal(instance.getContainer().hasClass('hidden'), false, 'The component instance does not have the hidden class');
+        assert.equal(instance.getElement().hasClass('hidden'), false, 'The component instance does not have the hidden class');
 
         instance.hide();
 
         assert.equal(instance.is('hidden'), true, 'The component instance is hidden');
-        assert.equal(instance.getContainer().hasClass('hidden'), true, 'The component instance has the hidden class');
+        assert.equal(instance.getElement().hasClass('hidden'), true, 'The component instance has the hidden class');
 
         instance.show();
 
         assert.equal(instance.is('hidden'), false, 'The component instance is visible');
-        assert.equal(instance.getContainer().hasClass('hidden'), false, 'The component instance does not have the hidden class');
+        assert.equal(instance.getElement().hasClass('hidden'), false, 'The component instance does not have the hidden class');
 
         instance.destroy();
     });
 
 
     QUnit.test('enable/disable', function(assert) {
-        var instance = component().init();
-        var $component = instance.render();
+        var instance = component()
+                        .init()
+                        .render();
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The component instance must be rendered');
         assert.equal($component.length, 1, 'The component instance returns the rendered content');
 
         assert.equal(instance.is('disabled'), false, 'The component instance is enabled');
-        assert.equal(instance.getContainer().hasClass('disabled'), false, 'The component instance does not have the disabled class');
+        assert.equal(instance.getElement().hasClass('disabled'), false, 'The component instance does not have the disabled class');
 
         instance.disable();
 
         assert.equal(instance.is('disabled'), true, 'The component instance is disabled');
-        assert.equal(instance.getContainer().hasClass('disabled'), true, 'The component instance has the disabled class');
+        assert.equal(instance.getElement().hasClass('disabled'), true, 'The component instance has the disabled class');
 
         instance.enable();
 
         assert.equal(instance.is('disabled'), false, 'The component instance is enabled');
-        assert.equal(instance.getContainer().hasClass('disabled'), false, 'The component instance does not have the disabled class');
+        assert.equal(instance.getElement().hasClass('disabled'), false, 'The component instance does not have the disabled class');
 
         instance.destroy();
     });
 
 
     QUnit.test('state', function(assert) {
-        var instance = component().init();
-        var $component = instance.render();
+        var instance = component()
+                        .init()
+                        .render();
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The component instance must be rendered');
         assert.equal($component.length, 1, 'The component instance returns the rendered content');
 
         assert.equal(instance.is('customState'), false, 'The component instance does not have the customState state');
-        assert.equal(instance.getContainer().hasClass('customState'), false, 'The component instance does not have the customState class');
+        assert.equal(instance.getElement().hasClass('customState'), false, 'The component instance does not have the customState class');
 
         instance.setState('customState', true);
 
         assert.equal(instance.is('customState'), true, 'The component instance has the customState state');
-        assert.equal(instance.getContainer().hasClass('customState'), true, 'The component instance has the customState class');
+        assert.equal(instance.getElement().hasClass('customState'), true, 'The component instance has the customState class');
 
         instance.setState('customState', false);
 
         assert.equal(instance.is('customState'), false, 'The component instance does not have the customState state');
-        assert.equal(instance.getContainer().hasClass('customState'), false, 'The component instance does not have the customState class');
+        assert.equal(instance.getElement().hasClass('customState'), false, 'The component instance does not have the customState class');
 
         instance.destroy();
     });
@@ -237,7 +245,8 @@ define([
     QUnit.asyncTest('events', function(assert) {
         var instance = component();
 
-        QUnit.stop(7);
+        QUnit.expect(4);
+        QUnit.stop(3);
 
         instance.on('custom', function() {
             assert.ok(true, 'The component instance can handle custom events');
@@ -259,42 +268,11 @@ define([
             QUnit.start();
         });
 
-        instance.init({
-            oncustom : function() {
-                assert.ok(true, 'The component instance can handle custom events directly from its config');
-                QUnit.start();
-            },
-
-            oninit : function(ins) {
-                assert.ok(true, 'The component instance triggers event when it is initialized (handler set in config)');
-                assert.equal(ins, instance, 'The init event comes with instance as parameter');
-                QUnit.start();
-            },
-
-            onrender : function($dom, ins) {
-                assert.ok(true, 'The component instance triggers event when it is rendered (handler set in config)');
-                assert.equal($dom, instance.getContainer(), 'The render event comes with rendered content as parameter');
-                assert.equal(ins, instance, 'The render event comes with instance as parameter');
-                QUnit.start();
-            },
-
-            ondestroy : function(ins) {
-                assert.ok(true, 'The component instance triggers event when it is destroyed (handler set in config)');
-                assert.equal(ins, instance, 'The destroy event comes with instance as parameter');
-                QUnit.start();
-            }
-        });
-
-        assert.equal(instance.config.hasOwnProperty('oncustom'), false, 'The component instance did not forward the event custom to config');
-        assert.equal(instance.config.hasOwnProperty('oninit'), false, 'The component instance did not forward the event init to config');
-        assert.equal(instance.config.hasOwnProperty('onrender'), false, 'The component instance did not forward the event render to config');
-        assert.equal(instance.config.hasOwnProperty('ondestroy'), false, 'The component instance did not forward the event destroy to config');
-
-        instance.render();
-
-        instance.trigger('custom');
-
-        instance.destroy();
+        instance
+            .init()
+            .render()
+            .trigger('custom')
+            .destroy();
     });
 
 });

--- a/views/js/test/ui/listbox/test.js
+++ b/views/js/test/ui/listbox/test.js
@@ -52,6 +52,7 @@ define([
         { name : 'setTextEmpty', title : 'setTextEmpty' },
         { name : 'setTextLoading', title : 'setTextLoading' },
         { name : 'getContainer', title : 'getContainer' },
+        { name : 'getElement', title : 'getElement' },
         { name : 'getTemplate', title : 'getTemplate' },
         { name : 'setTemplate', title : 'setTemplate' }
     ];
@@ -124,42 +125,42 @@ define([
 
         assert.equal($container.find('.dummy').length, 0, 'The container does not contain an element of the class dummy');
         assert.equal(instance.is('rendered'), true, 'The listBox instance must be rendered');
-        assert.equal(typeof instance.getContainer(), 'object', 'The listBox instance returns the rendered content as an object');
-        assert.equal(instance.getContainer().length, 1, 'The listBox instance returns the rendered content');
-        assert.equal(instance.getContainer().parent().get(0), $container.get(0), 'The listBox instance is rendered inside the right container');
+        assert.equal(typeof instance.getElement(), 'object', 'The listBox instance returns the rendered content as an object');
+        assert.equal(instance.getElement().length, 1, 'The listBox instance returns the rendered content');
+        assert.equal(instance.getElement().parent().get(0), $container.get(0), 'The listBox instance is rendered inside the right container');
 
-        assert.equal(instance.getContainer().find('h1').text(), config.title, 'The listBox instance has rendered a title with the right content');
-        assert.equal(instance.getContainer().find('.empty-list').text(), config.textEmpty, 'The listBox instance has rendered a message to display when the list is empty, and set the right content');
-        assert.equal(instance.getContainer().find('.available-list .label').text(), config.textNumber, 'The listBox instance has rendered a message to show the number of boxes, and set the right content');
-        assert.equal(instance.getContainer().find('.loading').text(), config.textLoading + '...', 'The listBox instance has rendered a message to show when the component is in loading state, and set the right content');
+        assert.equal(instance.getElement().find('h1').text(), config.title, 'The listBox instance has rendered a title with the right content');
+        assert.equal(instance.getElement().find('.empty-list').text(), config.textEmpty, 'The listBox instance has rendered a message to display when the list is empty, and set the right content');
+        assert.equal(instance.getElement().find('.available-list .label').text(), config.textNumber, 'The listBox instance has rendered a message to show the number of boxes, and set the right content');
+        assert.equal(instance.getElement().find('.loading').text(), config.textLoading + '...', 'The listBox instance has rendered a message to show when the component is in loading state, and set the right content');
 
-        assert.equal(instance.getContainer().find('.list .entry').length, config.list.length, 'The listBox instance has rendered the list of boxes');
+        assert.equal(instance.getElement().find('.list .entry').length, config.list.length, 'The listBox instance has rendered the list of boxes');
 
         // 1st
-        assert.equal(instance.getContainer().find('.list .entry').first().hasClass('flex-col-8'), true, 'The listBox instance has set the right flex width in the first entry');
-        assert.equal(instance.getContainer().find('.list .entry').first().find('a').attr('href'), config.list[0].url, 'The listBox instance has set the right url in the first entry');
-        assert.equal(instance.getContainer().find('.list .entry').first().find('h3').text(), config.list[0].label, 'The listBox instance has set the right label in the first entry');
-        assert.equal(instance.getContainer().find('.list .entry').first().find('.content').html(), config.list[0].content, 'The listBox instance has set the content text in the first entry');
-        assert.equal(instance.getContainer().find('.list .entry').first().find('.text-link').text(), config.list[0].text, 'The listBox instance has set the right bottom text in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').first().hasClass('flex-col-8'), true, 'The listBox instance has set the right flex width in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').first().find('a').attr('href'), config.list[0].url, 'The listBox instance has set the right url in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').first().find('h3').text(), config.list[0].label, 'The listBox instance has set the right label in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').first().find('.content').html(), config.list[0].content, 'The listBox instance has set the content text in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').first().find('.text-link').text(), config.list[0].text, 'The listBox instance has set the right bottom text in the first entry');
 
         // 2nd
-        assert.equal(instance.getContainer().find('.list .entry').last().hasClass('flex-col-4'), true, 'The listBox instance has set the right flex width in the second entry');
-        assert.equal(instance.getContainer().find('.list .entry').last().hasClass('myclass'), true, 'The listBox instance has set an extra CSS class in the second entry');
-        assert.equal(instance.getContainer().find('.list .entry').last().find('a').attr('href'), config.list[1].url, 'The listBox instance has set the right url in the second entry');
-        assert.equal(instance.getContainer().find('.list .entry').last().find('h3').text(), config.list[1].label, 'The listBox instance has set the right label in the second entry');
-        assert.equal(instance.getContainer().find('.list .entry').last().find('.content').html(), config.list[1].content, 'The listBox instance has set the content text in the second entry');
-        assert.equal(instance.getContainer().find('.list .entry').last().find('.text-link').text(), config.list[1].text, 'The listBox instance has set the right bottom text in the second entry');
+        assert.equal(instance.getElement().find('.list .entry').last().hasClass('flex-col-4'), true, 'The listBox instance has set the right flex width in the second entry');
+        assert.equal(instance.getElement().find('.list .entry').last().hasClass('myclass'), true, 'The listBox instance has set an extra CSS class in the second entry');
+        assert.equal(instance.getElement().find('.list .entry').last().find('a').attr('href'), config.list[1].url, 'The listBox instance has set the right url in the second entry');
+        assert.equal(instance.getElement().find('.list .entry').last().find('h3').text(), config.list[1].label, 'The listBox instance has set the right label in the second entry');
+        assert.equal(instance.getElement().find('.list .entry').last().find('.content').html(), config.list[1].content, 'The listBox instance has set the content text in the second entry');
+        assert.equal(instance.getElement().find('.list .entry').last().find('.text-link').text(), config.list[1].text, 'The listBox instance has set the right bottom text in the second entry');
 
         instance.destroy();
 
         assert.equal($container.children().length, 0, 'The container is now empty');
-        assert.equal(instance.getContainer(), null, 'The listBox instance has removed its rendered content');
+        assert.equal(instance.getElement(), null, 'The listBox instance has removed its rendered content');
     });
 
 
     QUnit.test('update', function(assert) {
-        var instance = listBox();
-        var $component = instance.render();
+        var instance = listBox().render();
+        var $component = instance.getElement();
         var list = [{
             url: 'http://localhost/test',
             label: 'Test',
@@ -170,10 +171,10 @@ define([
         assert.equal(instance.is('rendered'), true, 'The listBox instance must be rendered');
         assert.equal($component.length, 1, 'The listBox instance returns the rendered content');
 
-        assert.equal(instance.getContainer().find('.list .entry').length, 0, 'The listBox instance has rendered an empty list');
-        assert.equal(instance.getContainer().hasClass('empty'), true, 'The listBox instance displays a message telling the list is empty');
-        assert.equal(instance.getContainer().hasClass('loaded'), false, 'The listBox instance does not display the number of boxes');
-        assert.equal(instance.getContainer().hasClass('loading'), false, 'The listBox instance is not loading');
+        assert.equal(instance.getElement().find('.list .entry').length, 0, 'The listBox instance has rendered an empty list');
+        assert.equal(instance.getElement().hasClass('empty'), true, 'The listBox instance displays a message telling the list is empty');
+        assert.equal(instance.getElement().hasClass('loaded'), false, 'The listBox instance does not display the number of boxes');
+        assert.equal(instance.getElement().hasClass('loading'), false, 'The listBox instance is not loading');
 
         assert.equal(instance.is('empty'), true, 'The listBox instance has the state empty');
         assert.equal(instance.is('loaded'), false, 'The listBox instance does not have the state loaded');
@@ -181,17 +182,17 @@ define([
 
         instance.update(list);
 
-        assert.equal(instance.getContainer().find('.list .entry').length, list.length, 'The listBox instance has rendered the list of boxes');
-        assert.equal(instance.getContainer().find('.list .entry').first().hasClass('flex-col-12'), true, 'The listBox instance has set the right flex width in the first entry');
-        assert.equal(instance.getContainer().find('.list .entry').first().find('a').attr('href'), list[0].url, 'The listBox instance has set the right url in the first entry');
-        assert.equal(instance.getContainer().find('.list .entry').first().find('h3').text(), list[0].label, 'The listBox instance has set the right label in the first entry');
-        assert.equal(instance.getContainer().find('.list .entry').first().find('.content').html(), list[0].content, 'The listBox instance has set the content text in the first entry');
-        assert.equal(instance.getContainer().find('.list .entry').first().find('.text-link').text(), list[0].text, 'The listBox instance has set the right bottom text in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').length, list.length, 'The listBox instance has rendered the list of boxes');
+        assert.equal(instance.getElement().find('.list .entry').first().hasClass('flex-col-12'), true, 'The listBox instance has set the right flex width in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').first().find('a').attr('href'), list[0].url, 'The listBox instance has set the right url in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').first().find('h3').text(), list[0].label, 'The listBox instance has set the right label in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').first().find('.content').html(), list[0].content, 'The listBox instance has set the content text in the first entry');
+        assert.equal(instance.getElement().find('.list .entry').first().find('.text-link').text(), list[0].text, 'The listBox instance has set the right bottom text in the first entry');
 
-        assert.equal(instance.getContainer().hasClass('empty'), false, 'The listBox instance does not display a message telling the list is empty');
-        assert.equal(instance.getContainer().hasClass('loaded'), true, 'The listBox instance displays the number of boxes');
-        assert.equal(instance.getContainer().hasClass('loading'), false, 'The listBox instance is not loading');
-        assert.equal(instance.getContainer().find('.available-list .count').text(), list.length, 'The listBox instance dispkays the right number of boxes');
+        assert.equal(instance.getElement().hasClass('empty'), false, 'The listBox instance does not display a message telling the list is empty');
+        assert.equal(instance.getElement().hasClass('loaded'), true, 'The listBox instance displays the number of boxes');
+        assert.equal(instance.getElement().hasClass('loading'), false, 'The listBox instance is not loading');
+        assert.equal(instance.getElement().find('.available-list .count').text(), list.length, 'The listBox instance dispkays the right number of boxes');
 
         assert.equal(instance.is('empty'), false, 'The listBox instance does not have the state empty');
         assert.equal(instance.is('loaded'), true, 'The listBox instance has the state loaded');
@@ -202,87 +203,87 @@ define([
 
 
     QUnit.test('show/hide', function(assert) {
-        var instance = listBox();
-        var $component = instance.render();
+        var instance = listBox().render();
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The listBox instance must be rendered');
         assert.equal($component.length, 1, 'The listBox instance returns the rendered content');
 
         assert.equal(instance.is('hidden'), false, 'The listBox instance is visible');
-        assert.equal(instance.getContainer().hasClass('hidden'), false, 'The listBox instance does not have the hidden class');
+        assert.equal(instance.getElement().hasClass('hidden'), false, 'The listBox instance does not have the hidden class');
 
         instance.hide();
 
         assert.equal(instance.is('hidden'), true, 'The listBox instance is hidden');
-        assert.equal(instance.getContainer().hasClass('hidden'), true, 'The listBox instance has the hidden class');
+        assert.equal(instance.getElement().hasClass('hidden'), true, 'The listBox instance has the hidden class');
 
         instance.show();
 
         assert.equal(instance.is('hidden'), false, 'The listBox instance is visible');
-        assert.equal(instance.getContainer().hasClass('hidden'), false, 'The listBox instance does not have the hidden class');
+        assert.equal(instance.getElement().hasClass('hidden'), false, 'The listBox instance does not have the hidden class');
 
         instance.destroy();
     });
 
 
     QUnit.test('enable/disable', function(assert) {
-        var instance = listBox();
-        var $component = instance.render();
+        var instance = listBox().render();
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The listBox instance must be rendered');
         assert.equal($component.length, 1, 'The listBox instance returns the rendered content');
 
         assert.equal(instance.is('disabled'), false, 'The listBox instance is enabled');
-        assert.equal(instance.getContainer().hasClass('disabled'), false, 'The listBox instance does not have the disabled class');
+        assert.equal(instance.getElement().hasClass('disabled'), false, 'The listBox instance does not have the disabled class');
 
         instance.disable();
 
         assert.equal(instance.is('disabled'), true, 'The listBox instance is disabled');
-        assert.equal(instance.getContainer().hasClass('disabled'), true, 'The listBox instance has the disabled class');
+        assert.equal(instance.getElement().hasClass('disabled'), true, 'The listBox instance has the disabled class');
 
         instance.enable();
 
         assert.equal(instance.is('disabled'), false, 'The listBox instance is enabled');
-        assert.equal(instance.getContainer().hasClass('disabled'), false, 'The listBox instance does not have the disabled class');
+        assert.equal(instance.getElement().hasClass('disabled'), false, 'The listBox instance does not have the disabled class');
 
         instance.destroy();
     });
 
 
     QUnit.test('state', function(assert) {
-        var instance = listBox();
-        var $component = instance.render();
+        var instance = listBox().render();
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The listBox instance must be rendered');
         assert.equal($component.length, 1, 'The listBox instance returns the rendered content');
 
         // loading
         assert.equal(instance.is('loading'), false, 'The listBox instance is not loading');
-        assert.equal(instance.getContainer().hasClass('loading'), false, 'The listBox instance does not have the loading class');
+        assert.equal(instance.getElement().hasClass('loading'), false, 'The listBox instance does not have the loading class');
 
         instance.setLoading(true);
 
         assert.equal(instance.is('loading'), true, 'The listBox instance is loading');
-        assert.equal(instance.getContainer().hasClass('loading'), true, 'The listBox instance has the loading class');
+        assert.equal(instance.getElement().hasClass('loading'), true, 'The listBox instance has the loading class');
 
         instance.setLoading(false);
 
         assert.equal(instance.is('loading'), false, 'The listBox instance is not loading');
-        assert.equal(instance.getContainer().hasClass('loading'), false, 'The listBox instance does not have the loading class');
+        assert.equal(instance.getElement().hasClass('loading'), false, 'The listBox instance does not have the loading class');
 
         // custom state
         assert.equal(instance.is('customState'), false, 'The listBox instance does not have the customState state');
-        assert.equal(instance.getContainer().hasClass('customState'), false, 'The listBox instance does not have the customState class');
+        assert.equal(instance.getElement().hasClass('customState'), false, 'The listBox instance does not have the customState class');
 
         instance.setState('customState', true);
 
         assert.equal(instance.is('customState'), true, 'The listBox instance has the customState state');
-        assert.equal(instance.getContainer().hasClass('customState'), true, 'The listBox instance has the customState class');
+        assert.equal(instance.getElement().hasClass('customState'), true, 'The listBox instance has the customState class');
 
         instance.setState('customState', false);
 
         assert.equal(instance.is('customState'), false, 'The listBox instance does not have the customState state');
-        assert.equal(instance.getContainer().hasClass('customState'), false, 'The listBox instance does not have the customState class');
+        assert.equal(instance.getElement().hasClass('customState'), false, 'The listBox instance does not have the customState class');
 
         instance.destroy();
     });
@@ -295,8 +296,8 @@ define([
             textNumber: 'Number',
             textLoading: 'Please wait'
         };
-        var instance = listBox();
-        var $component = instance.render();
+        var instance = listBox().render();
+        var $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The listBox instance must be rendered');
         assert.equal($component.length, 1, 'The listBox instance returns the rendered content');
@@ -306,32 +307,33 @@ define([
         assert.notEqual(instance.config.textNumber, config.textNumber, 'The listBox instance has its own number label');
         assert.notEqual(instance.config.textLoading, config.textLoading, 'The listBox instance has its own loading message');
 
-        assert.notEqual(instance.getContainer().find('h1').text(), config.title, 'The listBox instance has rendered a title with its own content');
-        assert.notEqual(instance.getContainer().find('.empty-list').text(), config.textEmpty, 'The listBox instance has rendered a message to display when the list is empty, and set its own content');
-        assert.notEqual(instance.getContainer().find('.available-list .label').text(), config.textNumber, 'The listBox instance has rendered a message to show the number of boxes, and set its own content');
-        assert.notEqual(instance.getContainer().find('.loading').text(), config.textLoading + '...', 'The listBox instance has rendered a message to show when the component is in loading state, and set its own content');
+        assert.notEqual(instance.getElement().find('h1').text(), config.title, 'The listBox instance has rendered a title with its own content');
+        assert.notEqual(instance.getElement().find('.empty-list').text(), config.textEmpty, 'The listBox instance has rendered a message to display when the list is empty, and set its own content');
+        assert.notEqual(instance.getElement().find('.available-list .label').text(), config.textNumber, 'The listBox instance has rendered a message to show the number of boxes, and set its own content');
+        assert.notEqual(instance.getElement().find('.loading').text(), config.textLoading + '...', 'The listBox instance has rendered a message to show when the component is in loading state, and set its own content');
 
         instance.setTitle(config.title);
         assert.equal(instance.config.title, config.title, 'The listBox instance has taken the right title');
-        assert.equal(instance.getContainer().find('h1').text(), config.title, 'The listBox instance has updated the title with the right content');
+        assert.equal(instance.getElement().find('h1').text(), config.title, 'The listBox instance has updated the title with the right content');
 
         instance.setTextEmpty(config.textEmpty);
         assert.equal(instance.config.textEmpty, config.textEmpty, 'The listBox instance has the right empty list message');
-        assert.equal(instance.getContainer().find('.empty-list').text(), config.textEmpty, 'The listBox instance has updated the message to display when the list is empty, and set the right content');
+        assert.equal(instance.getElement().find('.empty-list').text(), config.textEmpty, 'The listBox instance has updated the message to display when the list is empty, and set the right content');
 
         instance.setTextNumber(config.textNumber);
         assert.equal(instance.config.textNumber, config.textNumber, 'The listBox instance has the right number label');
-        assert.equal(instance.getContainer().find('.available-list .label').text(), config.textNumber, 'The listBox instance has updated the number label, and set the right content');
+        assert.equal(instance.getElement().find('.available-list .label').text(), config.textNumber, 'The listBox instance has updated the number label, and set the right content');
 
         instance.setTextLoading(config.textLoading);
         assert.equal(instance.config.textLoading, config.textLoading, 'The listBox instance has the right loading label');
-        assert.equal(instance.getContainer().find('.loading').text(), config.textLoading + '...', 'The listBox instance has updated the loading label, and set the right content');
+        assert.equal(instance.getElement().find('.loading').text(), config.textLoading + '...', 'The listBox instance has updated the loading label, and set the right content');
 
         instance.destroy();
 
         assert.equal(instance.is('rendered'), false, 'The listBox instance must be destroyed');
 
-        $component = instance.render();
+        instance.render();
+        $component = instance.getElement();
 
         assert.equal(instance.is('rendered'), true, 'The listBox instance must be rendered');
         assert.equal($component.length, 1, 'The listBox instance returns the rendered content');
@@ -341,9 +343,9 @@ define([
         assert.equal(instance.config.textNumber, config.textNumber, 'The listBox instance has its own number label');
         assert.equal(instance.config.textLoading, config.textLoading, 'The listBox instance has its own loading message');
 
-        assert.equal(instance.getContainer().find('h1').text(), config.title, 'The listBox instance has rendered a title with its own content');
-        assert.equal(instance.getContainer().find('.empty-list').text(), config.textEmpty, 'The listBox instance has rendered a message to display when the list is empty, and set its own content');
-        assert.equal(instance.getContainer().find('.available-list .label').text(), config.textNumber, 'The listBox instance has rendered a message to show the number of boxes, and set its own content');
-        assert.equal(instance.getContainer().find('.loading').text(), config.textLoading + '...', 'The listBox instance has rendered a message to show when the component is in loading state, and set its own content');
+        assert.equal(instance.getElement().find('h1').text(), config.title, 'The listBox instance has rendered a title with its own content');
+        assert.equal(instance.getElement().find('.empty-list').text(), config.textEmpty, 'The listBox instance has rendered a message to display when the list is empty, and set its own content');
+        assert.equal(instance.getElement().find('.available-list .label').text(), config.textNumber, 'The listBox instance has rendered a message to show the number of boxes, and set its own content');
+        assert.equal(instance.getElement().find('.loading').text(), config.textLoading + '...', 'The listBox instance has rendered a message to show when the component is in loading state, and set its own content');
     });
 });

--- a/views/js/ui/breadcrumbs.js
+++ b/views/js/ui/breadcrumbs.js
@@ -72,7 +72,7 @@ define([
     /**
      * Remove the link from the last crumb
      */
-    var removeLastLink = function() {
+    var removeLastLink = function removeLastLink() {
         var breadcrumbs = this.config.breadcrumbs;
 
         if (breadcrumbs && breadcrumbs.length) {
@@ -91,13 +91,11 @@ define([
      * @returns {breadcrumbs}
      */
     var breadcrumbsFactory = function breadcrumbsFactory(config) {
-        var instance = component(breadcrumbs);
-        instance.setTemplate(breadcrumbsTpl);
-
-        instance.on('init', removeLastLink);
-        instance.on('update', removeLastLink);
-
-        return instance.init(config);
+        return component(breadcrumbs)
+                .on('init', removeLastLink)
+                .on('update', removeLastLink)
+                .setTemplate(breadcrumbsTpl)
+                .init(config);
     };
 
     return breadcrumbsFactory;

--- a/views/js/ui/component.js
+++ b/views/js/ui/component.js
@@ -57,7 +57,13 @@ define([
              */
             init : function init(config) {
                 var self = this;
-                this.config = _.defaults(_.clone(config) || {}, defaults || {});
+
+                this.config = _(config || {})
+                                .omit(function(value){
+                                    return value === null || value === undefined;
+                                })
+                                .defaults(defaults || {})
+                                .value();
 
                 componentState = {};
 

--- a/views/js/ui/listbox.js
+++ b/views/js/ui/listbox.js
@@ -71,7 +71,9 @@ define([
                         width: this.config.width
                     }));
 
-                    $numberValue && $numberValue.text(list.length);
+                    if($numberValue){
+                        $numberValue.text(list.length);
+                    }
 
                     this.setState('empty', false);
                     this.setState('loaded', true);
@@ -126,10 +128,10 @@ define([
             var $textAvailable = this.controls && this.controls.$textAvailable;
             this.config.textNumber = text;
             if ($numberLabel) {
-                if (false === text) {
-                    $textAvailable && $textAvailable.addClass('hidden');
-                } else {
+                if(text !== false){
                     $numberLabel.html(text).removeClass('hidden');
+                } else if ($textAvailable){
+                    $textAvailable.addClass('hidden');
                 }
             }
 
@@ -188,38 +190,37 @@ define([
      * @param {Boolean} [config.replace] - When the component is appended to its container, clears the place before
      * @returns {listBox}
      */
-    var entryPointsFactory = function entryPointsFactory(config) {
-        var instance = component(listBox, _defaults);
+    var listBoxactory = function listBoxFactory(config) {
 
-        instance.setTemplate(mainTpl);
+        return component(listBox, _defaults)
+                .setTemplate(mainTpl)
 
-        // uninstalls the component
-        instance.on('destroy', function() {
-            this.controls = null;
-        });
+                // uninstalls the component
+                .on('destroy', function() {
+                    this.controls = null;
+                })
 
-        // renders the component
-        instance.on('render', function() {
-            this.controls = {
-                $title : this.$component.find('h1'),
-                $textEmpty : this.$component.find('.empty-list'),
-                $textAvailable : this.$component.find('.available-list'),
-                $textLoading : this.$component.find('.loading span'),
-                $numberLabel : this.$component.find('.available-list .label'),
-                $numberValue : this.$component.find('.available-list .count'),
-                $list : this.$component.find('.list')
-            };
+                // renders the component
+                .on('render', function() {
+                    this.controls = {
+                        $title : this.$component.find('h1'),
+                        $textEmpty : this.$component.find('.empty-list'),
+                        $textAvailable : this.$component.find('.available-list'),
+                        $textLoading : this.$component.find('.loading span'),
+                        $numberLabel : this.$component.find('.available-list .label'),
+                        $numberValue : this.$component.find('.available-list .count'),
+                        $list : this.$component.find('.list')
+                    };
 
-            if (this.config.list) {
-                this.update(this.config.list);
-            } else {
-                this.setState('empty', true);
-                this.setState('loaded', false);
-            }
-        });
-
-        return instance.init(config);
+                    if (this.config.list) {
+                        this.update(this.config.list);
+                    } else {
+                        this.setState('empty', true);
+                        this.setState('loaded', false);
+                    }
+                })
+                .init(config);
     };
 
-    return entryPointsFactory;
+    return listBoxactory;
 });


### PR DESCRIPTION
 changes : 
 - `getContainer` returns the component container (= renderTo) 
 - `getElement` (previously `getContainer`) returns the component element
 - `render` chains to the API and does not return the container anymore
 - events can only be attached using the eventifier API  (`on`) and there is no   `config.onSomething` anymore
 - events doesn't use the context in arguments as the eventifier delegates already the context on this.