### PR TITLE
fix test names in the build report

### DIFF
--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -23,9 +23,18 @@ module.exports = function(grunt) {
     grunt.config('qunit_junit', {
         options : {
             dest : reportOutput,
+
             fileNamer : function(url){
                 return url
                     .replace(testUrl + '/', '')
+                    .replace('/test.html', '')
+                    .replace(/\//g, '.');
+            },
+
+            classNamer : function (moduleName, url) {
+                return url
+                    .replace(testUrl + '/', '')
+                    .replace('views/js/test/', '')
                     .replace('/test.html', '')
                     .replace(/\//g, '.');
             }


### PR DESCRIPTION
It was difficult to figure which test was failing in the reports. You can test the difference using :
```sh
grunt connect qunit_junit qunit:single --test=/tao/views/js/test/core/timer/test.html
```
and then check the file `reports/TEST-tao.views.js.test.core.timer.xml`