### PR TITLE
TAO-2811 Now you can deselect all values from a treeview.

### DIFF
--- a/helpers/form/elements/xhtml/class.Treeview.php
+++ b/helpers/form/elements/xhtml/class.Treeview.php
@@ -32,12 +32,7 @@ use oat\tao\model\GenerisTreeFactory;
 class tao_helpers_form_elements_xhtml_Treeview
     extends tao_helpers_form_elements_Treeview
 {
-    // --- ASSOCIATIONS ---
-
-
-    // --- ATTRIBUTES ---
-
-    // --- OPERATIONS ---
+    const NO_TREEVIEW_INTERACTION_IDENTIFIER = 'x-tao-no-treeview-interaction';
 
     /**
      * Short description of method feed
@@ -48,24 +43,21 @@ class tao_helpers_form_elements_xhtml_Treeview
      */
     public function feed()
     {
-        
 		$expression = "/^" . preg_quote($this->name, "/") . "(.)*[0-9]+$/";
-		$found = false;
+        $foundIndexes = array();
 		foreach ($_POST as $key => $value) {
 			if (preg_match($expression, $key)) {
-				$found = true;
-				break;
-			}
-		}
-		if ($found) {
-			$this->setValues(array());
-			foreach ($_POST as $key => $value) {
-				if (preg_match($expression, $key)) {
-					$this->addValue(tao_helpers_Uri::decode($value));
-				}
+				$foundIndexes[] = $key;
 			}
 		}
         
+        if ((count($foundIndexes) > 0 && $_POST[$foundIndexes[0]] !== self::NO_TREEVIEW_INTERACTION_IDENTIFIER) || count($foundIndexes) === 0) {
+             $this->setValues(array());
+        }
+        
+        foreach ($foundIndexes as $index) {
+            $this->addValue(tao_helpers_Uri::decode($_POST[$index]));
+        }
     }
 
     /**
@@ -121,7 +113,9 @@ class tao_helpers_form_elements_xhtml_Treeview
         $returnValue .= "<label class='form_desc' for='{$this->name}'>". _dh($this->getDescription())."</label>";
 
         $returnValue .= "<div class='form-elt-container' style='min-height:50px; overflow-y:auto;'>";
-        $returnValue .= "<div id='{$widgetValueName}'></div>";
+        $returnValue .= "<div id='{$widgetValueName}'>";
+        $returnValue .= '<input type="hidden" value="' . self::NO_TREEVIEW_INTERACTION_IDENTIFIER . '" name="' . $this->name . '_0"/>';
+        $returnValue .= "</div>";
 
 
 		$returnValue .= "<div id='{$widgetTreeName}'></div>";

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '5.9.0',
+    'version' => '5.9.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=2.25.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -556,7 +556,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('5.6.3');
         }
 
-        $this->skip('5.6.3', '5.9.0');
+        $this->skip('5.6.3', '5.9.1');
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
Without this patch, it is impossible to remove all the selected elements of a Treeview widget. You can check that by installing taoClientRestrict. Without this patch, it's impossible to unslect all the browsers/os previously checked.