### PR TITLE
update grunt and plugins

### DIFF
--- a/views/build/package.json
+++ b/views/build/package.json
@@ -2,23 +2,23 @@
   "name": "tao-build",
   "description": "Client side build tool chain for TAO",
   "scripts": {
-    "build": "grunt build --no-color",
-    "bundle": "grunt bundleall --no-color",
-    "sass": "grunt sassall --no-color",
-    "test": "grunt testall --no-color --force"
+    "build": "./node_modules/.bin/grunt build --no-color",
+    "bundle": "./node_modules/.bin/grunt bundleall --no-color",
+    "sass": "./node_modules/.bin/grunt sassall --no-color",
+    "test": "./node_modules/.bin/grunt testall --no-color --force"
   },
   "devDependencies": {
-    "grunt": ">=0.4.5",
+    "grunt": "^1.0.0",
     "grunt-concurrent": "^2.1.0",
     "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-connect": "^0.11.0",
-    "grunt-contrib-copy": "^0.8.0",
-    "grunt-contrib-jshint": "^0.12.0",
+    "grunt-contrib-connect": "^1.0.2",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-qunit": "^1.0.0",
-    "grunt-contrib-requirejs": "^0.4.4",
-    "grunt-contrib-sass": "^0.8.1",
-    "grunt-contrib-uglify": "^0.11.0",
-    "grunt-contrib-watch": "~0.6.1",
+    "grunt-contrib-requirejs": "^1.0.0",
+    "grunt-contrib-sass": "^1.0.0",
+    "grunt-contrib-uglify": "^1.0.1",
+    "grunt-contrib-watch": "^1.0.0",
     "grunt-contrib-compress" : "^1.0.0",
     "grunt-notify": "^0.4.3",
     "grunt-qunit-junit": "^0.3.0",
@@ -26,6 +26,6 @@
     "grunt-aws-s3" : "^0.14.0",
     "load-grunt-tasks": "^3.4.0",
     "time-grunt": "^1.0.0",
-    "lodash": "~4.4.0"
+    "lodash": "^4.13.1"
   }
 }


### PR DESCRIPTION
I've updated the dependency to grunt (to grunt 1.0.0) and most of the grunt plugins. 
On my computer it reduces the compilation time from 27min to 3min.

Even if the requirejs, uglify and sass version are backward compatible this could have an impact everywhere.

Please reinstall the dependencies, compile all full build (`npm run build`) and test the platform in production mode (a configuration with the new TR for example because it involves a lot compiled bundles).

It requires https://github.com/oat-sa/extension-tao-delivery/pull/174 because the new version of `grunt-contrib-sass` is more strict and fails when a file does not exists.

Because this is a more or less risky PR, don't hesitate to involve the test team.  