### PR TITLE
feature/async-process

### DIFF
--- a/views/js/core/asyncProcess.js
+++ b/views/js/core/asyncProcess.js
@@ -1,0 +1,107 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'lodash',
+    'core/promise'
+], function (_, Promise) {
+    'use strict';
+
+    /**
+     * Defines a manager for async process with deferred steps.
+     * It will start the process only if it is not already running.
+     * The running process must register each deferred steps, and it must also notify its logical end
+     * (i.e.: when its main stuff is finished, no matter if the deferred steps are also finished)
+     * @returns {asyncProcess}
+     */
+    function asyncProcessFactory() {
+        var running = false;
+        var steps = [];
+
+        return {
+            /**
+             * Tells if a process is running
+             * @returns {Boolean}
+             */
+            isRunning: function isRunning() {
+                return running;
+            },
+
+            /**
+             * Start a new process if there is no running process.
+             * @param {Function} [cb] - The process to start
+             * @returns {boolean} - Returns true if the process can be started
+             */
+            start: function start(cb) {
+                var started = false;
+                if (!running) {
+                    steps = [];
+                    running = true;
+                    started = true;
+                    if (_.isFunction(cb)) {
+                        cb();
+                    }
+                }
+                return started;
+            },
+
+            /**
+             * Add a process step by providing a promise.
+             * The manager will wait for this promise to declare the process is finished.
+             * @param {Promise} step
+             * @returns {asyncProcess}
+             */
+            addStep: function addStep(step) {
+                steps.push(step);
+                return this;
+            },
+
+            /**
+             * Notifies the logical end of the running process. The deferred steps may still be running at this time.
+             * Note: All the deferred steps must be already registered. No later registration will be accepted.
+             * @param {Function} [cb] - A nodeback like function which will be called when all the deferred steps have finished or an error occurs
+             * @returns {Promise} - Returns the finish promise
+             */
+            done: function done(cb) {
+                var finish = Promise.all(steps);
+
+                finish
+                    .then(function(data) {
+                        running = false;
+
+                        if (_.isFunction(cb)) {
+                            cb(null, data);
+                        }
+                    })
+                    .catch(function(error) {
+                        running = false;
+
+                        if (_.isFunction(cb)) {
+                            cb(error || true);
+                        }
+                    });
+
+                return finish;
+            }
+        }
+    }
+
+    return asyncProcessFactory;
+});

--- a/views/js/test/core/asyncProcess/test.html
+++ b/views/js/test/core/asyncProcess/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test - AsyncProcess</title>
+    <base href="../../../../" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="core/asyncProcess.js"></script>
+
+    <script  type="text/javascript">
+
+        //don't start the test now
+        QUnit.config.autostart = false;
+
+        //load the config
+        require(['/tao/ClientConfig/config'], function(){
+
+            //load the test
+            require(['test/core/asyncProcess/test'], function(){
+
+                //Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/core/asyncProcess/test.js
+++ b/views/js/test/core/asyncProcess/test.js
@@ -1,0 +1,245 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien.conan@vesperiagroup.com>
+ */
+define([
+    'lodash',
+    'core/promise',
+    'core/asyncProcess'
+], function (_, Promise, asyncProcessFactory) {
+    'use strict';
+
+    QUnit.module('asyncProcess');
+
+
+    QUnit.test('factory', function (assert) {
+        QUnit.expect(3);
+        assert.ok(typeof asyncProcessFactory === 'function', 'the module exposes a function');
+        assert.ok(typeof asyncProcessFactory() === 'object', 'the factory produces an object');
+        assert.ok(asyncProcessFactory() !== asyncProcessFactory(), 'the factory produces a different object at each call');
+    });
+
+
+    var asyncProcessApi = [
+        {name: 'isRunning', title: 'isRunning'},
+        {name: 'start', title: 'start'},
+        {name: 'addStep', title: 'addStep'},
+        {name: 'done', title: 'done'}
+    ];
+
+    QUnit
+        .cases(asyncProcessApi)
+        .test('asyncProcess API ', 1, function (data, assert) {
+            QUnit.expect(1);
+
+            var asyncProcess = asyncProcessFactory();
+
+            assert.equal(typeof asyncProcess[data.name], 'function', 'The asyncProcess expose a "' + data.name + '" function');
+        });
+
+
+    QUnit.asyncTest('simple process', function (assert) {
+        QUnit.expect(9);
+
+        var asyncProcess = asyncProcessFactory();
+
+        assert.equal(asyncProcess.isRunning(), false, 'There is no running process at this time');
+
+        assert.equal(asyncProcess.start(), true, 'The process has started');
+
+        assert.equal(asyncProcess.start(), false, 'No other process can start until the current one is finished');
+
+        assert.equal(asyncProcess.isRunning(), true, 'There is a running process at this time');
+
+        var p = asyncProcess.done(function (err) {
+            assert.ok(!err, 'No error is reported by the handler');
+            assert.equal(asyncProcess.isRunning(), false, 'The process is now finished');
+            QUnit.start();
+        });
+
+        QUnit.stop();
+
+        assert.ok('object' === typeof p, 'The done method returns an object');
+        assert.ok('function' === typeof p.then && 'function' === typeof p.catch, 'The done method returns a promise');
+
+        p.then(function () {
+            assert.ok(true, 'The promise is resolved');
+            QUnit.start();
+        }).catch(function () {
+            assert.ok(false, 'The promise must not be rejected');
+            QUnit.start();
+        })
+    });
+
+
+    QUnit.asyncTest('deferred process', function (assert) {
+        QUnit.expect(11);
+        QUnit.stop();
+
+        var asyncProcess = asyncProcessFactory();
+
+        function process() {
+            assert.ok(true, 'The process main has been called');
+            assert.ok(asyncProcess.isRunning(), 'The process is running');
+
+            setTimeout(function() {
+                var p = asyncProcess.done(function (err) {
+                    assert.ok(!err, 'No error is reported by the handler');
+                    assert.equal(asyncProcess.isRunning(), false, 'The process is now finished');
+                    QUnit.start();
+                });
+
+                assert.ok('object' === typeof p, 'The done method returns an object');
+                assert.ok('function' === typeof p.then && 'function' === typeof p.catch, 'The done method returns a promise');
+
+                p.then(function () {
+                    assert.ok(true, 'The promise is resolved');
+                    QUnit.start();
+                }).catch(function () {
+                    assert.ok(false, 'The promise must not be rejected');
+                    QUnit.start();
+                })
+            }, 250);
+        }
+
+        assert.equal(asyncProcess.isRunning(), false, 'There is no running process at this time');
+
+        assert.equal(asyncProcess.start(process), true, 'The process has started');
+
+        assert.equal(asyncProcess.start(process), false, 'No other process can start until the current one is finished');
+
+        assert.equal(asyncProcess.isRunning(), true, 'There is a running process at this time');
+    });
+
+
+    QUnit.asyncTest('process with steps', function (assert) {
+        QUnit.expect(17);
+        QUnit.stop();
+
+        var asyncProcess = asyncProcessFactory();
+
+        function process() {
+            assert.ok(true, 'The process main has been called');
+            assert.ok(asyncProcess.isRunning(), 'The process is running');
+
+            asyncProcess.addStep(new Promise(function(resolve) {
+                setTimeout(function() {
+                    resolve(1);
+                }, 300);
+            }));
+
+            asyncProcess.addStep(new Promise(function(resolve) {
+                setTimeout(function() {
+                    resolve(2);
+                }, 400);
+            }));
+
+            setTimeout(function() {
+                var p = asyncProcess.done(function (err, data) {
+                    assert.ok(!err, 'No error is reported by the handler');
+                    assert.equal(asyncProcess.isRunning(), false, 'The process is now finished');
+
+                    assert.ok(_.isArray(data), 'The resolved data has been provided');
+                    assert.ok(_.indexOf(data, 1) !== -1, 'The data contains the first resolved step');
+                    assert.ok(_.indexOf(data, 2) !== -1, 'The data contains the second resolved step');
+
+                    QUnit.start();
+                });
+
+                assert.ok('object' === typeof p, 'The done method returns an object');
+                assert.ok('function' === typeof p.then && 'function' === typeof p.catch, 'The done method returns a promise');
+
+                p.then(function (data) {
+                    assert.ok(true, 'The promise is resolved');
+
+                    assert.ok(_.isArray(data), 'The resolved data has been provided');
+                    assert.ok(_.indexOf(data, 1) !== -1, 'The data contains the first resolved step');
+                    assert.ok(_.indexOf(data, 2) !== -1, 'The data contains the second resolved step');
+
+                    QUnit.start();
+                }).catch(function () {
+                    assert.ok(false, 'The promise must not be rejected');
+                    QUnit.start();
+                })
+            }, 250);
+        }
+
+        assert.equal(asyncProcess.isRunning(), false, 'There is no running process at this time');
+
+        assert.equal(asyncProcess.start(process), true, 'The process has started');
+
+        assert.equal(asyncProcess.start(process), false, 'No other process can start until the current one is finished');
+
+        assert.equal(asyncProcess.isRunning(), true, 'There is a running process at this time');
+    });
+
+
+    QUnit.asyncTest('process with errors', function (assert) {
+        QUnit.expect(11);
+        QUnit.stop();
+
+        var asyncProcess = asyncProcessFactory();
+
+        function process() {
+            assert.ok(true, 'The process main has been called');
+            assert.ok(asyncProcess.isRunning(), 'The process is running');
+
+            asyncProcess.addStep(new Promise(function(resolve, reject) {
+                setTimeout(function() {
+                    reject('oups');
+                }, 300);
+            }));
+
+            asyncProcess.addStep(new Promise(function(resolve) {
+                setTimeout(function() {
+                    resolve(2);
+                }, 400);
+            }));
+
+            setTimeout(function() {
+                var p = asyncProcess.done(function (err, data) {
+                    assert.equal(err, 'oups', 'An error is reported by the handler');
+                    assert.equal(asyncProcess.isRunning(), false, 'The process is now finished');
+
+                    QUnit.start();
+                });
+
+                assert.ok('object' === typeof p, 'The done method returns an object');
+                assert.ok('function' === typeof p.then && 'function' === typeof p.catch, 'The done method returns a promise');
+
+                p.then(function () {
+                    assert.ok(false, 'The promise must be rejected!');
+                    QUnit.start();
+                }).catch(function (err) {
+                    assert.equal(err, 'oups', 'An error is reported by the handler');
+                    QUnit.start();
+                })
+            }, 250);
+        }
+
+        assert.equal(asyncProcess.isRunning(), false, 'There is no running process at this time');
+
+        assert.equal(asyncProcess.start(process), true, 'The process has started');
+
+        assert.equal(asyncProcess.start(process), false, 'No other process can start until the current one is finished');
+
+        assert.equal(asyncProcess.isRunning(), true, 'There is a running process at this time');
+    });
+
+});

--- a/views/js/test/core/asyncProcess/test.js
+++ b/views/js/test/core/asyncProcess/test.js
@@ -55,9 +55,23 @@ define([
 
 
     QUnit.asyncTest('simple process', function (assert) {
-        QUnit.expect(9);
+        QUnit.expect(11);
 
         var asyncProcess = asyncProcessFactory();
+
+        asyncProcess
+            .on('start', function() {
+                assert.ok(true, 'The process is started');
+                QUnit.start();
+            })
+            .on('resolve', function() {
+                assert.ok(true, 'The process is finished and the resolve event has been triggered');
+                QUnit.start();
+            })
+            .on('reject', function() {
+                assert.ok(false, 'The process is finished and the reject event has been triggered');
+                QUnit.start();
+            });
 
         assert.equal(asyncProcess.isRunning(), false, 'There is no running process at this time');
 
@@ -73,7 +87,7 @@ define([
             QUnit.start();
         });
 
-        QUnit.stop();
+        QUnit.stop(3);
 
         assert.ok('object' === typeof p, 'The done method returns an object');
         assert.ok('function' === typeof p.then && 'function' === typeof p.catch, 'The done method returns a promise');
@@ -89,10 +103,24 @@ define([
 
 
     QUnit.asyncTest('deferred process', function (assert) {
-        QUnit.expect(11);
-        QUnit.stop();
+        QUnit.expect(13);
+        QUnit.stop(3);
 
         var asyncProcess = asyncProcessFactory();
+
+        asyncProcess
+            .on('start', function() {
+                assert.ok(true, 'The process is started');
+                QUnit.start();
+            })
+            .on('resolve', function() {
+                assert.ok(true, 'The process is finished and the resolve event has been triggered');
+                QUnit.start();
+            })
+            .on('reject', function() {
+                assert.ok(false, 'The process is finished and the reject event has been triggered');
+                QUnit.start();
+            });
 
         function process() {
             assert.ok(true, 'The process main has been called');
@@ -129,10 +157,32 @@ define([
 
 
     QUnit.asyncTest('process with steps', function (assert) {
-        QUnit.expect(17);
-        QUnit.stop();
+        QUnit.expect(24);
+        QUnit.stop(5);
 
         var asyncProcess = asyncProcessFactory();
+
+        asyncProcess
+            .on('start', function() {
+                assert.ok(true, 'The process is started');
+                QUnit.start();
+            })
+            .on('step', function() {
+                assert.ok(true, 'A step has been added');
+                QUnit.start();
+            })
+            .on('resolve', function(data) {
+                assert.ok(true, 'The process is finished and the resolve event has been triggered');
+
+                assert.ok(_.isArray(data), 'The resolved data has been provided');
+                assert.ok(_.indexOf(data, 1) !== -1, 'The data contains the first resolved step');
+                assert.ok(_.indexOf(data, 2) !== -1, 'The data contains the second resolved step');
+                QUnit.start();
+            })
+            .on('reject', function() {
+                assert.ok(false, 'The process is finished and the reject event has been triggered');
+                QUnit.start();
+            });
 
         function process() {
             assert.ok(true, 'The process main has been called');
@@ -191,10 +241,25 @@ define([
 
 
     QUnit.asyncTest('process with errors', function (assert) {
-        QUnit.expect(11);
-        QUnit.stop();
+        QUnit.expect(14);
+        QUnit.stop(3);
 
         var asyncProcess = asyncProcessFactory();
+
+        asyncProcess
+            .on('start', function() {
+                assert.ok(true, 'The process is started');
+                QUnit.start();
+            })
+            .on('resolve', function() {
+                assert.ok(false, 'The process is finished and the resolve event has been triggered');
+                QUnit.start();
+            })
+            .on('reject', function(err) {
+                assert.ok(true, 'The process is finished and the reject event has been triggered');
+                assert.equal(err, 'oups', 'An error is reported by the handler');
+                QUnit.start();
+            });
 
         function process() {
             assert.ok(true, 'The process main has been called');
@@ -213,7 +278,7 @@ define([
             }));
 
             setTimeout(function() {
-                var p = asyncProcess.done(function (err, data) {
+                var p = asyncProcess.done(function (err) {
                     assert.equal(err, 'oups', 'An error is reported by the handler');
                     assert.equal(asyncProcess.isRunning(), false, 'The process is now finished');
 


### PR DESCRIPTION
Add a core module to handle async process with deferred steps:
- start a process with no concurrence (only one at once): `asyncProcess.start(Function)`
- the process can register deferred steps: `asyncProcess.addStep(Promise)`
- the process declare its logical end: `asyncProcess.done(Function)`
- the manager will wait for all steps to finish and to allow new run