### PR TITLE
Implement PhpSerializable interface

### DIFF
--- a/models/classes/requiredAction/RequiredActionAbstract.php
+++ b/models/classes/requiredAction/RequiredActionAbstract.php
@@ -117,6 +117,20 @@ abstract class RequiredActionAbstract implements RequiredActionInterface
     }
 
     /**
+     * @see \oat\oatbox\PhpSerializable::__toPhpCode()
+     */
+    public function __toPhpCode()
+    {
+        $class = get_class($this);
+        $name = $this->name;
+        $rules = \common_Utils::toHumanReadablePhpString($this->getRules());
+        return "new $class(
+            '$name',
+            $rules
+        )";
+    }
+
+    /**
      * Check rules whether action must be performed.
      * If at least one rule returns true the action will be performed.
      * If result is `true` then action must be performed.

--- a/models/classes/requiredAction/RequiredActionInterface.php
+++ b/models/classes/requiredAction/RequiredActionInterface.php
@@ -20,6 +20,7 @@
  */
 
 namespace oat\tao\model\requiredAction;
+use oat\oatbox\PhpSerializable;
 
 /**
  * Interface RequiredActionInterface
@@ -29,7 +30,7 @@ namespace oat\tao\model\requiredAction;
  * @package oat\tao\model\requiredAction
  * @author Aleh Hutnilau <hutnikau@1pt.com>
  */
-interface RequiredActionInterface
+interface RequiredActionInterface extends PhpSerializable
 {
     /**
      * @return string

--- a/models/classes/requiredAction/RequiredActionRuleInterface.php
+++ b/models/classes/requiredAction/RequiredActionRuleInterface.php
@@ -20,7 +20,7 @@
  */
 
 namespace oat\tao\model\requiredAction;
-
+use oat\oatbox\PhpSerializable;
 /**
  * Interface RequiredActionRuleInterface
  *
@@ -29,7 +29,7 @@ namespace oat\tao\model\requiredAction;
  * @package oat\tao\model\requiredAction
  * @author Aleh Hutnilau <hutnikau@1pt.com>
  */
-interface RequiredActionRuleInterface
+interface RequiredActionRuleInterface extends PhpSerializable
 {
     /**
      * Check the rule.

--- a/models/classes/requiredAction/implementation/RequiredActionRedirect.php
+++ b/models/classes/requiredAction/implementation/RequiredActionRedirect.php
@@ -87,6 +87,22 @@ class RequiredActionRedirect extends RequiredActionAbstract
     }
 
     /**
+     * @see \oat\oatbox\PhpSerializable::__toPhpCode()
+     */
+    public function __toPhpCode()
+    {
+        $class = get_class($this);
+        $name = $this->name;
+        $url = $this->url;
+        $rules = \common_Utils::toHumanReadablePhpString($this->getRules());
+        return "new $class(
+            '$name',
+            $rules,
+            '$url'
+        )";
+    }
+
+    /**
      * Some actions should not be redirected (such as retrieving requireJs config)
      * @return array
      */

--- a/models/classes/requiredAction/implementation/TimeRule.php
+++ b/models/classes/requiredAction/implementation/TimeRule.php
@@ -109,11 +109,19 @@ class TimeRule implements RequiredActionRuleInterface
     public function __toPhpCode()
     {
         $class = get_class($this);
-        $interval = serialize($this->getInterval());
-        $executionTime = serialize($this->getExecutionTime());
+        $executionTime = $this->getExecutionTime();
+        if ($executionTime === null) {
+            $serializedExecutionTime = 'null';
+        } else {
+            $serializedExecutionTime = 'new \DateTime(' . $executionTime->getTimestamp() . ')';
+        }
+
+        $interval = $this->getInterval();
+        $serializedInterval = 'new \DateInterval("' . $interval->format('P%yY%mM%dDT%hH%iM%sS') . '")';
+
         return "new $class(
-            unserialize('$interval'),
-            unserialize('$executionTime')
+            $serializedInterval,
+            $serializedExecutionTime
         )";
     }
 

--- a/models/classes/requiredAction/implementation/TimeRule.php
+++ b/models/classes/requiredAction/implementation/TimeRule.php
@@ -104,6 +104,20 @@ class TimeRule implements RequiredActionRuleInterface
     }
 
     /**
+     * @see \oat\oatbox\PhpSerializable::__toPhpCode()
+     */
+    public function __toPhpCode()
+    {
+        $class = get_class($this);
+        $interval = serialize($this->getInterval());
+        $executionTime = serialize($this->getExecutionTime());
+        return "new $class(
+            unserialize('$interval'),
+            unserialize('$executionTime')
+        )";
+    }
+
+    /**
      * Check if it is time to perform an action.
      * If `$this->lastExecution` is null (action has never been executed)
      * or since the last execution took time more than specified interval (`$this->interval`) then action must be performed.


### PR DESCRIPTION
I have implemented `__toPhpCode()` method for action and rule classes but `TimeRule::__construct` waits to get `DateInterval` and `DateTime` instances. Obviously these objects has no `__toPhpCode()` method so i just serialized it.

So, config looks like this:

```php
return new oat\tao\model\requiredAction\implementation\RequiredActionService(array(
    'required_actions' => array(
        new oat\tao\model\requiredAction\implementation\RequiredActionRedirect(
            'codeOfConduct',
            array(
                new oat\taoAct\model\requiredAction\implementation\CodeOfConductRule(
                    unserialize('O:12:"DateInterval":15:{s:1:"y";i:1;s:1:"m";i:0;s:1:"d";i:0;s:1:"h";i:0;s:1:"i";i:0;s:1:"s";i:0;s:7:"weekday";i:0;s:16:"weekday_behavior";i:0;s:17:"first_last_day_of";i:0;s:6:"invert";i:0;s:4:"days";b:0;s:12:"special_type";i:0;s:14:"special_amount";i:0;s:21:"have_weekday_relative";i:0;s:21:"have_special_relative";i:0;}'),
                    unserialize('N;')
                )
            ),
            'http://package-tao/taoAct/RequiredAction/codeofconduct'
        )
    )
));
```

I believe it acceptable.