### PR TITLE
Add reset to first page when filtering was used

### DIFF
--- a/views/js/ui/datatable.js
+++ b/views/js/ui/datatable.js
@@ -579,6 +579,7 @@ define([
             // set correct filter data
             options.filterquery = query;
             options.filtercolumns = (columns && columns.length) ? columns : [];
+            options.page = 1;
 
             //rebind options to the elt
             $elt.data(dataNs, options);


### PR DESCRIPTION
Issue: When a user is navigating a list of data and is on a page after the first, and then does a filter which results in only one page, then the user is not brought back to the first page.

This PR fix described issue.