### PR TITLE
hide search icon when advanced mode is active for custom properties

### DIFF
--- a/views/js/form/post-render-props.js
+++ b/views/js/form/post-render-props.js
@@ -100,6 +100,8 @@ define([
                 var $property = $(this);
                 if($property.attr !== undefined){
                     var type = (function() {
+                        var $propertyMode = $('.property-mode');
+
                         switch($property.attr('id').replace(/_?property_[\d]+/, '')) {
                             case 'ro':
                                 return 'readonly-property';
@@ -117,7 +119,6 @@ define([
                                 _hideProperties($editContainer);
                                 _hideIndexes($editContainer);
 
-                                var $propertyMode = $('.property-mode');
                                 if ($propertyMode.hasClass('property-mode-simple')) {
                                     $indexIcon.hide();
                                 } else if($propertyMode.hasClass('property-mode-advanced')) {

--- a/views/js/form/post-render-props.js
+++ b/views/js/form/post-render-props.js
@@ -117,6 +117,13 @@ define([
                                 _hideProperties($editContainer);
                                 _hideIndexes($editContainer);
 
+                                var $propertyMode = $('.property-mode');
+                                if ($propertyMode.hasClass('property-mode-simple')) {
+                                    $indexIcon.hide();
+                                } else if($propertyMode.hasClass('property-mode-advanced')) {
+                                    $indexIcon.show();
+                                }
+
                                 //on click on edit icon show property form or hide it
                                 $editIcon.on('click', function() {
                                     //form is close so open it (hide index, show property)

--- a/views/js/test/form/post-render-prop/test.html
+++ b/views/js/test/form/post-render-prop/test.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Form Test - Post-render-props</title>
+        <base href="../../../../" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="form/post-render-props.js"></script>
+        <script  type="text/javascript">
+            
+            //don't start the test now
+            QUnit.config.autostart = false;
+            
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+                
+                //load the test
+                require(['test/form/post-render-prop/test'], function(){
+                    
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div class="content-block">
+                <div class="xhtml_form">
+                    <form>
+                        <div id="property_xxx" class="form-group">
+                            <span class="icon-find"></span>
+                        </div>
+                        <a href="#" class="property-mode"></a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/views/js/test/form/post-render-prop/test.js
+++ b/views/js/test/form/post-render-prop/test.js
@@ -1,0 +1,38 @@
+define(['jquery', 'form/post-render-props'], function($, postRenderProps){
+    'use strict';
+
+    QUnit.module('form/post-render-props');
+
+    QUnit.test('module', function(assert){
+        assert.ok(typeof postRenderProps === 'object', 'The module expose an object');
+    });
+
+    QUnit.test('index icon visibility in Advanced mode', function(assert) {
+        var $testScope = $('#qunit-fixture');
+
+        // setup advanced mode
+        // mode state is stored in .property-mode, as a toggle for the opposite mode
+        $testScope.find('.property-mode').removeClass('property-mode-advanced');
+        $testScope.find('.property-mode').addClass('property-mode-simple');
+
+        postRenderProps.init();
+
+        var indexIconVisibility = $testScope.find('.icon-find').is(':visible');
+        assert.ok(!indexIconVisibility, 'index icon should be invisible!');
+    });
+
+    QUnit.test('index icon visibility in Simple mode', function(assert) {
+        var $testScope = $('#qunit-fixture');
+
+        // setup simple mode
+        $testScope.find('.property-mode').addClass('property-mode-advanced');
+        $testScope.find('.property-mode').removeClass('property-mode-simple');
+
+        postRenderProps.init();
+
+        var indexIconVisibility = $testScope.find('.icon-find').is(':visible');
+        assert.ok(indexIconVisibility, 'index icon should be visible!');
+    });
+});
+
+


### PR DESCRIPTION
this was not a bug, as the "expected behaviour" wasn't implemented on purpose.

However, I think this is misleading having a button with no behaviour implemented, so I decided to hide it when in advanced mode.