### PR TITLE
Move the plugin model and pluginLoader to core

### DIFF
--- a/views/js/core/plugin.js
+++ b/views/js/core/plugin.js
@@ -58,14 +58,15 @@ define([
      * @param {Object} provider - the plugin provider
      * @param {String} provider.name - the plugin name
      * @param {Function} provider.init - the plugin initialization method
-     * @param {Function} [provider.render] - plugin render behaviorV
-     * @param {Function} [provider.finish] - plugin render behaviorV
+     * @param {Function} [provider.render] - plugin rendering behavior
+     * @param {Function} [provider.finish] - plugin finish behavior
      * @param {Function} [provider.destroy] - plugin destroy behavior
      * @param {Function} [provider.show] - plugin show behavior
      * @param {Function} [provider.hide] - plugin hide behavior
      * @param {Function} [provider.enable] - plugin enable behavior
      * @param {Function} [provider.disable] - plugin disable behavior
      * @param {Object} defaults - default configuration to be assigned
+     * @param {String} [defaults.hostName] - the name of the host, used to alias the getHost method to getHostName
      * @returns {Function} - the generated plugin factory
      */
     function pluginFactory(provider, defaults){
@@ -83,7 +84,7 @@ define([
          * The configured plugin factory
          *
          * @param {host} host - the plugin host instance
-         * @param {areaBroker} areaBroker - an instance of an areaBroker
+         * @param {areaBroker} [areaBroker] - an instance of an areaBroker. This should be your access point to GUI.
          * @param {Object} [config] - plugin configuration
          * @returns {plugin} the plugin instance
          */
@@ -205,8 +206,8 @@ define([
                 },
 
                 /**
-                 * Get the host testRunner
-                 * @returns {host} the plugins's host
+                 * Get the host's areaBroker
+                 * @returns {areaBroker} the areaBroker
                  */
                 getAreaBroker : function getAreaBroker(){
                     return areaBroker;

--- a/views/js/core/plugin.js
+++ b/views/js/core/plugin.js
@@ -1,0 +1,337 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016  (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * Plugin modelisation :
+ *  - helps you to create plugin's definition
+ *  - helps you to bind plugin's behavior to the host
+ *  - have it's own state and lifecycle convention (init -> render -> finish -> destroy)
+ *  - promise based
+ *
+ * @example
+ *
+ * 1. create the plugin definition
+ * var factory = pluginFactory({
+ *   name : 'foo',
+ *   init(){
+ *      console.log('foo');
+ *   }
+ * });
+ *
+ * 2.instiantiate it
+ * var plugin = factory(myPluginHost);
+ *
+ * 3. Link it to your host lifecycle
+ * myPluginHost({
+ *  init(){
+ *      plugin.init();
+ *  }
+ * });
+ *
+ *
+ * @author Sam <sam@taotesting.com>
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/promise'
+], function (_, Promise){
+    'use strict';
+
+    /**
+     * Meta factory for plugins. Let's you create a plugin definition.
+     *
+     * @param {Object} provider - the plugin provider
+     * @param {String} provider.name - the plugin name
+     * @param {Function} provider.init - the plugin initialization method
+     * @param {Function} [provider.render] - plugin render behaviorV
+     * @param {Function} [provider.finish] - plugin render behaviorV
+     * @param {Function} [provider.destroy] - plugin destroy behavior
+     * @param {Function} [provider.show] - plugin show behavior
+     * @param {Function} [provider.hide] - plugin hide behavior
+     * @param {Function} [provider.enable] - plugin enable behavior
+     * @param {Function} [provider.disable] - plugin disable behavior
+     * @param {Object} defaults - default configuration to be assigned
+     * @returns {Function} - the generated plugin factory
+     */
+    function pluginFactory(provider, defaults){
+        var pluginName;
+
+        if(!_.isPlainObject(provider) || !_.isString(provider.name) || _.isEmpty(provider.name) || !_.isFunction(provider.init)){
+            throw new TypeError('A plugin should be defined at least by a name property and an init method');
+        }
+
+        pluginName = provider.name;
+
+        defaults = defaults || {};
+
+        /**
+         * The configured plugin factory
+         *
+         * @param {host} host - the plugin host instance
+         * @param {areaBroker} areaBroker - an instance of an areaBroker
+         * @param {Object} [config] - plugin configuration
+         * @returns {plugin} the plugin instance
+         */
+        return function instanciatePlugin(host, areaBroker, config){
+            var plugin;
+
+            var states = {};
+
+            //basic checking for the host
+            if(!_.isObject(host) || !_.isFunction(host.on) || !_.isFunction(host.trigger)){
+                throw new TypeError('A plugin host should be a valid eventified object');
+            }
+
+            /**
+             * Delegate a function call to the provider
+             *
+             * @param {String} fnName - the function name
+             * @param {...} args - additional args are given to the provider
+             * @returns {*} up to the provider
+             */
+            function delegate(fnName){
+                var args = [].slice.call(arguments, 1);
+                return new Promise(function(resolve){
+                    if(!_.isFunction(provider[fnName])){
+                        return resolve();
+                    }
+                    return resolve(provider[fnName].apply(plugin, args));
+                });
+            }
+
+
+            config = _.defaults(config || {}, defaults);
+
+            /**
+             * The plugin instance.
+             * @typedef {plugin}
+             */
+            plugin = {
+
+                /**
+                 * Called when the host is initializing
+                 * @returns {Promise} to resolve async delegation
+                 */
+                init : function init(){
+                    var self = this;
+                    states = {};
+
+                    return delegate('init').then(function(){
+                        self.setState('init', true)
+                            .trigger('init');
+                    });
+                },
+
+                /**
+                 * Called when the host is rendering
+                 * @returns {Promise} to resolve async delegation
+                 */
+                render : function render(){
+                    var self = this;
+
+                    return delegate('render').then(function(){
+                        self.setState('ready', true)
+                            .trigger('render')
+                            .trigger('ready');
+                    });
+                },
+
+                /**
+                 * Called when the host is finishing
+                 * @returns {Promise} to resolve async delegation
+                 */
+                finish : function finish(){
+                    var self = this;
+
+                    return delegate('finish').then(function(){
+                        self.setState('finish', true)
+                            .trigger('finish');
+                    });
+                },
+
+                /**
+                 * Called when the host is destroying
+                 * @returns {Promise} to resolve async delegation
+                 */
+                destroy : function destroy(){
+                    var self = this;
+
+                    return delegate('destroy').then(function(){
+
+                        config = {};
+                        states = {};
+
+                        self.setState('init', false);
+                        self.trigger('destroy');
+                    });
+                },
+
+                /**
+                 * Triggers the events on the host using the pluginName as namespace
+                 * and prefixed by plugin-
+                 * For example trigger('foo') will trigger('plugin-foo.pluginA') on the host
+                 *
+                 * @param {String} name - the event name
+                 * @param {...} args - additional args are given to the event
+                 * @returns {plugin} chains
+                 */
+                trigger : function trigger(name){
+                    var args = [].slice.call(arguments, 1);
+                    host.trigger.apply(host, ['plugin-' + name + '.' + pluginName, plugin].concat(args));
+                    return this;
+                },
+
+                /**
+                 * Get the plugin host
+                 * @returns {host} the plugins's host
+                 */
+                getHost : function getHost(){
+                    return host;
+                },
+
+                /**
+                 * Get the host testRunner
+                 * @returns {host} the plugins's host
+                 */
+                getAreaBroker : function getAreaBroker(){
+                    return areaBroker;
+                },
+
+                /**
+                 * Get the config
+                 * @returns {Object} config
+                 */
+                getConfig : function getConfig(){
+                    return config;
+                },
+
+                /**
+                 * Set a config entry
+                 * @param {String|Object} name - the entry name or an object to merge
+                 * @param {*} [value] - the config value if name is an entry
+                 * @returns {plugin} chains
+                 */
+                setConfig : function setConfig(name, value){
+                    if(_.isPlainObject(name)){
+                        config = _.defaults(name, config);
+                    }else{
+                        config[name] = value;
+                    }
+                    return this;
+                },
+
+                /**
+                 * Get a state of the plugin
+                 *
+                 * @param {String} name - the state name
+                 * @returns {Boolean} if active, false if not set
+                 */
+                getState : function getState(name){
+                    return !!states[name];
+                },
+
+                /**
+                 * Set a state to the plugin
+                 *
+                 * @param {String} name - the state name
+                 * @param {Boolean} active - is the state active
+                 * @returns {plugin} chains
+                 * @throws {TypeError} if the state name is not a valid string
+                 */
+                setState : function setState(name, active){
+                    if(!_.isString(name) || _.isEmpty(name)){
+                        throw new TypeError('The state must have a name');
+                    }
+                    states[name] = !!active;
+
+                    return this;
+                },
+
+                /**
+                 * Get the plugin name
+                 *
+                 * @returns {String} the name
+                 */
+                getName : function getName(){
+                    return pluginName;
+                },
+
+                /**
+                 * Shows the component related to this plugin
+                 * @returns {Promise} to resolve async delegation
+                 */
+                show : function show(){
+                    var self = this;
+
+                    return delegate('show').then(function(){
+                        self.setState('visible', true)
+                            .trigger('show');
+                    });
+                },
+
+                /**
+                 * Hides the component related to this plugin
+                 * @returns {Promise} to resolve async delegation
+                 */
+                hide : function hide(){
+                    var self = this;
+
+                    return delegate('hide').then(function(){
+                        self.setState('visible', false)
+                            .trigger('hide');
+                    });
+                },
+
+                /**
+                 * Enables the plugin
+                 * @returns {Promise} to resolve async delegation
+                 */
+                enable : function enable(){
+                    var self = this;
+
+                    return delegate('enable').then(function(){
+                        self.setState('enabled', true)
+                            .trigger('enable');
+                    });
+                },
+
+                /**
+                 * Disables the plugin
+                 * @returns {Promise} to resolve async delegation
+                 */
+                disable : function disable(){
+                    var self = this;
+
+                    return delegate('disable').then(function(){
+                        self.setState('enabled', false)
+                            .trigger('disable');
+                    });
+                }
+            };
+
+            //add a convenience method that alias getHost using the hostName
+            if(_.isString(defaults.hostName) && !_.isEmpty(defaults.hostName)){
+                plugin['get' + defaults.hostName.charAt(0).toUpperCase() + defaults.hostName.slice(1)] = plugin.getHost;
+            }
+
+            return plugin;
+        };
+    }
+
+    return pluginFactory;
+});

--- a/views/js/core/pluginLoader.js
+++ b/views/js/core/pluginLoader.js
@@ -1,0 +1,176 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Loads plugins
+ *
+ * It provides 2 distinct way of loading plugins :
+ *  1. The "required" plugins that are necessary. Provided as factory (function)
+ *  2. The "dynamic" plugins that are loaded on demand, they are provided as AMD modules. The module is loaded using the load method.
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/promise'
+], function(_, Promise) {
+    'use strict';
+
+    /**
+     * Creates a loader with the list of required plugins
+     * @param {String: Function[]} requiredPlugins - where the key is the category and the value are an array of plugins
+     * @returns {loader} the plugin loader
+     * @throws TypeError if something is not well formated
+     */
+    return function pluginLoader(requiredPlugins) {
+
+        var plugins = {};
+        var modules = {};
+
+        /**
+         * The plugin loader
+         * @typedef {loader}
+         */
+        var loader = {
+
+            /**
+             * Add a new dynamic plugin
+             * @param {String} module - AMD module name of the plugin
+             * @param {String} category - the plugin category
+             * @param {String|Number} [position = 'append'] - append, prepend or plugin position within the category
+             * @returns {loader} chains
+             * @throws {TypeError} misuse
+             */
+            add: function add(module, category, position) {
+                if(!_.isString(module)){
+                    throw new TypeError('An AMD module must be defined');
+                }
+                if(!_.isString(category)){
+                    throw new TypeError('Plugins must belong to a category');
+                }
+
+                modules[category] = modules[category] || [];
+
+                if(_.isNumber(position)){
+                    modules[category][position] = module;
+                }
+                else if(position === 'prepend' || position === 'before'){
+                    modules[category].unshift(module);
+                } else {
+                    modules[category].push(module);
+                }
+
+                return this;
+            },
+
+            /**
+             * Append a new dynamic plugin to a category
+             * @param {String} module - AMD module name of the plugin
+             * @param {String} category - the plugin category
+             * @returns {loader} chains
+             * @throws {TypeError} misuse
+             */
+            append: function append(module, category) {
+                return this.add(module, category);
+            },
+
+            /**
+             * Prepend a new dynamic plugin to a category
+             * @param {String} module - AMD module name of the plugin
+             * @param {String} category - the plugin category
+             * @returns {loader} chains
+             * @throws {TypeError} misuse
+             */
+            prepend: function prepend(module, category) {
+                return this.add(module, category, 'before');
+            },
+
+            /**
+             * Loads the dynamic plugins : trigger the dependency resolution
+             * @returns {Promise}
+             */
+            load: function load() {
+                return new Promise(function(resolve, reject){
+
+                    var dependencies = _(modules).values().flatten().uniq().value();
+
+                    if(dependencies.length){
+
+                        require(dependencies, function(){
+                            var loadedModules = [].slice.call(arguments);
+                            _.forEach(dependencies, function(dependency, index){
+                                var plugin = loadedModules[index];
+                                var category = _.findKey(modules, function(val){
+                                    return _.contains(val, dependency);
+                                });
+                                if(_.isFunction(plugin) && _.isString(category)){
+                                    plugins[category] = plugins[category] || [];
+                                    plugins[category].push(plugin);
+                                }
+                            });
+                            resolve();
+
+                        }, reject);
+                        return;
+                    }
+                    resolve();
+                });
+            },
+
+            /**
+             * Get the resolved plugin list.
+             * Load needs to be called before to have the dynamic plugins.
+             * @param {String} [category] - to get the plugins for a given category, if not set, we get everything
+             * @returns {Function[]} the plugins
+             */
+            getPlugins: function getPlugins(category) {
+                if(_.isString(category)){
+                    return plugins[category] || [];
+                }
+                return _(plugins).values().flatten().uniq().value();
+            },
+
+            /**
+             * Get the plugin categories
+             * @returns {String[]} the categories
+             */
+            getCategories: function getCategories(){
+                return _.keys(plugins);
+            }
+        };
+
+        //verify and add the required plugins
+        _.forEach(requiredPlugins, function(pluginList, category){
+            if(!_.isString(category)){
+                throw new TypeError('Plugins must belong to a category');
+            }
+
+            if(!_.isArray(pluginList) || !_.all(pluginList, _.isFunction)){
+                throw new TypeError('A plugin must be an array of function');
+            }
+
+            if(plugins[category]){
+                plugins[category] = plugins[category].concat(pluginList);
+            } else {
+                plugins[category] = pluginList;
+            }
+        });
+
+        return loader;
+    };
+});

--- a/views/js/core/pluginifier.js
+++ b/views/js/core/pluginifier.js
@@ -1,4 +1,9 @@
 /**
+ * Used to register jquery plugins
+ *
+ * !!! Prefer component to jQuery plugins !!!
+ *
+ *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  * @requires jquery
  * @requires lodash
@@ -30,10 +35,10 @@ define(['jquery', 'lodash'], function($, _){
         },
 
        /**
-        * Disable the component. 
-        * 
+        * Disable the component.
+        *
         * It can be called prior to the plugin initilization.
-        * 
+        *
         * Called the jQuery way once registered by the Pluginifier.
         * @example $('selector').pluginName('disable');
         * @param  {String} dataNs - the data namespace
@@ -51,9 +56,9 @@ define(['jquery', 'lodash'], function($, _){
             });
        },
 
-       /**  
-        * Enable the component. 
-        * 
+       /**
+        * Enable the component.
+        *
         * Called the jQuery way once registered by the Pluginifier.
         * @example $('selector').pluginName('enable');
         * @param  {String} dataNs - the data namespace
@@ -71,19 +76,19 @@ define(['jquery', 'lodash'], function($, _){
             });
        },
     };
-   
-   /** 
+
+   /**
     * Helps you to create a jQuery plugin, the Cards way
     * @exports core/pluginifer
     */
     var Pluginifier = {
-        
+
         /**
          * Regsiter a new jQuery plugin, the Cards way
          * @param {string} pluginName - the name of the plugin to regsiter. ie $('selector').pluginName();
-         * @param {Object} plugin - the plugin as a plain object 
+         * @param {Object} plugin - the plugin as a plain object
          * @param {Function} plugin.init - the entry point of the plugin is always an init method
-         * @param {Object} [config] - plugin configuration 
+         * @param {Object} [config] - plugin configuration
          * @param {String} [config.ns = pluginName] - plugin namespace (used for events and data-attr)
          * @param {String} [config.dataNs = ui.pluginName] - plugin namespace (used for events and data-attr)
          * @param {Array<String>} [config.expose] - list of methods to expose
@@ -101,24 +106,24 @@ define(['jquery', 'lodash'], function($, _){
             if(!_.isPlainObject(plugin) || !_.isFunction(plugin.init)){
                 return $.error('The object to register as a jQuery plugin must be a plain object with an `init` method.');
             }
-            
+
             //configure and augments the plugin
             _.assign(plugin, _.transform(basePlugin, function(result, prop, key){
                 if(_.isFunction(prop)){
                     result[key] = _.partial(basePlugin[key], dataNs, ns);
                 }
             }));
-            
+
             //set up public methods to wrap privates the jquery way
             _.forEach(expose, function(toExposeName){
-                var privateMethod = toExposeName; 
-                var publicMethod  = toExposeName; 
+                var privateMethod = toExposeName;
+                var publicMethod  = toExposeName;
                 if(!/^_/.test(expose)){
                     privateMethod = '_' + privateMethod;
                 } else {
                     publicMethod = publicMethod.replace(/^_/, '');
                 }
-        
+
                 //do not override if exists
                 if(_.isFunction(plugin[privateMethod]) && !_.isFunction(plugin[publicMethod])){
                     plugin[publicMethod] = function(){
@@ -145,12 +150,12 @@ define(['jquery', 'lodash'], function($, _){
                      }
                 } else if ( typeof method === 'object' || ! method) {
                      return plugin.init.apply( this, arguments );
-                } 
+                }
                 $.error( 'Method ' + method + ' does not exist on plugin' );
             };
         }
     };
-   
+
     return Pluginifier;
 });
 

--- a/views/js/test/core/plugin/test.html
+++ b/views/js/test/core/plugin/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Core - Plugins</title>
+        <base href="../../../../" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="plugin.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['test/core/plugin/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/core/plugin/test.js
+++ b/views/js/test/core/plugin/test.js
@@ -1,0 +1,334 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Plugin's test
+ *
+ * @author Sam <sam@taotesting.com>
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/plugin',
+    'core/eventifier'
+], function (_, pluginFactory, eventifier){
+    'use strict';
+
+    var mockProvider = {
+        name : 'foo',
+        init : _.noop
+    };
+
+    var defaultConfig = {
+        a : false,
+        b : 10
+    };
+
+    var mockHost = {
+        on: _.noop,
+        trigger : _.noop
+    };
+
+    QUnit.module('plugin');
+
+    QUnit.test('module', function (assert){
+        QUnit.expect(3);
+
+        assert.equal(typeof pluginFactory, 'function', "The plugin module exposes a function");
+        assert.equal(typeof pluginFactory(mockProvider), 'function', "The plugin factory produces a function");
+        assert.notStrictEqual(pluginFactory(mockProvider), pluginFactory(mockProvider), "The plugin factory provides a different object on each call");
+    });
+
+    QUnit.test('provider format', function (assert){
+        QUnit.expect(4);
+
+        assert.throws(function(){
+            pluginFactory();
+        }, TypeError, 'A provider should be an object');
+
+        assert.throws(function(){
+            pluginFactory({});
+        }, TypeError, 'A plugin provider should have a name');
+
+        assert.throws(function(){
+            pluginFactory({ name : ''});
+        }, TypeError, 'A plugin provider should have a valid name');
+
+        assert.throws(function(){
+            pluginFactory({ name : 'foo'});
+        }, TypeError, 'A plugin provider should have a init function');
+
+
+        pluginFactory({
+            name : 'foo',
+            init : _.noop
+        });
+    });
+
+    QUnit.test('instantiation', function (assert){
+        QUnit.expect(19);
+
+        var myPlugin = pluginFactory(mockProvider, defaultConfig);
+
+        assert.throws(function(){
+            myPlugin();
+        }, TypeError, 'A plugin is instanciated with an host');
+
+        assert.throws(function(){
+            myPlugin({});
+        }, TypeError, 'A plugin is instanciated with an eventified host');
+
+        assert.equal(typeof myPlugin(mockHost), 'object', "My plugin factory produce a plugin instance object");
+        assert.notStrictEqual(myPlugin(mockHost), myPlugin(mockHost), "My plugin factory provides different object on each call");
+
+        var plugin = myPlugin(mockHost);
+        assert.equal(typeof plugin.init, 'function', 'The plugin instance has also the default function init');
+        assert.equal(typeof plugin.getAreaBroker, 'function', 'The plugin instance has also the default function getAreaBroker');
+        assert.equal(typeof plugin.finish, 'function', 'The plugin instance has also the default function finish');
+        assert.equal(typeof plugin.render, 'function', 'The plugin instance has also the default function render');
+        assert.equal(typeof plugin.destroy, 'function', 'The plugin instance has also the default function destroy');
+        assert.equal(typeof plugin.show, 'function', 'The plugin instance has also the default function show');
+        assert.equal(typeof plugin.hide, 'function', 'The plugin instance has also the default function hide');
+        assert.equal(typeof plugin.enable, 'function', 'The plugin instance has also the default function enable');
+        assert.equal(typeof plugin.disable, 'function', 'The plugin instance has also the default function disable');
+        assert.equal(typeof plugin.setState, 'function', 'The plugin instance has also the default function setState');
+        assert.equal(typeof plugin.getState, 'function', 'The plugin instance has also the default function getState');
+        assert.equal(typeof plugin.getConfig, 'function', 'The plugin instance has also the default function getConfig');
+        assert.equal(typeof plugin.setConfig, 'function', 'The plugin instance has also the default function setConfig');
+        assert.equal(typeof plugin.getName, 'function', 'The plugin instance has also the default function getName');
+        assert.equal(typeof plugin.getHost, 'function', 'The plugin instance has also the default function getHost');
+    });
+
+    QUnit.test('config', function (assert){
+        QUnit.expect(5);
+
+        var myPlugin = pluginFactory(mockProvider, defaultConfig);
+        var plugin = myPlugin(mockHost);
+
+        assert.equal(typeof plugin, 'object', "My plugin factory produce a plugin instance object");
+
+        var config1 = plugin.getConfig();
+        assert.equal(config1.a, defaultConfig.a, 'instance1 inherits the default config');
+        assert.equal(config1.b, defaultConfig.b, 'instance1 inherit the default config');
+
+        var config2 = {
+            a : true,
+            b : 999
+        };
+
+        plugin.setConfig(config2);
+        assert.equal(plugin.getConfig().a, config2.a, 'instance2 has new config value');
+        assert.equal(plugin.getConfig().b, config2.b, 'instance2 has new config value');
+    });
+
+    QUnit.test('methods', function (assert){
+        QUnit.expect(11);
+
+        var samplePluginImpl = {
+            name : 'samplePluginImpl',
+            init : function (){
+                var config = this.getConfig();
+                assert.ok(true, 'called init');
+
+                assert.equal(config.a, defaultConfig.a, 'instance1 inherits the default config');
+                assert.equal(config.b, defaultConfig.b, 'instance1 inherit the default config');
+            },
+            render : function (){
+                assert.ok(true, 'called render');
+            },
+            finish : function (){
+                assert.ok(true, 'called finish');
+            },
+            destroy : function (){
+                assert.ok(true, 'called destory');
+            },
+            show : function (){
+                assert.ok(true, 'called show');
+            },
+            hide : function (){
+                assert.ok(true, 'called hide');
+            },
+            enable : function (){
+                assert.ok(true, 'called enable');
+            },
+            disable : function (){
+                assert.ok(true, 'called disable');
+            }
+        };
+
+        var myPlugin = pluginFactory(samplePluginImpl, defaultConfig);
+
+        assert.equal(typeof myPlugin(mockHost), 'object', "My plugin factory produce a plugin instance object");
+
+        var instance1 = myPlugin(mockHost);
+        instance1.init();
+        instance1.render();
+        instance1.hide();
+        instance1.show();
+        instance1.disable();
+        instance1.enable();
+        instance1.finish();
+        instance1.destroy();
+    });
+
+    QUnit.asyncTest('state', function (assert){
+        QUnit.expect(14);
+
+        var myPlugin = pluginFactory(mockProvider);
+
+        assert.equal(typeof myPlugin(mockHost), 'object', "My plugin factory produce a plugin instance object");
+
+        var instance1 = myPlugin(mockHost);
+
+        assert.throws(function(){
+            instance1.setState({}, false);
+        }, TypeError, 'The state must have a valid name');
+
+        //custom state : active
+        assert.strictEqual(instance1.getState('active'), false, 'no state set by default');
+        instance1.setState('active', true);
+        assert.strictEqual(instance1.getState('active'), true, 'active state set');
+        instance1.setState('active', false);
+        assert.strictEqual(instance1.getState('active'), false, 'no state set by default');
+
+        //built-in state init:
+        assert.strictEqual(instance1.getState('init'), false, 'init state = false by default');
+        instance1.init().then(function(){
+
+            assert.strictEqual(instance1.getState('init'), true, 'init state set');
+
+            //built-in visible state
+            assert.strictEqual(instance1.getState('visible'), false, 'visible state = false by default');
+            instance1.show().then(function(){
+                assert.strictEqual(instance1.getState('visible'), true, 'visible state set');
+                instance1.hide().then(function(){
+                    assert.strictEqual(instance1.getState('visible'), false, 'visible turns to false');
+                });
+            });
+
+            //built-in enabled state
+            assert.strictEqual(instance1.getState('enabled'), false, 'enabled state = false by default');
+            instance1.enable().then(function(){
+                assert.strictEqual(instance1.getState('enabled'), true, 'enabled state set');
+                instance1.disable().then(function(){
+                    assert.strictEqual(instance1.getState('enabled'), false, 'enabled turns to false');
+                });
+            });
+
+            //built-in init state
+            setTimeout(function(){
+                instance1.destroy().then(function(){
+                    assert.strictEqual(instance1.getState('init'), false, 'destoyed state set');
+                    QUnit.start();
+                });
+            }, 10);
+        });
+    });
+
+    QUnit.test('host name alias', function (assert){
+        QUnit.expect(3);
+
+        var myPlugin = pluginFactory(mockProvider, {
+            hostName : 'fooStopper'
+        });
+        var plugin = myPlugin(mockHost);
+
+        assert.equal(typeof plugin, 'object', "My plugin factory produce a plugin instance object");
+        assert.equal(typeof plugin.getFooStopper, 'function', "Getter with alias has been created");
+        assert.deepEqual(plugin.getFooStopper(), mockHost, "The host alias returns the host");
+    });
+
+    QUnit.test('host binding', function (assert){
+        QUnit.expect(4);
+        var value1 = 'xxx';
+        var host = {
+            prop1 : 123,
+            method1 : function (){
+                return value1;
+            },
+            on: _.noop,
+            trigger: _.noop
+        };
+
+        var samplePluginImpl = {
+            name : 'hostPlugin',
+            init : function (){
+                assert.ok(true, 'called init');
+
+                assert.deepEqual(this.getHost(), host, 'The plugin has access to the test runner');
+                assert.strictEqual(this.getHost().method1(), value1, 'called root component method');
+            }
+        };
+
+        var myPlugin = pluginFactory(samplePluginImpl);
+
+        var instance1 = myPlugin(host);
+        instance1.init();
+        assert.strictEqual(instance1.getHost(), host, 'root component is set');
+    });
+
+
+    QUnit.asyncTest('root component event', function (assert){
+        QUnit.expect(6);
+
+        var eventParams = ['ABC', true, 12345];
+        var myPlugin = pluginFactory({
+            name : 'pluginA',
+            init : function(){
+                this.trigger('someEvent', eventParams[0], eventParams[1], eventParams[2]);
+            }
+        });
+
+        var host = eventifier()
+            .on('plugin-init.pluginA', function (plugin){
+                assert.ok(true, 'root component knows knows that pluginA has been initialized');
+                assert.deepEqual(plugin, instance1, 'The given plugin instance is correct');
+                QUnit.start();
+            })
+            .on('plugin-someEvent.pluginA', function (plugin, arg1, arg2, arg3){
+                assert.ok(true, 'someEvent triggered and forwarded to root component');
+                assert.strictEqual(eventParams[0], arg1, 'event param ok');
+                assert.strictEqual(eventParams[1], arg2, 'event param ok');
+                assert.strictEqual(eventParams[2], arg3, 'event param ok');
+            });
+
+        var instance1 = myPlugin(host);
+        instance1.init();
+    });
+
+    QUnit.asyncTest('get plugin name', function(assert){
+        QUnit.expect(3);
+
+        var name = 'foo-plugin';
+
+        var samplePluginImpl = {
+            name : name,
+            init : function (){
+                assert.ok(true, 'called init');
+                assert.equal(this.getName(), name, 'The name matches');
+                QUnit.start();
+            }
+        };
+
+        var myPlugin = pluginFactory(samplePluginImpl);
+
+        var instance1 = myPlugin(mockHost);
+        assert.equal(instance1.getName(), name, 'The name matches');
+        instance1.init();
+    });
+});

--- a/views/js/test/core/pluginLoader/mockPlugin.js
+++ b/views/js/test/core/pluginLoader/mockPlugin.js
@@ -1,0 +1,12 @@
+define([], function(){
+    'use strict';
+
+    return function(){
+        return {
+            name : 'mock',
+            init : function(){
+
+            }
+        };
+    };
+});

--- a/views/js/test/core/pluginLoader/test.html
+++ b/views/js/test/core/pluginLoader/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Core - Plugins Loader</title>
+        <base href="../../../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="pluginLoader.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['test/core/pluginLoader/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/core/pluginLoader/test.js
+++ b/views/js/test/core/pluginLoader/test.js
@@ -1,0 +1,146 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Plugin loader's test
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/pluginLoader',
+    'core/promise',
+], function (_, pluginLoader, Promise){
+    'use strict';
+
+
+    QUnit.module('API');
+
+    QUnit.test('module', function (assert){
+        QUnit.expect(3);
+
+        assert.equal(typeof pluginLoader, 'function', "The plugin loader exposes a function");
+        assert.equal(typeof pluginLoader(), 'object', "The plugin loader produces an object");
+        assert.notStrictEqual(pluginLoader(), pluginLoader(), "The plugin loader provides a different object on each call");
+    });
+
+    QUnit.test('loader methods', function (assert){
+        QUnit.expect(6);
+        var loader = pluginLoader();
+
+        assert.equal(typeof loader, 'object', "The loader is an object");
+        assert.equal(typeof loader.add, 'function', "The loader exposes the add method");
+        assert.equal(typeof loader.append, 'function', "The loader exposes the append method");
+        assert.equal(typeof loader.prepend, 'function', "The loader exposes the prepend method");
+        assert.equal(typeof loader.load, 'function', "The loader exposes the load method");
+        assert.equal(typeof loader.getPlugins, 'function', "The loader exposes the getPlugins method");
+
+    });
+
+
+    QUnit.module('required');
+
+    QUnit.test('required plugin format', function (assert){
+        QUnit.expect(4);
+
+        assert.throws(function(){
+            pluginLoader({ 12 : _.noop });
+        }, TypeError, 'Wrong category format');
+
+        assert.throws(function(){
+            pluginLoader({ 'foo' : true });
+        }, TypeError, 'The plugin list must be an array');
+
+        assert.throws(function(){
+            pluginLoader({ 'foo' : [true] });
+        }, TypeError, 'The plugin list must be an array of function');
+
+        assert.throws(function(){
+            pluginLoader({ 'foo' : ['true', _.noop] });
+        }, TypeError, 'The plugin list must be an array with only functions');
+
+        var loader = pluginLoader({
+            foo : [_.noop],
+            bar : [_.noop, _.noop]
+        });
+    });
+
+    QUnit.test('required plugin loading', function (assert){
+        QUnit.expect(5);
+
+        var a = function a (){ return 'a'; };
+        var b = function b (){ return 'b'; };
+        var c = function c (){ return 'c'; };
+        var plugins = {
+            foo : [a],
+            bar : [b, c]
+        };
+
+        var loader = pluginLoader(plugins);
+
+        assert.equal(typeof loader, 'object', "The loader is an object");
+        assert.deepEqual(loader.getCategories(), ['foo', 'bar'], "The plugins categories are correct");
+        assert.deepEqual(loader.getPlugins(), [a, b, c], "The plugins have been registered");
+        assert.deepEqual(loader.getPlugins('foo'), plugins.foo, "The plugins are registered under the right category");
+        assert.deepEqual(loader.getPlugins('bar'), plugins.bar, "The plugins are registered under the right category");
+    });
+
+
+    QUnit.module('dynamic');
+
+    QUnit.test('add plugin module format', function (assert){
+        QUnit.expect(3);
+
+        var loader = pluginLoader();
+
+        assert.equal(typeof loader, 'object', "The loader is an object");
+
+        assert.throws(function(){
+            loader.add(12);
+        }, TypeError, 'A module is a string');
+
+        assert.throws(function(){
+            loader.add('12', true);
+        }, TypeError, 'A category is a string');
+
+        loader.add('foo', 'foo');
+    });
+
+    QUnit.asyncTest('load a plugin', function (assert){
+        QUnit.expect(5);
+
+        var loader = pluginLoader();
+
+        assert.equal(typeof loader, 'object', "The loader is an object");
+
+        assert.deepEqual(loader.append('test/core/pluginLoader/mockPlugin', 'mock'), loader, 'The loader chains');
+
+        var p = loader.load();
+
+        assert.ok(p instanceof Promise, "The load method returns a Promise");
+        assert.deepEqual(loader.getPlugins('mock'), [], 'The loader mock category is empty');
+
+        p.then(function(){
+            assert.equal(loader.getPlugins('mock').length, 1, 'The mock category contains now a plugin');
+            QUnit.start();
+        }).catch(function(e){
+            assert.ok(false, e);
+            QUnit.start();
+        });
+    });
+});


### PR DESCRIPTION
I've moved the plugin factory from taoTests to tao in order to use it in the item creator.
All references to the test runner should have been removed.
The plugins have now an access to it's "host" using the `getHost` method. For convenience it's possible to alias this method if the `hostName` is provided in the config.