### PR TITLE
deselect tree node before refresh

### DIFF
--- a/views/js/layout/tree.js
+++ b/views/js/layout/tree.js
@@ -411,6 +411,8 @@ define([
                     treeState = _.merge($elt.data('tree-state') || {}, data);
 
                     if (data && data.loadNode) {
+                        tree.deselect_branch(tree.selected);
+                        tree.settings.selected = false;
                         treeState.selectNode = data.loadNode;
                     }
                     $elt.data('tree-state', treeState);


### PR DESCRIPTION
I cannot reproduce it on my local installation of TAO but i figured out the problem.
Sometimes after click "Open" button request to the /taoItems/Items/editItem executed twice (first with current selected item id and second with item id which should be opened).
You can check it by following steps:
- create folder and item in this folder
- select any item in the root folder
- refresh the page (created folder should be closed)
- input in the search field name of the created item
- click the "Open" button

You will see that editItem request will be executed twice. If first request will finished after the second then previously selected item will be selected on the tree (as described in the issue).