### PR TITLE
better support of dropped files

### DIFF
--- a/views/js/ui/uploader.js
+++ b/views/js/ui/uploader.js
@@ -215,9 +215,20 @@ define([
                             .on('dragend', dragOutHandler)
                             .on('dragleave', dragOutHandler)
                             .on('drop', function(e){
+                                var files = [];
                                 dragOutHandler(e);
 
-                                self._selectFiles($elt, _.values(e.target.files || e.originalEvent.files || e.originalEvent.dataTransfer.files), options.$dropZone.children('ul').length > 0);
+                                if(e.target.files){
+                                    files = _.values(e.target.files);
+                                } else if ( e.originalEvent.files){
+                                    files = _.values(e.originalEvent.files);
+                                } else if ( e.originalEvent.dataTransfer && e.originalEvent.dataTransfer.files){
+                                    files = _.values(e.originalEvent.dataTransfer.files);
+                                }
+
+                                if(files && files.length){
+                                    self._selectFiles($elt, files, options.$dropZone.children('ul').length > 0);
+                                }
                                 return false;
                             });
                     } else {


### PR DESCRIPTION
I was not able to reproduce the drag 'n drop issue, but while debugging, sometime the `dataTransfer`  from 'e.originalEvent` is null and then an error is thrown.

This is only a safety fix.

Test in different browsers if you can:
 - import a test or an item using drag and drop.
 - download one or multiple images from the item creator