### PR TITLE
Feature/event context

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.5.0',
+    'version' => '7.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=2.30.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -563,7 +563,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('6.1.0');
         }
 
-        $this->skip('6.1.0', '7.5.0');
+        $this->skip('6.1.0', '7.6.0');
     }
 
     private function migrateFsAccess() {

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -289,23 +289,23 @@ define([
             return eventHandlers[ns][name][type];
         };
 
-       /**
-        * The API itself is just a placeholder, all methods will be delegated to a target.
-        */
+        /**
+         * The API itself is just a placeholder, all methods will be delegated to a target.
+         */
         var eventApi = {
 
-           /**
-            * Attach an handler to an event.
-            * Calling `on` with the same eventName multiple times add callbacks: they
-            * will all be executed.
-            *
-            * @example target.on('foo', function(bar){ console.log('Cool ' + bar) } );
-            *
-            * @this the target
-            * @param {String} eventNames - the name of the event, or multiple events separated by a space
-            * @param {Function} handler - the callback to run once the event is triggered
-            * @returns {Object} the target object
-            */
+            /**
+             * Attach an handler to an event.
+             * Calling `on` with the same eventName multiple times add callbacks: they
+             * will all be executed.
+             *
+             * @example target.on('foo', function(bar){ console.log('Cool ' + bar) } );
+             *
+             * @this the target
+             * @param {String} eventNames - the name of the event, or multiple events separated by a space
+             * @param {Function} handler - the callback to run once the event is triggered
+             * @returns {Object} the target object
+             */
             on : function on(eventNames, handler){
                 if(_.isFunction(handler)){
                     _.forEach(getEventNames(eventNames), function(eventName){
@@ -315,25 +315,25 @@ define([
                 return this;
             },
 
-           /**
-            * Remove ALL handlers for an event.
-            *
-            * @example remove ALL
-            * target.off('foo');
-            *
-            * @example remove targeted namespace
-            * target.off('foo.bar');
-            *
-            * @example remove all handlers by namespace
-            * target.off('.bar');
-            *
-            * @example remove all namespaces, keep non namespace
-            * target.off('.*');
-            *
-            * @this the target
-            * @param {String} eventNames - the name of the event, or multiple events separated by a space
-            * @returns {Object} the target object
-            */
+            /**
+             * Remove ALL handlers for an event.
+             *
+             * @example remove ALL
+             * target.off('foo');
+             *
+             * @example remove targeted namespace
+             * target.off('foo.bar');
+             *
+             * @example remove all handlers by namespace
+             * target.off('.bar');
+             *
+             * @example remove all namespaces, keep non namespace
+             * target.off('.*');
+             *
+             * @this the target
+             * @param {String} eventNames - the name of the event, or multiple events separated by a space
+             * @returns {Object} the target object
+             */
             off : function off(eventNames){
 
                 _.forEach(getEventNames(eventNames), function(eventName){
@@ -363,14 +363,29 @@ define([
             },
 
             /**
-            * Trigger an event.
-            *
-            * @example target.trigger('foo', 'Awesome');
-            *
-            * @this the target
-            * @param {String} eventNames - the name of the event to trigger, or multiple events separated by a space
-            * @returns {Object} the target object
-            */
+             * Remove ALL registered handlers
+             *
+             * @example remove ALL
+             * target.removeAllListeners();
+             *
+             * @this the target
+             * @returns {Object} the target object
+             */
+            removeAllListeners : function removeAllListeners(){
+                // full erase
+                eventHandlers  = {};
+                return this;
+            },
+
+            /**
+             * Trigger an event.
+             *
+             * @example target.trigger('foo', 'Awesome');
+             *
+             * @this the target
+             * @param {String} eventNames - the name of the event to trigger, or multiple events separated by a space
+             * @returns {Object} the target object
+             */
             trigger : function trigger(eventNames){
                 var self = this;
                 var args = [].slice.call(arguments, 1);

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -100,7 +100,7 @@
  *
  * TODO replace before done syntax by promises. Work in progress:
  * - promise support added: instead of using e.done() or e.prevent() you can now just return a promise and rely on its workflow to resolve/reject the event
- * - need now to update every extension with new syntax, then finish the work
+ * - need now to update every extension with the new syntax in order to be able to use a full promise version
  * TODO support flow control for all types of events not only before.
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -72,7 +72,7 @@
  *      });
  * });
  *
- * TODO replace before done syntax by promises
+ * TODO replace before done syntax by promises (work in progress: promise support added, need now to update every extension with new syntax, then finish the work)
  * TODO support flow control for all types of events not only before.
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
@@ -80,8 +80,9 @@
 define([
     'lodash',
     'async',
+    'core/promise',
     'lib/uuid'
-], function(_, async, uuid){
+], function(_, async, Promise, uuid){
     'use strict';
 
     /**
@@ -169,7 +170,7 @@ define([
                         //if the call
                         prevent();
                     }else{
-                        done();
+                        Promise.resolve(result).then(done).catch(prevent);
                     }
                 }
             };

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -252,7 +252,7 @@ define([
             * @example target.on('foo', function(bar){ console.log('Cool ' + bar) } );
             *
             * @this the target
-            * @param {String} eventNames- the name of the event, or multiple events separated by a space
+            * @param {String} eventNames - the name of the event, or multiple events separated by a space
             * @param {Function} handler - the callback to run once the event is triggered
             * @returns {Object} the target object
             */
@@ -271,7 +271,7 @@ define([
             * @example target.off('foo');
             *
             * @this the target
-            * @param {String} eventNames- the name of the event, or multiple events separated by a space
+            * @param {String} eventNames - the name of the event, or multiple events separated by a space
             * @returns {Object} the target object
             */
             off : function off(eventNames){
@@ -302,7 +302,7 @@ define([
             * @example target.trigger('foo', 'Awesome');
             *
             * @this the target
-            * @param {String} eventNames- the name of the event to trigger, or multiple events separated by a space
+            * @param {String} eventNames - the name of the event to trigger, or multiple events separated by a space
             * @returns {Object} the target object
             */
             trigger : function trigger(eventNames){
@@ -315,15 +315,15 @@ define([
 
                     //check which ns needs to be executed and then merge the handlers to be executed
                     var mergedHandlers = _(eventHandlers)
-                    .filter(function(nsHandlers, namespace){
-                        return nsHandlers[name] && (ns === globalNs || ns === namespace);
-                    })
-                    .reduce(function(acc, nsHandlers){
-                        acc.before  = acc.before.concat(nsHandlers[name].before);
-                        acc.between = acc.between.concat(nsHandlers[name].between);
-                        acc.after   = acc.after.concat(nsHandlers[name].after);
-                        return acc;
-                    }, getHandlerObject());
+                        .filter(function(nsHandlers, namespace){
+                            return nsHandlers[name] && (ns === globalNs || ns === namespace);
+                        })
+                        .reduce(function(acc, nsHandlers){
+                            acc.before  = acc.before.concat(nsHandlers[name].before);
+                            acc.between = acc.between.concat(nsHandlers[name].between);
+                            acc.after   = acc.after.concat(nsHandlers[name].after);
+                            return acc;
+                        }, getHandlerObject());
 
                     if(mergedHandlers){
 
@@ -358,13 +358,14 @@ define([
             },
 
             /**
-            * Register a callback that is executed before the given event name
-            * Provides an opportunity to cancel the execution of the event if one of the returned value is false
-            *
-            * @this the target
-            * @param {String} eventName
-            * @returns {Object} the target object
-            */
+             * Register a callback that is executed before the given event name
+             * Provides an opportunity to cancel the execution of the event if one of the returned value is false
+             *
+             * @this the target
+             * @param {String} eventNames - the name of the event, or multiple events separated by a space
+             * @param {Function} handler - the callback to run once the event is triggered
+             * @returns {Object} the target object
+             */
             before : function before(eventNames, handler){
                 if(_.isFunction(handler)) {
                     _.forEach(getEventNames(eventNames), function(eventName){
@@ -375,13 +376,14 @@ define([
             },
 
             /**
-            * Register a callback that is executed after the given event name
-            * The handlers will all be executed, no matter what
-            *
-            * @this the target
-            * @param {String} eventName
-            * @returns {Object} the target object
-            */
+             * Register a callback that is executed after the given event name
+             * The handlers will all be executed, no matter what
+             *
+             * @this the target
+             * @param {String} eventNames - the name of the event, or multiple events separated by a space
+             * @param {Function} handler - the callback to run once the event is triggered
+             * @returns {Object} the target object
+             */
             after : function after(eventNames, handler){
                 if(_.isFunction(handler)) {
                     _.forEach(getEventNames(eventNames), function(eventName){

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -77,11 +77,13 @@ define([
      * Create an async callstack
      * @param {array} handlers - array of handlers to create the async callstack from
      * @param {object} context - the object that each handler will be applied on
+     * @param {String} eventName - The name of the triggered event
+     * @param {String} namespace - The namespace of the triggered event
      * @param {array} args - the arguments passed to each handler
      * @param {function} success - the success callback
      * @returns {array} array of aync call stack
      */
-    function createAsyncCallstack(handlers, context, args, success){
+    function createAsyncCallstack(handlers, context, eventName, namespace, args, success){
 
         var callstack =  _.map(handlers, function(handler){
 
@@ -92,6 +94,8 @@ define([
                 var asyncMode = false;
                 var _args = _.clone(args);
                 var event = {
+                    name: eventName,
+                    namespace: namespace,
                     done : function asyncDone(){
                         asyncMode = true;
                         //returns the done function and wait until it is called to continue the async queue processing
@@ -325,7 +329,7 @@ define([
 
                         //if there is something in before we delay the execution
                         if(mergedHandlers.before.length){
-                            createAsyncCallstack(mergedHandlers.before, self, args, _.partial(triggerEvent, mergedHandlers));
+                            createAsyncCallstack(mergedHandlers.before, self, name, ns, args, _.partial(triggerEvent, mergedHandlers));
                         } else {
                             triggerEvent(mergedHandlers);
                         }

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -54,6 +54,32 @@
  * @example using before asynchronously
  * emitter.before('hello', function(e, who){
  *
+ *      // you can know about the event context
+ *      var eventName = e.name;
+ *      var eventNamespace = e.namespace;
+ *      console.log('Received a ' + eventName + '.' + eventNamespace + ' event');
+ *
+ *      // I am in an asynchronous context
+ *      return new Promise(function(resolve, reject) {
+ *          // ajax call
+ *          fetch('do/I/know?who='+who).then(function(yes) {
+ *              if (yes) {
+ *                  console.log('I know', who);
+ *                  resolve();
+ *              } else {
+ *                  console.log('I don't talk to stranger');
+ *                  reject();
+ *              }
+ *          }).catch(function(err){
+ *              console.log('System failure, I should quit now');
+ *              reject(err);
+ *          });
+ *      });
+ * });
+ *
+ * @example using before asynchronously (deprecated)
+ * emitter.before('hello', function(e, who){
+ *
  *      //I am in an asynchronous context
  *      var done = e.done();
  *
@@ -72,7 +98,9 @@
  *      });
  * });
  *
- * TODO replace before done syntax by promises (work in progress: promise support added, need now to update every extension with new syntax, then finish the work)
+ * TODO replace before done syntax by promises. Work in progress:
+ * - promise support added: instead of using e.done() or e.prevent() you can now just return a promise and rely on its workflow to resolve/reject the event
+ * - need now to update every extension with new syntax, then finish the work
  * TODO support flow control for all types of events not only before.
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>

--- a/views/js/test/core/eventifier/test.js
+++ b/views/js/test/core/eventifier/test.js
@@ -3,7 +3,9 @@ define(['core/eventifier'], function(eventifier){
 
     QUnit.module('eventifier');
 
-    QUnit.test("api", 2, function(assert){
+    QUnit.test("api", function(assert){
+        QUnit.expect(2);
+
         assert.ok(typeof eventifier !== 'undefined', "The module exports something");
         assert.ok(typeof eventifier === 'function', "The module has an eventifier method");
     });
@@ -11,9 +13,11 @@ define(['core/eventifier'], function(eventifier){
 
     QUnit.module('eventification');
 
-    QUnit.test("delegates", 4, function(assert){
+    QUnit.test("delegates", function(assert){
 
         var emitter = eventifier();
+
+        QUnit.expect(4);
 
         assert.ok(typeof emitter === 'object', "the emitter definition is an object");
         assert.ok(typeof emitter.on === 'function', "the emitter defintion holds the method on");
@@ -21,10 +25,12 @@ define(['core/eventifier'], function(eventifier){
         assert.ok(typeof emitter.off === 'function', "the emitter defintion holds the method off");
     });
 
-    QUnit.asyncTest("listen and trigger with params", 3, function(assert){
+    QUnit.asyncTest("listen and trigger with params", function(assert){
 
         var emitter = eventifier();
         var params = ['bar', 'baz'];
+
+        QUnit.expect(3);
 
         emitter.on('foo', function handleFoo(p0, p1){
             assert.ok(true, "The foo event is triggered on emitter");
@@ -36,18 +42,22 @@ define(['core/eventifier'], function(eventifier){
         emitter.trigger('foo', params[0], params[1]);
     });
 
-    QUnit.test("on context", 1, function(assert){
+    QUnit.test("on context", function(assert){
 
         var emitter1 = eventifier();
         var emitter2 = eventifier();
+
+        QUnit.expect(1);
 
         assert.notDeepEqual(emitter1, emitter2, "Emitters are different objects");
     });
 
 
-    QUnit.asyncTest("trigger context", 2, function(assert){
+    QUnit.asyncTest("trigger context", function(assert){
         var emitter1 = eventifier();
         var emitter2 = eventifier();
+
+        QUnit.expect(2);
 
         emitter1.on('foo', function(success){
             assert.ok(success, "The foo event is triggered on emitter1");
@@ -63,8 +73,10 @@ define(['core/eventifier'], function(eventifier){
         }, 10);
     });
 
-    QUnit.asyncTest("off", 1, function(assert){
+    QUnit.asyncTest("off", function(assert){
         var emitter = eventifier();
+
+        QUnit.expect(1);
 
         emitter.on('foo', function(){
             assert.ok(false, "The foo event shouldn't be triggered");
@@ -81,8 +93,10 @@ define(['core/eventifier'], function(eventifier){
         }, 10);
     });
 
-    QUnit.asyncTest("multiple listeners", 2, function(assert){
+    QUnit.asyncTest("multiple listeners", function(assert){
         var emitter = eventifier();
+
+        QUnit.expect(2);
 
         emitter.on('foo', function(){
             assert.ok(true, "The 1st foo listener should be executed");
@@ -95,12 +109,12 @@ define(['core/eventifier'], function(eventifier){
         emitter.trigger('foo');
     });
 
-    QUnit.module('namspaces');
+    QUnit.module('namespaces');
 
     QUnit.asyncTest("listen namespace, trigger without namespace", function(assert){
-        QUnit.expect(2);
-
         var emitter = eventifier();
+
+        QUnit.expect(2);
 
         emitter.on('foo', function(){
             assert.ok(true, 'the foo handler is called');
@@ -114,9 +128,9 @@ define(['core/eventifier'], function(eventifier){
     });
 
     QUnit.asyncTest("listen namespace, trigger with namespace", function(assert){
-        QUnit.expect(1);
-
         var emitter = eventifier();
+
+        QUnit.expect(1);
 
         emitter.on('foo', function(){
             assert.ok(false, 'the foo handler should not be called');
@@ -130,9 +144,9 @@ define(['core/eventifier'], function(eventifier){
     });
 
     QUnit.asyncTest("off namespaced event", function(assert){
-        QUnit.expect(0);
-
         var emitter = eventifier();
+
+        QUnit.expect(0);
 
         emitter.on('foo', function(){
             assert.ok(false, 'the foo handler should not be called');
@@ -179,6 +193,8 @@ define(['core/eventifier'], function(eventifier){
         var arg1 = 'X',
             arg2 = 'Y';
 
+        QUnit.expect(21);
+
         testDriver.on('next', function(){
             assert.ok(true, "The 1st listener should be executed : e.g. save context recovery");
         });
@@ -191,11 +207,23 @@ define(['core/eventifier'], function(eventifier){
         });
 
         testDriver.before('next', function(e, a1, a2){
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'next', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             assert.equal(a1, arg1, 'the first event arg is correct');
             assert.equal(a2, arg2, 'the second event arg is correct');
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate item state");
         });
         testDriver.before('next', function(e, a1, a2){
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'next', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             assert.equal(a1, arg1, 'the first event arg is correct');
             assert.equal(a2, arg2, 'the second event arg is correct');
             assert.ok(true, "The 2nd 'before' listener should be executed : e.g. validate a special interaction state");
@@ -210,6 +238,8 @@ define(['core/eventifier'], function(eventifier){
         var arg1 = 'X',
             arg2 = 'Y';
 
+        QUnit.expect(21);
+
         testDriver.on('next', function(){
             assert.ok(true, "The 1st listener should be executed : e.g. save context recovery");
         });
@@ -222,6 +252,12 @@ define(['core/eventifier'], function(eventifier){
         });
 
         testDriver.before('next', function(e, a1, a2){
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'next', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             assert.equal(a1, arg1, 'the first event arg is correct');
             assert.equal(a2, arg2, 'the second event arg is correct');
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate item state");
@@ -232,6 +268,12 @@ define(['core/eventifier'], function(eventifier){
         });
 
         testDriver.before('next', function(e, a1, a2){
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'next', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             assert.equal(a1, arg1, 'the first event arg is correct');
             assert.equal(a2, arg2, 'the second event arg is correct');
             assert.ok(true, "The 2nd 'before' listener should be executed : e.g. validate a special interaction state");
@@ -240,22 +282,30 @@ define(['core/eventifier'], function(eventifier){
         testDriver.trigger('next', arg1, arg2);
     });
 
-    QUnit.test("async done - fail to call done()", 1, function(assert){
+    QUnit.test("async done - fail to call done()", function(assert){
 
         var testDriver = eventifier();
 
+        QUnit.expect(7);
+
         testDriver.on('next', function(){
-            assert.ok(true, "The listener should not be executed : e.g. save context recovery");
+            assert.ok(false, "The listener should not be executed : e.g. save context recovery");
         });
 
         testDriver.before('next', function(e){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate item state");
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'next', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             var done = e.done();
             //fail to call done here although we are in an async context
         });
 
         testDriver.before('next', function(e){
-            assert.ok(true, "The 2nd 'before' listener should not be executed : e.g. validate a special interaction state");
+            assert.ok(false, "The 2nd 'before' listener should not be executed : e.g. validate a special interaction state");
         });
 
         testDriver.trigger('next');
@@ -265,16 +315,30 @@ define(['core/eventifier'], function(eventifier){
 
         var itemEditor = eventifier();
 
+        QUnit.expect(14);
+
         itemEditor.on('save', function(){
-            assert.ok(true, "The listener should not be executed : e.g. do save item");
+            assert.ok(false, "The listener should not be executed : e.g. do save item");
         });
         itemEditor.before('save', function(e){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'save', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             //form invalid
             return false;
         });
         itemEditor.before('save', function(e){
             assert.ok(true, "The 2nd 'before' listener should be executed : e.g. do save item stylesheet");
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'save', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             QUnit.start();
         });
 
@@ -285,16 +349,30 @@ define(['core/eventifier'], function(eventifier){
 
         var itemEditor = eventifier();
 
+        QUnit.expect(14);
+
         itemEditor.on('save', function(){
-            assert.ok(true, "The listener should not be executed : e.g. do save item");
+            assert.ok(false, "The listener should not be executed : e.g. do save item");
         });
         itemEditor.before('save', function(e){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'save', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             //form invalid
             e.prevent();
         });
         itemEditor.before('save', function(e){
             assert.ok(true, "The 2nd 'before' listener should be executed : e.g. do save item stylesheet");
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'save', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             QUnit.start();
         });
 
@@ -305,11 +383,19 @@ define(['core/eventifier'], function(eventifier){
 
         var itemEditor = eventifier();
 
+        QUnit.expect(14);
+
         itemEditor.on('save', function(){
-            assert.ok(true, "The listener should not be executed : e.g. do save item");
+            assert.ok(false, "The listener should not be executed : e.g. do save item");
         });
         itemEditor.before('save', function(e){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'save', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             var done = e.done();
             setTimeout(function(){
                 e.prevent();
@@ -319,42 +405,64 @@ define(['core/eventifier'], function(eventifier){
         });
         itemEditor.before('save', function(e){
             assert.ok(true, "The 2nd 'before' listener should be executed : e.g. do save item stylesheet");
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'save', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             QUnit.start();
         });
 
         itemEditor.trigger('save');
     });
 
-    QUnit.asyncTest("sync prevent now", 1, function(assert){
+    QUnit.asyncTest("sync prevent now", function(assert){
 
         var itemEditor = eventifier();
 
+        QUnit.expect(7);
+
         itemEditor.on('save', function(){
-            assert.ok(true, "The listener should not be executed : e.g. do save item");
+            assert.ok(false, "The listener should not be executed : e.g. do save item");
         });
         itemEditor.before('save', function(e){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'save', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             //form invalid that interrupt all following call
             e.preventNow();
             QUnit.start();
         });
         itemEditor.before('save', function(e){
-            assert.ok(true, "The 2nd 'before' listener should not be executed : e.g. do save item stylesheet");
+            assert.ok(false, "The 2nd 'before' listener should not be executed : e.g. do save item stylesheet");
         });
 
         itemEditor.trigger('save');
     });
 
 
-    QUnit.asyncTest("async prevent now", 1, function(assert){
+    QUnit.asyncTest("async prevent now", function(assert){
 
         var itemEditor = eventifier();
 
+        QUnit.expect(7);
+
         itemEditor.on('save', function(){
-            assert.ok(true, "The listener should not be executed : e.g. do save item");
+            assert.ok(false, "The listener should not be executed : e.g. do save item");
         });
         itemEditor.before('save', function(e){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'save', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             e.done();
 
             //form invalid that interrupt all following call
@@ -365,22 +473,23 @@ define(['core/eventifier'], function(eventifier){
             QUnit.start();
         });
         itemEditor.before('save', function(e){
-            assert.ok(true, "The 2nd 'before' listener should not be executed : e.g. do save item stylesheet");
+            assert.ok(false, "The 2nd 'before' listener should not be executed : e.g. do save item stylesheet");
         });
 
         itemEditor.trigger('save');
     });
 
     QUnit.asyncTest("namespaced events before order", function(assert){
-        QUnit.expect(12);
-
         var emitter = eventifier();
+
         var state = {
             foo : false,
             foobar : false,
             beforefoo: false,
             beforefoobar : false
         };
+
+        QUnit.expect(24);
 
         emitter.on('foo', function(){
             assert.ok(true, "The foo handler is called");
@@ -394,16 +503,32 @@ define(['core/eventifier'], function(eventifier){
             assert.equal(state.beforefoobar, true, 'The before foo.bar handler should have been called');
             state.foobar = true;
         });
-        emitter.before('foo', function(){
-            assert.ok(true, "The after foo handler is called");
+        emitter.before('foo', function(e){
+            assert.ok(true, "The before foo handler is called");
             assert.equal(state.foo, false, 'The foo handler should not have been called');
             assert.equal(state.foobar, false, 'The foo.bar handler should have been called');
+
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'foo', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+
             state.beforefoo = true;
         });
-        emitter.before('foo.bar', function(){
-            assert.ok(true, "The after foo.bar handler is called");
+        emitter.before('foo.bar', function(e){
+            assert.ok(true, "The before foo.bar handler is called");
             assert.equal(state.foo, false, 'The foo handler should not have been called');
             assert.equal(state.foobar, false, 'The foo.bar handler should have been called');
+
+            assert.equal(typeof e, 'object', 'the event context object is provided');
+            assert.equal(e.name, 'foo', 'the event name is provided');
+            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+            assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+            assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+
             state.beforefoobar = true;
         });
 
@@ -414,12 +539,186 @@ define(['core/eventifier'], function(eventifier){
         }, 10);
     });
 
+    QUnit.asyncTest("events context (simple)", function(assert){
+        var emitter = eventifier();
+
+        QUnit.expect(24);
+        QUnit.stop(1);
+
+        emitter
+            .on('ev1', function(){
+                assert.ok(true, "The ev1 handler is called");
+            })
+            .on('ev1.ns', function(){
+                assert.ok(true, "The ev1.ns handler is called");
+            })
+            .before('ev1', function(e){
+                assert.ok(true, "The before ev1 handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev1', 'the event name is provided');
+                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+            })
+            .before('ev1.ns', function(e){
+                assert.ok(true, "The before ev1.ns handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev1', 'the event name is provided');
+                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+
+                QUnit.start();
+            });
+
+        emitter
+            .on('ev2', function(){
+                assert.ok(false, "The ev2 handler should not be called");
+            })
+            .on('ev2.ns', function(){
+                assert.ok(true, "The ev2.ns handler is called");
+            })
+            .before('ev2', function(e){
+                assert.ok(false, "The before ev2 handler should not be called");
+            })
+            .before('ev2.ns', function(e){
+                assert.ok(true, "The before ev2.ns handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev2', 'the event name is provided');
+                assert.equal(e.namespace, 'ns', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+
+                QUnit.start();
+            });
+
+        emitter.trigger('ev1');
+        emitter.trigger('ev2.ns');
+    });
+
+    QUnit.asyncTest("events context (multi)", function(assert){
+        var emitter = eventifier();
+
+        QUnit.expect(96);
+        QUnit.stop(7);
+
+        emitter
+            .on('ev1', function(){
+                assert.ok(true, "The ev1 handler is called");
+            })
+            .on('ev1.ns', function(){
+                assert.ok(true, "The ev1.ns handler is called");
+            })
+            .before('ev1', function(e){
+                assert.ok(true, "The before ev1 handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev1', 'the event name is provided');
+                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+            })
+            .before('ev1.ns', function(e){
+                assert.ok(true, "The before ev1.ns handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev1', 'the event name is provided');
+                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+
+                QUnit.start();
+            });
+
+        emitter
+            .on('ev2', function(){
+                assert.ok(true, "The ev2 handler is called");
+            })
+            .on('ev2.ns', function(){
+                assert.ok(true, "The ev2.ns handler is called");
+            })
+            .before('ev2', function(e){
+                assert.ok(true, "The before ev1 handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev2', 'the event name is provided');
+                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+            })
+            .before('ev2.ns', function(e){
+                assert.ok(true, "The before ev1.ns handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev2', 'the event name is provided');
+                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+
+                QUnit.start();
+            });
+
+        emitter
+            .on('ev3', function(){
+                assert.ok(false, "The ev3 handler should not be called");
+            })
+            .on('ev3.ns3', function(){
+                assert.ok(true, "The ev3.ns3 handler is called");
+            })
+            .before('ev3', function(e){
+                assert.ok(false, "The before ev3 handler should not be called");
+            })
+            .before('ev3.ns3', function(e){
+                assert.ok(true, "The before ev3.ns3 handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev3', 'the event name is provided');
+                assert.equal(e.namespace, 'ns3', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+
+                QUnit.start();
+            });
+
+        emitter
+            .on('ev4', function(){
+                assert.ok(false, "The ev4 handler should not be called");
+            })
+            .on('ev4.ns4', function(){
+                assert.ok(true, "The ev4.ns4 handler is called");
+            })
+            .before('ev4', function(e){
+                assert.ok(false, "The before ev4 handler should not be called");
+            })
+            .before('ev4.ns4', function(e){
+                assert.ok(true, "The before ev4.ns4 handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev4', 'the event name is provided');
+                assert.equal(e.namespace, 'ns4', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+
+                QUnit.start();
+            });
+
+        emitter.trigger('ev1 ev2');
+        emitter.trigger('ev3.ns3 ev4.ns4');
+        emitter.trigger('ev1 ev3.ns3');
+        emitter.trigger('ev4.ns4 ev2');
+    });
+
 
     QUnit.module('after');
 
-    QUnit.asyncTest("trigger", 2, function(assert){
+    QUnit.asyncTest("trigger", function(assert){
 
         var testDriver = eventifier();
+
+        QUnit.expect(2);
 
         testDriver.on('next', function(){
             assert.ok(true, "This listener should be executed : e.g. move to next item");
@@ -434,15 +733,16 @@ define(['core/eventifier'], function(eventifier){
     });
 
     QUnit.asyncTest("namespaced after events order", function(assert){
-        QUnit.expect(12);
-
         var emitter = eventifier();
+
         var state = {
             foo : false,
             foobar : false,
             afterfoo: false,
             afterfoobar : false
         };
+
+        QUnit.expect(12);
 
         emitter.on('foo', function(){
             assert.ok(true, "The foo handler is called");
@@ -480,11 +780,12 @@ define(['core/eventifier'], function(eventifier){
     QUnit.module('multiple events names');
 
     QUnit.asyncTest("listen multiples, trigger one by one", function(assert){
-        QUnit.expect(2);
-
         var emitter = eventifier();
 
         var counter = 0;
+
+        QUnit.expect(2);
+
         emitter.on('foo bar', function(){
             assert.ok(true, 'the handler is called');
 
@@ -497,11 +798,12 @@ define(['core/eventifier'], function(eventifier){
     });
 
     QUnit.asyncTest("listen multiple, trigger multiples with params", function(assert){
-        QUnit.expect(8);
-
         var emitter = eventifier();
 
         var counter = 0;
+
+        QUnit.expect(8);
+
         emitter.on('foo bar', function(bool, str, num){
             assert.ok(true, 'the handler is called');
             assert.equal(bool, true, 'The 1st parameter is correct');
@@ -516,9 +818,9 @@ define(['core/eventifier'], function(eventifier){
     });
 
     QUnit.asyncTest("listen multiple, off multiple", function(assert){
-        QUnit.expect(1);
-
         var emitter = eventifier();
+
+        QUnit.expect(1);
 
         emitter.on('foo bar', function(){
             assert.ok(false, 'the handler must not be called');
@@ -535,11 +837,12 @@ define(['core/eventifier'], function(eventifier){
     });
 
     QUnit.asyncTest("support namespace in multiple events", function(assert){
-        QUnit.expect(3);
-
         var emitter = eventifier();
 
         var counter = 0;
+
+        QUnit.expect(3);
+
         emitter.on('foo bar.moo', function(){
             assert.ok(true, 'the handler is called');
 
@@ -553,9 +856,7 @@ define(['core/eventifier'], function(eventifier){
 
     QUnit.module('logger');
 
-    QUnit.asyncTest("logging events", 2, function(assert){
-        QUnit.expect(3);
-
+    QUnit.asyncTest("logging events", function(assert){
         var emitter = eventifier({
                 name : 'moo'
             }, {
@@ -567,6 +868,8 @@ define(['core/eventifier'], function(eventifier){
                 QUnit.start();
             }
         });
+
+        QUnit.expect(3);
 
         emitter.trigger('foo.bar');
     });

--- a/views/js/test/core/eventifier/test.js
+++ b/views/js/test/core/eventifier/test.js
@@ -17,12 +17,15 @@ define(['core/eventifier', 'core/promise'], function(eventifier, Promise){
 
         var emitter = eventifier();
 
-        QUnit.expect(4);
+        QUnit.expect(7);
 
         assert.ok(typeof emitter === 'object', "the emitter definition is an object");
         assert.ok(typeof emitter.on === 'function', "the emitter defintion holds the method on");
-        assert.ok(typeof emitter.trigger === 'function', "the emitter defintion holds the method trigger");
+        assert.ok(typeof emitter.before === 'function', "the emitter defintion holds the method before");
+        assert.ok(typeof emitter.after === 'function', "the emitter defintion holds the method after");
         assert.ok(typeof emitter.off === 'function', "the emitter defintion holds the method off");
+        assert.ok(typeof emitter.removeAllListeners === 'function', "the emitter defintion holds the method removeAllListeners");
+        assert.ok(typeof emitter.trigger === 'function', "the emitter defintion holds the method trigger");
     });
 
     QUnit.asyncTest("listen and trigger with params", function(assert){
@@ -82,7 +85,7 @@ define(['core/eventifier', 'core/promise'], function(eventifier, Promise){
             assert.ok(false, "The foo event shouldn't be triggered");
         });
         emitter.on('bar', function(){
-            assert.ok(true, "The bar event should  be triggered");
+            assert.ok(true, "The bar event should be triggered");
             QUnit.start();
         });
 
@@ -90,6 +93,31 @@ define(['core/eventifier', 'core/promise'], function(eventifier, Promise){
         emitter.trigger('foo');
         setTimeout(function(){
             emitter.trigger('bar');
+        }, 10);
+    });
+
+    QUnit.asyncTest("removeAllListeners", function(assert){
+        var emitter = eventifier();
+
+        QUnit.expect(0);
+
+        emitter.on('foo', function(){
+            assert.ok(false, "The foo event shouldn't be triggered");
+        });
+        emitter.on('bar', function(){
+            assert.ok(true, "The bar event shouldn't be triggered");
+        });
+
+        emitter.removeAllListeners();
+        emitter.trigger('foo');
+        emitter.trigger('bar');
+        setTimeout(function(){
+            emitter.trigger('foo');
+            emitter.trigger('bar');
+
+            setTimeout(function(){
+                QUnit.start();
+            }, 10);
         }, 10);
     });
 

--- a/views/js/test/core/eventifier/test.js
+++ b/views/js/test/core/eventifier/test.js
@@ -96,6 +96,26 @@ define(['core/eventifier', 'core/promise'], function(eventifier, Promise){
         }, 10);
     });
 
+    QUnit.asyncTest("off empty", function(assert){
+        var emitter = eventifier();
+
+        QUnit.expect(2);
+
+        emitter.on('foo', function(){
+            assert.ok(true, "The foo event should be triggered");
+        });
+        emitter.on('bar', function(){
+            assert.ok(true, "The bar event should be triggered");
+            QUnit.start();
+        });
+
+        emitter.off();
+        emitter.trigger('foo');
+        setTimeout(function(){
+            emitter.trigger('bar');
+        }, 10);
+    });
+
     QUnit.asyncTest("removeAllListeners", function(assert){
         var emitter = eventifier();
 

--- a/views/js/test/core/eventifier/test.js
+++ b/views/js/test/core/eventifier/test.js
@@ -114,10 +114,13 @@ define(['core/eventifier'], function(eventifier){
     QUnit.asyncTest("listen namespace, trigger without namespace", function(assert){
         var emitter = eventifier();
 
-        QUnit.expect(2);
+        QUnit.expect(3);
 
         emitter.on('foo', function(){
             assert.ok(true, 'the foo handler is called');
+        });
+        emitter.on('foo.*', function(){
+            assert.ok(true, 'the foo.* handler is called');
         });
         emitter.on('foo.bar', function(){
             assert.ok(true, 'the foo.bar handler is called');
@@ -130,14 +133,20 @@ define(['core/eventifier'], function(eventifier){
     QUnit.asyncTest("listen namespace, trigger with namespace", function(assert){
         var emitter = eventifier();
 
-        QUnit.expect(1);
+        QUnit.expect(2);
 
         emitter.on('foo', function(){
             assert.ok(false, 'the foo handler should not be called');
         });
+        emitter.on('foo.*', function(){
+            assert.ok(true, 'the foo.* handler is called');
+        });
         emitter.on('foo.bar', function(){
             assert.ok(true, 'the foo.bar handler is called');
             QUnit.start();
+        });
+        emitter.on('foo.baz', function(){
+            assert.ok(false, 'the foo.baz handler should not be called');
         });
 
         emitter.trigger('foo.bar');
@@ -162,13 +171,16 @@ define(['core/eventifier'], function(eventifier){
         }, 1);
     });
 
-    QUnit.asyncTest("off all namespace", function(assert){
-        QUnit.expect(1);
+    QUnit.asyncTest("off namespaced", function(assert){
+        QUnit.expect(2);
 
         var emitter = eventifier();
 
         emitter.on('foo', function(){
-            assert.ok(true, 'the foo handler should  be called');
+            assert.ok(true, 'the foo handler should be called');
+        });
+        emitter.on('foo.baz', function(){
+            assert.ok(true, 'the foo.baz handler should be called');
             QUnit.start();
         });
         emitter.on('foo.bar', function(){
@@ -182,7 +194,31 @@ define(['core/eventifier'], function(eventifier){
         emitter.off('.bar');
 
         emitter.trigger('foo').trigger('norz');
+    });
 
+    QUnit.asyncTest("off all namespaces", function(assert){
+        QUnit.expect(1);
+
+        var emitter = eventifier();
+
+        emitter.on('foo', function(){
+            assert.ok(true, 'the foo handler should be called');
+            QUnit.start();
+        });
+        emitter.on('foo.baz', function(){
+            assert.ok(false, 'the foo.baz handler should not be called');
+        });
+        emitter.on('foo.bar', function(){
+            assert.ok(false, 'the foo.bar handler should not be called');
+
+        });
+        emitter.on('norz.bar', function(){
+            assert.ok(false, 'the norz.bar handler should not be called');
+        });
+
+        emitter.off('.*');
+
+        emitter.trigger('foo').trigger('norz');
     });
 
     QUnit.module('before');
@@ -209,7 +245,7 @@ define(['core/eventifier'], function(eventifier){
         testDriver.before('next', function(e, a1, a2){
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'next', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -220,7 +256,7 @@ define(['core/eventifier'], function(eventifier){
         testDriver.before('next', function(e, a1, a2){
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'next', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -254,7 +290,7 @@ define(['core/eventifier'], function(eventifier){
         testDriver.before('next', function(e, a1, a2){
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'next', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -270,7 +306,7 @@ define(['core/eventifier'], function(eventifier){
         testDriver.before('next', function(e, a1, a2){
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'next', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -296,7 +332,7 @@ define(['core/eventifier'], function(eventifier){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate item state");
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'next', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -324,7 +360,7 @@ define(['core/eventifier'], function(eventifier){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'save', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -335,7 +371,7 @@ define(['core/eventifier'], function(eventifier){
             assert.ok(true, "The 2nd 'before' listener should be executed : e.g. do save item stylesheet");
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'save', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -358,7 +394,7 @@ define(['core/eventifier'], function(eventifier){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'save', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -369,7 +405,7 @@ define(['core/eventifier'], function(eventifier){
             assert.ok(true, "The 2nd 'before' listener should be executed : e.g. do save item stylesheet");
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'save', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -392,7 +428,7 @@ define(['core/eventifier'], function(eventifier){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'save', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -407,7 +443,7 @@ define(['core/eventifier'], function(eventifier){
             assert.ok(true, "The 2nd 'before' listener should be executed : e.g. do save item stylesheet");
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'save', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -430,7 +466,7 @@ define(['core/eventifier'], function(eventifier){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'save', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -459,7 +495,7 @@ define(['core/eventifier'], function(eventifier){
             assert.ok(true, "The 1st 'before' listener should be executed : e.g. validate current edition form");
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'save', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -510,7 +546,7 @@ define(['core/eventifier'], function(eventifier){
 
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'foo', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -524,7 +560,7 @@ define(['core/eventifier'], function(eventifier){
 
             assert.equal(typeof e, 'object', 'the event context object is provided');
             assert.equal(e.name, 'foo', 'the event name is provided');
-            assert.equal(e.namespace, '*', 'the event namespace is provided');
+            assert.equal(e.namespace, '@', 'the event namespace is provided');
             assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
             assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
             assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -542,12 +578,15 @@ define(['core/eventifier'], function(eventifier){
     QUnit.asyncTest("events context (simple)", function(assert){
         var emitter = eventifier();
 
-        QUnit.expect(24);
+        QUnit.expect(40);
         QUnit.stop(1);
 
         emitter
             .on('ev1', function(){
                 assert.ok(true, "The ev1 handler is called");
+            })
+            .on('ev1.*', function(){
+                assert.ok(true, "The ev1.* handler is called");
             })
             .on('ev1.ns', function(){
                 assert.ok(true, "The ev1.ns handler is called");
@@ -556,7 +595,16 @@ define(['core/eventifier'], function(eventifier){
                 assert.ok(true, "The before ev1 handler is called");
                 assert.equal(typeof e, 'object', 'the event context object is provided');
                 assert.equal(e.name, 'ev1', 'the event name is provided');
-                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(e.namespace, '@', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
+            })
+            .before('ev1.*', function(e){
+                assert.ok(true, "The before ev1.* handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev1', 'the event name is provided');
+                assert.equal(e.namespace, '@', 'the event namespace is provided');
                 assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
                 assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
                 assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -565,7 +613,7 @@ define(['core/eventifier'], function(eventifier){
                 assert.ok(true, "The before ev1.ns handler is called");
                 assert.equal(typeof e, 'object', 'the event context object is provided');
                 assert.equal(e.name, 'ev1', 'the event name is provided');
-                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(e.namespace, '@', 'the event namespace is provided');
                 assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
                 assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
                 assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -577,11 +625,23 @@ define(['core/eventifier'], function(eventifier){
             .on('ev2', function(){
                 assert.ok(false, "The ev2 handler should not be called");
             })
+            .on('ev2.*', function(){
+                assert.ok(true, "The ev2.* handler is called");
+            })
             .on('ev2.ns', function(){
                 assert.ok(true, "The ev2.ns handler is called");
             })
             .before('ev2', function(e){
                 assert.ok(false, "The before ev2 handler should not be called");
+            })
+            .before('ev2.*', function(e){
+                assert.ok(true, "The before ev2.* handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev2', 'the event name is provided');
+                assert.equal(e.namespace, 'ns', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             })
             .before('ev2.ns', function(e){
                 assert.ok(true, "The before ev2.ns handler is called");
@@ -602,7 +662,7 @@ define(['core/eventifier'], function(eventifier){
     QUnit.asyncTest("events context (multi)", function(assert){
         var emitter = eventifier();
 
-        QUnit.expect(96);
+        QUnit.expect(128);
         QUnit.stop(7);
 
         emitter
@@ -616,7 +676,7 @@ define(['core/eventifier'], function(eventifier){
                 assert.ok(true, "The before ev1 handler is called");
                 assert.equal(typeof e, 'object', 'the event context object is provided');
                 assert.equal(e.name, 'ev1', 'the event name is provided');
-                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(e.namespace, '@', 'the event namespace is provided');
                 assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
                 assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
                 assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -625,7 +685,7 @@ define(['core/eventifier'], function(eventifier){
                 assert.ok(true, "The before ev1.ns handler is called");
                 assert.equal(typeof e, 'object', 'the event context object is provided');
                 assert.equal(e.name, 'ev1', 'the event name is provided');
-                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(e.namespace, '@', 'the event namespace is provided');
                 assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
                 assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
                 assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -644,7 +704,7 @@ define(['core/eventifier'], function(eventifier){
                 assert.ok(true, "The before ev1 handler is called");
                 assert.equal(typeof e, 'object', 'the event context object is provided');
                 assert.equal(e.name, 'ev2', 'the event name is provided');
-                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(e.namespace, '@', 'the event namespace is provided');
                 assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
                 assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
                 assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -653,7 +713,7 @@ define(['core/eventifier'], function(eventifier){
                 assert.ok(true, "The before ev1.ns handler is called");
                 assert.equal(typeof e, 'object', 'the event context object is provided');
                 assert.equal(e.name, 'ev2', 'the event name is provided');
-                assert.equal(e.namespace, '*', 'the event namespace is provided');
+                assert.equal(e.namespace, '@', 'the event namespace is provided');
                 assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
                 assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
                 assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
@@ -665,11 +725,23 @@ define(['core/eventifier'], function(eventifier){
             .on('ev3', function(){
                 assert.ok(false, "The ev3 handler should not be called");
             })
+            .on('ev3.*', function(){
+                assert.ok(true, "The ev3.* handler is called");
+            })
             .on('ev3.ns3', function(){
                 assert.ok(true, "The ev3.ns3 handler is called");
             })
             .before('ev3', function(e){
                 assert.ok(false, "The before ev3 handler should not be called");
+            })
+            .before('ev3.*', function(e){
+                assert.ok(true, "The before ev3.* handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev3', 'the event name is provided');
+                assert.equal(e.namespace, 'ns3', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             })
             .before('ev3.ns3', function(e){
                 assert.ok(true, "The before ev3.ns3 handler is called");
@@ -687,11 +759,23 @@ define(['core/eventifier'], function(eventifier){
             .on('ev4', function(){
                 assert.ok(false, "The ev4 handler should not be called");
             })
+            .on('ev4.*', function(){
+                assert.ok(true, "The ev4.* handler is called");
+            })
             .on('ev4.ns4', function(){
                 assert.ok(true, "The ev4.ns4 handler is called");
             })
             .before('ev4', function(e){
                 assert.ok(false, "The before ev4 handler should not be called");
+            })
+            .before('ev4.*', function(e){
+                assert.ok(true, "The before ev4.* handler is called");
+                assert.equal(typeof e, 'object', 'the event context object is provided');
+                assert.equal(e.name, 'ev4', 'the event name is provided');
+                assert.equal(e.namespace, 'ns4', 'the event namespace is provided');
+                assert.equal(typeof e.done, 'function', 'the event async enabler API is provided');
+                assert.equal(typeof e.prevent, 'function', 'the event preventer API is provided');
+                assert.equal(typeof e.preventNow, 'function', 'the event immediate preventer API is provided');
             })
             .before('ev4.ns4', function(e){
                 assert.ok(true, "The before ev4.ns4 handler is called");

--- a/views/js/test/core/eventifier/test.js
+++ b/views/js/test/core/eventifier/test.js
@@ -114,13 +114,16 @@ define(['core/eventifier', 'core/promise'], function(eventifier, Promise){
     QUnit.asyncTest("listen namespace, trigger without namespace", function(assert){
         var emitter = eventifier();
 
-        QUnit.expect(3);
+        QUnit.expect(4);
 
         emitter.on('foo', function(){
             assert.ok(true, 'the foo handler is called');
         });
         emitter.on('foo.*', function(){
             assert.ok(true, 'the foo.* handler is called');
+        });
+        emitter.on('foo.@', function(){
+            assert.ok(true, 'the foo.@ handler is called');
         });
         emitter.on('foo.bar', function(){
             assert.ok(true, 'the foo.bar handler is called');
@@ -130,6 +133,28 @@ define(['core/eventifier', 'core/promise'], function(eventifier, Promise){
         emitter.trigger('foo');
     });
 
+    QUnit.asyncTest("listen namespace, trigger with default namespace", function(assert){
+        var emitter = eventifier();
+
+        QUnit.expect(4);
+
+        emitter.on('foo', function(){
+            assert.ok(true, 'the foo handler is called');
+        });
+        emitter.on('foo.*', function(){
+            assert.ok(true, 'the foo.* handler is called');
+        });
+        emitter.on('foo.@', function(){
+            assert.ok(true, 'the foo.@ handler is called');
+        });
+        emitter.on('foo.bar', function(){
+            assert.ok(true, 'the foo.bar handler is called');
+            QUnit.start();
+        });
+
+        emitter.trigger('foo.@');
+    });
+
     QUnit.asyncTest("listen namespace, trigger with namespace", function(assert){
         var emitter = eventifier();
 
@@ -137,6 +162,9 @@ define(['core/eventifier', 'core/promise'], function(eventifier, Promise){
 
         emitter.on('foo', function(){
             assert.ok(false, 'the foo handler should not be called');
+        });
+        emitter.on('foo.@', function(){
+            assert.ok(false, 'the foo.@ handler should not be called');
         });
         emitter.on('foo.*', function(){
             assert.ok(true, 'the foo.* handler is called');


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3008

Add event name and namespace in the context object provided to the `before` handlers.
```javascript
emitter.before('foo', function(e) {
    // name of event
    console.log(e.name);

    // namespace of event
    console.log(e.namespace);
});
```

Add global namespace to listen to every namespaced events:

```javascript
// listen to "foo" only
emitter.on('foo');

// listen to "foo" and "foo.bar"
emitter.on('foo.bar');

// listen to all "foo" events
emitter.on('foo.*');

// notify all "foo" listeners
emitter.trigger('foo');

// notify only "foo.bar" and "foo.*"
emitter.trigger('foo.bar');
```

Can now use promises in async event:

```javascript
emitter.before('foo', function() {
    return new Promise(resolve, reject) {
        if (ok) {
            resolve();
        } else {
            reject();
        }
    });
});
```

Add method to erase all registered handlers:

```javascript
emitter.removeAllListeners();
```