### PR TITLE
Feature/tao 2848 dialog exit reason

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.0.4',
+    'version' => '7.1.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=2.28.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -557,13 +557,13 @@ class Updater extends \common_ext_ExtensionUpdater {
 
         }
         $this->skip('5.9.2', '6.0.1');
-        
+
         if ($this->isVersion('6.0.1')) {
             OntologyUpdater::syncModels();
             $this->setVersion('6.1.0');
         }
 
-        $this->skip('6.1.0', '7.0.4');
+        $this->skip('6.1.0', '7.1.0');
     }
 
     private function migrateFsAccess() {

--- a/views/js/test/ui/modal/test.js
+++ b/views/js/test/ui/modal/test.js
@@ -128,8 +128,10 @@ define([
                 $modal.modal('close');
             }
         });
-        $modal.on('closed.modal', function() {
+        $modal.on('closed.modal', function(e, reason) {
             assert.ok(true, "The modal is now hidden");
+            assert.equal(typeof e, 'object', 'A event object is provided');
+            assert.equal(reason, 'api', 'The exit reason has been provided');
             QUnit.start();
 
             closed = true;

--- a/views/js/ui/dialog.js
+++ b/views/js/ui/dialog.js
@@ -113,6 +113,8 @@ define([
          * @param {String|jQuery|HTMLElement} options.renderTo - A container in which renders the dialog (default: 'body').
          * @param {Boolean} options.autoRender - Allow the dialog to be immediately rendered after initialise.
          * @param {Boolean} options.autoDestroy - Allow the dialog to be immediately destroyed when closing.
+         * @param {Boolean} [options.disableClosing = false] - to disable the default closers
+         * @param {Boolean} [options.disableEscape = false] - to disable the ability to escape close the dialog
          * @param {Number} options.width - The dialog box width in pixels (default: 500).
          * @param {Number|Boolean} options.animate - The dialog box animate duration (default: false).
          * @param {Function} options.onXYZbtn - An event handler assigned to a particular button (XYZ).
@@ -393,7 +395,7 @@ define([
                 }
             }
         },
-        
+
         /**
          * Installs the dialog box
          * @private
@@ -401,9 +403,11 @@ define([
         _install : function() {
             this.$html.modal({
                 width: this.width,
-                animate: this.animate
+                animate: this.animate,
+                disableClosing: this.disableClosing,
+                disableEscape: this.disableEscape
             });
-            
+
             this._setFocusOnModal();
         },
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-2848

Provide the exit reason as a parameter of the `close` event when the modal/dialog is closed.
