### PR TITLE
Fix/tao 2767 dynamic component closer

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '5.9.0',
+    'version' => '5.9.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=2.25.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -556,7 +556,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.6.3');
         }
 
-        $this->skip('5.6.3', '5.9.0');
+        $this->skip('5.6.3', '5.9.1');
     }
 
     private function migrateFsAccess() {

--- a/views/js/ui/dynamicComponent.js
+++ b/views/js/ui/dynamicComponent.js
@@ -111,13 +111,13 @@ define([
                 var config = this.config;
                 var draggableContainer;
                 var $draggingLayer;
-                
+
                 //set size + position
                 this.resetPosition();
                 this.resetSize();
 
                 //init closer
-                interact($element.find('.dynamic-component-title-bar .closer').selector).on('tap', function() {
+                $('.dynamic-component-title-bar .closer', $element).on('click', function() {
                     self.hide();
                 });
 
@@ -134,7 +134,7 @@ define([
                     if(_.isElement(draggableContainer) || _.isString(draggableContainer)){
                         //the dragging layer enable issue while dragging content with iframes
                         $draggingLayer = $content.find('.dynamic-component-layer');
-                        
+
                         interactElement.draggable({
                             inertia : false,
                             autoScroll : true,
@@ -152,10 +152,10 @@ define([
                                 $draggingLayer.removeClass('dragging-active');
                             }
                         });
-                        
+
                         //manually start interactjs draggable on the handle
                         interact($element.find('.dynamic-component-title-bar')[0]).on('down', function (event){
-                            
+
                             var interaction = event.interaction,
                                 handle = event.currentTarget;
 


### PR DESCRIPTION
contextualize the event, also move from interact's tap to a plain click (not really necessary).