### PR TITLE
Check user uri before editing

### DIFF
--- a/actions/class.Users.php
+++ b/actions/class.Users.php
@@ -186,10 +186,9 @@ class tao_actions_Users extends tao_actions_CommonModule
             $message = __('User deletion not permited on a demo instance');
         } elseif ($this->hasRequestParameter('uri')) {
             $user = new core_kernel_classes_Resource(tao_helpers_Uri::decode($this->getRequestParameter('uri')));
+            $this->checkUser($user->getUri());
 
-            if ($user->getUri() == LOCAL_NAMESPACE . DEFAULT_USER_URI_SUFFIX) {
-                $message = __('Default user cannot be deleted');
-            } elseif ($this->userService->removeUser($user)) {
+            if ($this->userService->removeUser($user)) {
                 $deleted = true;
                 $message = __('User deleted successfully');
             }
@@ -289,6 +288,7 @@ class tao_actions_Users extends tao_actions_CommonModule
         }
 
         $user = new core_kernel_classes_Resource(tao_helpers_Uri::decode($this->getRequestParameter('uri')));
+        $this->checkUser($user->getUri());
 
         $myFormContainer = new tao_actions_form_Users($this->userService->getClass($user), $user);
         $myForm = $myFormContainer->getForm();
@@ -322,5 +322,17 @@ class tao_actions_Users extends tao_actions_CommonModule
         $this->setData('formTitle', __('Edit a user'));
         $this->setData('myForm', $myForm->render());
         $this->setView('user/form.tpl');
+    }
+
+    /**
+     * Check whether user user data can be changed
+     * @param $uri
+     * @throws Exception
+     */
+    private function checkUser($uri)
+    {
+        if ($uri === LOCAL_NAMESPACE . DEFAULT_USER_URI_SUFFIX) {
+            throw new Exception('Default user data cannot be changed');
+        }
     }
 }


### PR DESCRIPTION
Security testers found that they can change super user data by removing "disabled" attribute from button here:
![image](https://cloud.githubusercontent.com/assets/11025793/16633834/b9fae5cc-4390-11e6-9d08-23ffd37618b4.png)

I have added checking of user uri on server side.