### PR TITLE
Feature/tao 2497 core areabroker

### DIFF
--- a/views/js/core/areaBroker.js
+++ b/views/js/core/areaBroker.js
@@ -1,0 +1,129 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technlogies SA
+ *
+ */
+
+/**
+ * The area broker is a kind of areas hub, it gives the access to predefined areas.
+ *
+ *
+ * @example
+ * var broker = areaBroker(['content', 'panel'], $container);
+ * broker.defineAreas({
+ *    content : $('.content', $container),
+ *    //...
+ * });
+ *
+ * //then
+ * var $content = broker.getArea('content');
+ * var $content = broker.getContentArea();
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'jquery',
+    'lodash'
+], function ($, _) {
+    'use strict';
+
+    /**
+     * Creates a new area broker.
+     * @param {String[]} requireAreas - the list of required areas to map
+     * @param {jQueryElement|HTMLElement|String} $container - the main container
+     * @param {Object} mapping - keys are the area names, values are jQueryElement
+     * @returns {broker} the broker
+     * @throws {TypeError} without a valid container
+     */
+    return function areaBroker(requiredAreas, $container, mapping){
+
+        var broker,
+            areas;
+
+        if(typeof $container === 'string' || $container instanceof HTMLElement){
+            $container = $($container);
+        }
+        if(!$container || !$container.length){
+            throw new TypeError('Please provide the areaBroker a container');
+        }
+
+        requiredAreas = requiredAreas || [];
+
+        /**
+         * The Area broker instance
+         * @typedef broker
+         */
+        broker = {
+
+            /**
+             * Map the areas to elements.
+             *
+             * This method needs to be called before getting areas.
+             * It's separated from the factory call in order to prepare the mapping in a separated step.
+             *
+             * @param {Object} mapping - keys are the area names, values are jQueryElement
+             * @throws {TypeError} if the required areas are not part of the mapping
+             */
+            defineAreas : function defineAreas(mapping){
+                var keys, required;
+
+                if(!_.isPlainObject(mapping)){
+                    throw new TypeError('A mapping has the form of a plain object');
+                }
+
+                keys = _.keys(mapping);
+                required = _.all(requiredAreas, function(val){
+                    return _.contains(keys, val);
+                });
+                if(!required){
+                    throw new TypeError('You have to define a mapping for at least : ' + requiredAreas.join(', '));
+                }
+
+                areas = mapping;
+            },
+
+            /**
+             * Get the main container
+             * @returns {jQueryElement} the container
+             */
+            getContainer : function getContainer(){
+                return $container;
+            },
+
+            /**
+             * Get the area element
+             * @param {String} name - the area name
+             * @returns {jQueryElement} the area element
+             * @throws {Error} if the mapping hasn't been made previously
+             */
+            getArea : function getArea(name){
+                if(!areas){
+                    throw new Error('Sorry areas have not been defined yet!');
+                }
+                return areas[name];
+            }
+        };
+
+        broker.defineAreas(mapping);
+
+        _.forEach(requiredAreas, function(area){
+            broker['get' + area[0].toUpperCase() + area.slice(1) + 'Area'] = _.bind(_.partial(broker.getArea, area), broker);
+        });
+
+        return broker;
+    };
+
+});

--- a/views/js/test/core/areaBroker/test.html
+++ b/views/js/test/core/areaBroker/test.html
@@ -8,7 +8,7 @@
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
-        <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="areaBroker.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="core/areaBroker.js"></script>
 
         <script  type="text/javascript">
 

--- a/views/js/test/core/areaBroker/test.html
+++ b/views/js/test/core/areaBroker/test.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Core - Area Broker</title>
+        <base href="../../../../" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="areaBroker.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['test/core/areaBroker/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+
+            <div class="container">
+                <div class="header"></div>
+                <div class="footer"></div>
+                <div class="body"></div>
+                <div class="panel"></div>
+            </div>
+
+        </div>
+    </body>
+</html>

--- a/views/js/test/core/areaBroker/test.js
+++ b/views/js/test/core/areaBroker/test.js
@@ -1,0 +1,205 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Test the areaBroker
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'jquery',
+    'core/areaBroker',
+], function ($, areaBroker){
+    'use strict';
+
+    var fixture = '#qunit-fixture';
+    var required   = ['header', 'footer', 'body'];
+
+    QUnit.module('API');
+
+    QUnit.test('module', function (assert){
+        QUnit.expect(1);
+
+        assert.equal(typeof areaBroker, 'function', "The module exposes a function");
+    });
+
+    QUnit.test('factory', function (assert){
+        QUnit.expect(7);
+        var $fixture = $(fixture);
+
+        var $container = $('.container', $fixture);
+
+        var $header     = $('.header', $container);
+        var $footer     = $('.footer', $container);
+        var $body       = $('.body', $container);
+        var $panel      = $('.panel', $container);
+
+        var mapping    = {
+            'header'     : $header,
+            'footer'     : $footer,
+            'body'       : $body,
+            'panel'      : $panel
+        };
+
+        assert.ok($container.length,  "The container exists");
+
+        assert.throws(function(){
+            areaBroker();
+        }, TypeError, 'A broker must be created with a container');
+
+        assert.throws(function(){
+            areaBroker(required, 'foo');
+        }, TypeError, 'A broker must be created with an existing container');
+
+        assert.throws(function(){
+            areaBroker(required, $container);
+        }, TypeError, 'A broker must be created with an area mapping');
+
+        assert.throws(function(){
+            areaBroker(required, $container, {
+                'header'     : $header,
+            });
+        }, TypeError, 'A broker must be created with an full area mapping');
+
+
+        assert.equal(typeof areaBroker(required, $container, mapping), 'object', "The factory creates an object");
+        assert.notEqual(areaBroker(required, $container, mapping), areaBroker(required, $container, mapping), "The factory creates new instances");
+    });
+
+    QUnit.test('broker api', function (assert){
+        QUnit.expect(4);
+        var $fixture = $(fixture);
+        var $container = $('.container', $fixture);
+        var $header     = $('.header', $container);
+        var $footer     = $('.footer', $container);
+        var $body       = $('.body', $container);
+        var $panel      = $('.panel', $container);
+        var mapping    = {
+            'header'     : $header,
+            'footer'     : $footer,
+            'body'       : $body,
+            'panel'      : $panel
+        };
+
+        assert.ok($container.length,  "The container exists");
+
+        var broker = areaBroker(required, $container, mapping);
+        assert.equal(typeof broker.defineAreas, 'function', 'The broker has a defineAreas function');
+        assert.equal(typeof broker.getContainer, 'function', 'The broker has a getContainer function');
+        assert.equal(typeof broker.getArea, 'function', 'The broker has a getArea function');
+    });
+
+    QUnit.module('Area mapping');
+
+    QUnit.test('define mapping', function (assert){
+        QUnit.expect(9);
+        var $fixture = $(fixture);
+
+        var $container = $('.container', $fixture);
+
+        assert.ok($container.length,  "The container exists");
+
+        var $header     = $('.header', $container);
+        var $footer     = $('.footer', $container);
+        var $body       = $('.body', $container);
+        var $panel      = $('.panel', $container);
+        var mapping    = {
+            'header'     : $header,
+            'footer'     : $footer,
+            'body'       : $body,
+            'panel'      : $panel
+        };
+
+        var broker = areaBroker(required, $container, mapping);
+
+        assert.throws(function(){
+            broker.defineAreas();
+        }, TypeError, 'requires a mapping object');
+
+        assert.throws(function(){
+            broker.defineAreas({});
+        }, TypeError, 'required mapping missing');
+
+        assert.throws(function(){
+            broker.defineAreas({
+                'body'       : $body,
+                'panel'      : $panel
+            });
+        }, TypeError, 'required mapping incomplete');
+
+        broker.defineAreas(mapping);
+
+        assert.deepEqual(broker.getArea('header'), $header, 'The area match');
+        assert.deepEqual(broker.getArea('footer'), $footer, 'The area match');
+        assert.deepEqual(broker.getArea('body'), $body, 'The area match');
+        assert.deepEqual(broker.getArea('panel'), $panel, 'The area match');
+
+        assert.equal(broker.getArea('foo'), undefined, 'The area does not exists');
+
+    });
+
+    QUnit.test('aliases', function (assert){
+        QUnit.expect(5);
+        var $fixture = $(fixture);
+        var $container = $('.container', $fixture);
+
+        assert.ok($container.length,  "The container exists");
+
+        var $header     = $('.header', $container);
+        var $footer     = $('.footer', $container);
+        var $body       = $('.body', $container);
+        var $panel      = $('.panel', $container);
+        var mapping    = {
+            'header'     : $header,
+            'footer'     : $footer,
+            'body'       : $body,
+            'panel'      : $panel
+        };
+        var broker = areaBroker(required, $container, mapping);
+
+        assert.deepEqual(broker.getHeaderArea(), $header, 'The area match');
+        assert.deepEqual(broker.getFooterArea(), $footer, 'The area match');
+        assert.deepEqual(broker.getBodyArea(), $body, 'The area match');
+        assert.ok(typeof broker.getPanelArea === 'undefined', 'aliases are available only for required areas');
+    });
+
+
+    QUnit.module('container');
+
+    QUnit.test('retrieve', function (assert){
+        QUnit.expect(2);
+        var $fixture = $(fixture);
+        var $container = $('.container', $fixture);
+        var $header     = $('.header', $container);
+        var $footer     = $('.footer', $container);
+        var $body       = $('.body', $container);
+        var $panel      = $('.panel', $container);
+        var mapping    = {
+            'header'     : $header,
+            'footer'     : $footer,
+            'body'       : $body,
+            'panel'      : $panel
+        };
+
+        assert.ok($container.length,  "The container exists");
+
+        var broker = areaBroker(required, $container, mapping);
+
+        assert.deepEqual(broker.getContainer(), $container, 'The container match');
+    });
+});


### PR DESCRIPTION
Move the module `areaBroker` from `taoTests/runner` to `core`.
Make the list of required areas configurable.
The goal is to reuse it into the itemCreator