### PR TITLE
fix the TypeError

### DIFF
--- a/views/js/ui/mediasizer.js
+++ b/views/js/ui/mediasizer.js
@@ -275,7 +275,7 @@ define([
             $responsiveToggleField.on('click', function () {
                 _checkMode();
                 $elt.trigger('responsiveswitch.' + ns, [$responsiveToggleField.is(':checked')]);
-                $elt.trigger('sizechange.' + ns, this._publicArgs($elt, options));
+                $elt.trigger('sizechange.' + ns, self._publicArgs($elt, options));
             });
 
             //initialize it properly
@@ -327,6 +327,8 @@ define([
          * @private
          */
         _sync: function ($elt, $field, eventType) {
+            var self = this;
+
             eventType = eventType === 'sliderchange' ? 'sliderEvent' : 'fieldEvent';
 
             var options = $elt.data(dataNs),
@@ -426,7 +428,7 @@ define([
                 options.target.attr('width', currentValues.width);
                 options.target.attr('height', currentValues.height);
             }
-            $elt.trigger('sizechange.' + ns, this._publicArgs($elt, options));
+            $elt.trigger('sizechange.' + ns, self._publicArgs($elt, options));
         },
 
 
@@ -507,10 +509,10 @@ define([
          * @private
          */
         _getValues: function ($elt) {
-            
+
             var options = $elt.data(dataNs),
                 attr = {};
-            
+
             _.forOwn(options.sizeProps[options.sizeProps.currentUnit].current, function (value, dimension) {
                 if (_.isNull(value)) {
                     value = '';


### PR DESCRIPTION
In the Item Creator, include an image, switch from responsive to normal mode.
This fix just prevent the error, but the mediasizer still doesn't work in normal mode.
The test is useless and should be rewritten. 

The file was wrongly encoded,  but the real change is made here (`this` to `self`) https://github.com/oat-sa/tao-core/compare/develop...fix/error-mediasizer-mode?expand=1#diff-c44a232380cb3c35bcfd1d7059f8eb3bR431