### PR TITLE
better backend detection, store returns a promise

### DIFF
--- a/views/js/layout/tree.js
+++ b/views/js/layout/tree.js
@@ -57,7 +57,6 @@ define([
             limit           : pageRange
         });
 
-        var treeStore = store('taotree');
         var lastSelected;
 
         /**
@@ -84,12 +83,14 @@ define([
             // workaround to fix dublicate tree bindings on multiple page loads
             if (!$elt.hasClass('tree')) {
 
-                treeStore.getItem(context.section).then(function(node){
-                    if(node){
-                        lastSelected = node;
-                    }
-                    //create the tree
-                    $elt.tree(treeOptions);
+                store('taotree').then(function(treeStore){
+                    treeStore.getItem(context.section).then(function(node){
+                        if(node){
+                            lastSelected = node;
+                        }
+                        //create the tree
+                        $elt.tree(treeOptions);
+                    });
                 });
             }
         };
@@ -340,8 +341,10 @@ define([
                         nodeContext.context = ['instance', 'resource'];
 
                         //the last selected node is stored
-                        treeStore.setItem(context.section, nodeId).then(function(){
-                            executePossibleAction(options.actions, nodeContext, ['moveInstance', 'delete']);
+                        store('taotree').then(function(treeStore){
+                            treeStore.setItem(context.section, nodeId).then(function(){
+                                executePossibleAction(options.actions, nodeContext, ['moveInstance', 'delete']);
+                            });
                         });
                     }
 

--- a/views/js/test/core/store/store/test.html
+++ b/views/js/test/core/store/store/test.html
@@ -7,6 +7,7 @@
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="core/store.js"></script>
         <script type="text/javascript">
 


### PR DESCRIPTION
 - indexdb support detection is async (open on error) so retrieving the store is
 - prevent the invalidStateError to appear
 - better fallback

Easiest way to reproduce is using FF in private browsing mode (beause `window.indexdb` is available but it fails while opening a db, see https://bugzilla.mozilla.org/show_bug.cgi?id=781982)