### PR TITLE
remove preview.css from every page

### DIFF
--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -21,11 +21,8 @@ $hasVersionWarning = empty($_COOKIE['versionWarning'])
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?= Layout::getTitle() ?></title>
-    <link rel="shortcut icon" href="<?= Template::img('img/favicon.ico') ?>"/>
+    <link rel="shortcut icon" href="<?= Template::img('img/favicon.ico', 'tao') ?>"/>
 
-
-
-    <link rel="stylesheet" href="<?= Template::css('preview.css','taoItems') ?>" />
     <?= tao_helpers_Scriptloader::render() ?>
     <?= Layout::getAmdLoader() ?>
     <link rel="stylesheet" href="<?= Layout::getThemeStylesheet(Theme::CONTEXT_BACKOFFICE) ?>" />


### PR DESCRIPTION
Prevent loading the file `taoItems/views/css/preview.css` on every page (yes, I know). 

See https://github.com/oat-sa/tao-core/compare/develop...fix/remove-preview-css?expand=1#diff-d9fd2dde1e713a8d3c14c24e45685535L28

The whole file seems to be be wrongly encoded, so it has been re-encoded on to `utf-8[unix]`.


Requires https://github.com/oat-sa/extension-tao-item/pull/214

Related to https://oat-sa.atlassian.net/browse/TAO-1439