### PR TITLE
Remove mime quotes

### DIFF
--- a/views/js/ui/resourcemgr/fileSelector.js
+++ b/views/js/ui/resourcemgr/fileSelector.js
@@ -1,3 +1,26 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+/**
+ *
+ * @author Bertrand <bertrand@taotesting.com>
+ */
 define([
     'jquery',
     'lodash',

--- a/views/js/ui/resourcemgr/fileSelector.js
+++ b/views/js/ui/resourcemgr/fileSelector.js
@@ -177,10 +177,11 @@ define([
 
                     //check the mime-type
                     if(options.params.filters){
-                        var filters = [];
+                        var filters = [],
+                            i;
 
                         if (!_.isString(options.params.filters)) {
-                            for(var i in options.params.filters){
+                            for(i in options.params.filters){
                                 filters.push(options.params.filters[i]['mime']);
                             }
                         } else {
@@ -188,7 +189,10 @@ define([
                         }
                         //TODO check stars
                         files = _.filter(files, function(file){
-                            return _.contains(filters, file.type);
+                            // Under rare circumstances a browser may report the mime type
+                            // with quotes (e.g. "application/foo" instead of application/foo)
+                            var checkType = file.type.replace(/^["']+|['"]+$/g, '');
+                            return _.contains(filters, checkType);
                         });
                          
                         if(files.length !== givenLength){


### PR DESCRIPTION
Under certain circumstances that are difficult to replicate a browser may report the mime type in quotes (e.g. "application/foo" instead of application/foo). This fix removes possibly existing surrounding quotes before checking against the filter list to avoid false positives.