### PR TITLE
livereload, config.merge & testUrl options

### DIFF
--- a/views/build/Gruntfile.js
+++ b/views/build/Gruntfile.js
@@ -7,28 +7,18 @@ module.exports = function(grunt) {
      * in taoQtiItem/views/build/grunt/sass.js for extension specific configuration.
      */
 
-    //track build time
-    require('time-grunt')(grunt);
-
-    // load all grunt tasks matching the `grunt-*` pattern
-    require('load-grunt-tasks')(grunt);
-
-     // Load local tasks.
-    grunt.loadTasks('tasks');
-
-
     //set up contextual config
     var root                = require('path').resolve('../../../').replace(/\\/g, '/'); //tao dist root
-    var ext                 = require('./tasks/helpers/extensions')(grunt, root);   //extension helper
-    var currentExtension    = grunt.option('extension') || 'tao';                   //target extension, add "--extension name" to CLI if needed
-    var reportOutput        = grunt.option('reports') || 'reports';                 //where reports are saved
-    var testPort            = grunt.option('testPort') || 8082;                     //the port to run test web server, override with "--testPort value" to CLI if needed
+    var ext                 = require('./tasks/helpers/extensions')(grunt, root);       //extension helper
+    var currentExtension    = grunt.option('extension') || 'tao';                       //target extension, add "--extension name" to CLI if needed
+    var reportOutput        = grunt.option('reports') || 'reports';                     //where reports are saved
+    var testUrl             = grunt.option('testUrl') || '127.0.0.1';                   //the port to run test web server, override with "--testPort value" to CLI if needed
+    var testPort            = grunt.option('testPort') || 8082;                         //the port to run test web server, override with "--testPort value" to CLI if needed
 
-    //make the options avialable in sub tasks definitions
-    grunt.option('root', root);
-    grunt.option('currentExtension', currentExtension);
-    grunt.option('testPort', testPort);
-    grunt.option('reports', reportOutput);
+    var sassTasks   = [];
+    var bundleTasks = [];
+    var testTasks   = [];
+
 
     //Resolve some shared AMD modules
     var libsPattern =  ['views/js/*.js', 'views/js/core/**/*.js', 'views/js/ui/**/*.js', 'views/js/layout/**/*.js', 'views/js/util/**/*.js', '!views/js/main.*', '!views/js/*.min*', '!views/js/test/**/*.js'];
@@ -52,13 +42,25 @@ module.exports = function(grunt) {
         'html5-history-api']);
 
     grunt.option('mainlibs', libs);
+    grunt.option('root', root);
+    grunt.option('currentExtension', currentExtension);
+    grunt.option('testPort', testPort);
+    grunt.option('testUrl', testUrl);
+    grunt.option('reports', reportOutput);
+
+    //track build time
+    require('time-grunt')(grunt);
+
+    // load all grunt tasks matching the `grunt-*` pattern
+    require('load-grunt-tasks')(grunt);
+
+     // Load local tasks.
+    grunt.loadTasks('tasks');
 
     /*
      * Load separated configs into each extension
      */
-    var sassTasks   = [];
-    var bundleTasks = [];
-    var testTasks   = [];
+
     ext.getExtensions().forEach(function(extension){
 
         var extensionKey = extension.toLowerCase();

--- a/views/build/Gruntfile.js
+++ b/views/build/Gruntfile.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
     var reportOutput        = grunt.option('reports') || 'reports';                     //where reports are saved
     var testUrl             = grunt.option('testUrl') || '127.0.0.1';                   //the port to run test web server, override with "--testPort value" to CLI if needed
     var testPort            = grunt.option('testPort') || 8082;                         //the port to run test web server, override with "--testPort value" to CLI if needed
+    var livereloadPort      = parseInt(grunt.option('livereloadPort'), 10) || true;     //the livereload port, override with "--livereloadPort 35729" to CLI if needed
 
     var sassTasks   = [];
     var bundleTasks = [];
@@ -47,6 +48,7 @@ module.exports = function(grunt) {
     grunt.option('testPort', testPort);
     grunt.option('testUrl', testUrl);
     grunt.option('reports', reportOutput);
+    grunt.option('livereloadPort', livereloadPort);
 
     //track build time
     require('time-grunt')(grunt);

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -1,6 +1,8 @@
 module.exports = function(grunt) {
     'use strict';
 
+    var livereloadPort = grunt.option('livereloadPort');
+
     grunt.config.merge({
         sass : {
             options : {
@@ -28,7 +30,7 @@ module.exports = function(grunt) {
 
         watch: {
             options: {
-                livereload: true
+                livereload: livereloadPort
             },
             taosass : {
                 files : ['../scss/*.scss', '../scss/**/*.scss', '../js/lib/jsTree/**/*.scss'],

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -1,51 +1,53 @@
 module.exports = function(grunt) {
+    'use strict';
 
-    var sass    = grunt.config('sass') || {};
-    var watch   = grunt.config('watch') || {};
-    var notify  = grunt.config('notify') || {};
+    grunt.config.merge({
+        sass : {
+            options : {
+                noCache: true,
+                unixNewlines : true,
+                loadPath : ['../scss/', '../js/lib/'],
+                lineNumbers : false,
+                style : 'compressed'
+            },
+            tao: {
+                files : {
+                    '../css/tao-main-style.css' : '../scss/tao-main-style.scss',
+                    '../css/tao-3.css' : '../scss/tao-3.scss',
+                    '../css/layout.css' : '../scss/layout.scss',
+                    '../js/lib/jsTree/themes/css/style.css' : '../js/lib/jsTree/themes/scss/style.scss',
+                }
+            },
+            ckeditor : {
+                files : {
+                    '../js/lib/ckeditor/skins/tao/editor.css' : '../js/lib/ckeditor/skins/tao/scss/editor.scss',
+                    '../js/lib/ckeditor/skins/tao/dialog.css' : '../js/lib/ckeditor/skins/tao/scss/dialog.scss',
+                }
+            }
+        },
 
-    sass.options = {
-        noCache: true,
-        unixNewlines : true,
-        loadPath : ['../scss/', '../js/lib/'],
-        lineNumbers : false,
-        style : 'compressed'
-    };
+        watch: {
+            options: {
+                livereload: true
+            },
+            taosass : {
+                files : ['../scss/*.scss', '../scss/**/*.scss', '../js/lib/jsTree/**/*.scss'],
+                tasks : ['sass:tao', 'notify:taosass'],
+                options : {
+                    debounceDelay : 1000
+                }
+            }
+        },
 
-    sass.tao = {
-        files : {
-            '../css/tao-main-style.css' : '../scss/tao-main-style.scss',
-            '../css/tao-3.css' : '../scss/tao-3.scss',
-            '../css/layout.css' : '../scss/layout.scss',
-            '../js/lib/jsTree/themes/css/style.css' : '../js/lib/jsTree/themes/scss/style.scss',
+        notify : {
+            taosass : {
+                options: {
+                    title: 'Grunt SASS',
+                    message: 'SASS files compiled to CSS'
+                }
+            }
         }
-    };
-
-    sass.ckeditor = {
-        files : {
-            '../js/lib/ckeditor/skins/tao/editor.css' : '../js/lib/ckeditor/skins/tao/scss/editor.scss',
-            '../js/lib/ckeditor/skins/tao/dialog.css' : '../js/lib/ckeditor/skins/tao/scss/dialog.scss',
-        }
-    };
-
-    watch.taosass = {
-        files : ['../scss/*.scss', '../scss/**/*.scss', '../js/lib/jsTree/**/*.scss'],
-        tasks : ['sass:tao', 'notify:taosass'],
-        options : {
-            debounceDelay : 1000
-        }
-    };
-
-    notify.taosass = {
-        options: {
-            title: 'Grunt SASS',
-            message: 'SASS files compiled to CSS'
-        }
-    };
-
-    grunt.config('sass', sass);
-    grunt.config('watch', watch);
-    grunt.config('notify', notify);
+    });
 
     //register an alias for main build
     grunt.registerTask('taosass', ['sass:tao']);

--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -1,58 +1,86 @@
 module.exports = function(grunt) {
     'use strict';
 
-
     var root        = grunt.option('root');
     var testPort    = grunt.option('testPort');
+    var testUrl     = grunt.option('testUrl');
     var reportOutput= grunt.option('reports');
     var ext         = require(root + '/tao/views/build/tasks/helpers/extensions')(grunt, root);
     var fs          = require('fs');
     var path        = require('path');
-    var qunit       = grunt.config('qunit') || {};
-    var testUrl     = 'http://127.0.0.1:' + testPort;
 
-    /*
-     * Global tasks/config
-     */
-    qunit.options = {
-        inject: './config/phantomjs-bridge.js',
-        force: true
+    var baseUrl     = 'http://' + testUrl + ':' + testPort;
+
+    var testRunners = root + '/tao/views/js/test/**/test.html';
+
+    //extract unit tests  from FS to URL
+    var extractTests = function extractTests(){
+        return grunt.file.expand([testRunners]).map(function(testPath){
+            return testPath.replace(root, baseUrl);
+        });
     };
 
-    //convert QUnit report to JUnit reports for Jenkins
-    grunt.config('qunit_junit', {
-        options : {
-            dest : reportOutput,
+    grunt.config.merge({
 
-            fileNamer : function(url){
-                return url
-                    .replace(testUrl + '/', '')
-                    .replace('/test.html', '')
-                    .replace(/\//g, '.');
+        qunit : {
+
+            //global options
+            options : {
+                inject: './config/phantomjs-bridge.js',
+                force: true
             },
 
-            classNamer : function (moduleName, url) {
-                return url
-                    .replace(testUrl + '/', '')
-                    .replace('views/js/test/', '')
-                    .replace('/test.html', '')
-                    .replace(/\//g, '.');
-            }
-        }
-    });
+            //run a single test (requires the options test=${testUrl})
+            single : {
+                options : {
+                    console: true,
+                    force:   false,
+                    urls:    [baseUrl + grunt.option('test')]
+                }
+            },
 
-    //starts a static web server to serve assets for tests and the requirejs config
-    grunt.config('connect', {
-        test: {
+            //tests for the tao extension
+            taotest : {
+                options : {
+                    console : true,
+                    urls : extractTests()
+                }
+            }
+        },
+
+        //convert QUnit report to JUnit reports for Jenkins
+        'qunit_junit' : {
+            options : {
+                dest : reportOutput,
+
+                fileNamer : function(url){
+                    return url
+                        .replace(testUrl + '/', '')
+                        .replace('/test.html', '')
+                        .replace(/\//g, '.');
+                },
+
+                classNamer : function (moduleName, url) {
+                    return url
+                        .replace(testUrl + '/', '')
+                        .replace('views/js/test/', '')
+                        .replace('/test.html', '')
+                        .replace(/\//g, '.');
+                }
+            }
+        },
+
+        //starts a static web server to serve assets for tests and the requirejs config
+        connect : {
             options: {
                 protocol : 'http',
-                hostname : '127.0.0.1',
+                hostname : testUrl,
                 port: testPort,
                 base: root,
                 middleware: function(connect, options, middlewares) {
 
                     var rjsConfig = require('../config/requirejs.test.json');
-                    rjsConfig.baseUrl = testUrl + '/tao/views/js';
+                    rjsConfig.baseUrl = baseUrl + '/tao/views/js';
                     ext.getExtensions().forEach(function(extension){
                         rjsConfig.paths[extension] = '../../../' + extension + '/views/js';
                         rjsConfig.paths[extension + 'Css'] = '../../../' + extension + '/views/css';
@@ -69,8 +97,9 @@ module.exports = function(grunt) {
 
                     //allow post requests
                     middlewares.unshift(function(req, res, next) {
+                        var filepath;
                         if (req.method.toLowerCase() === 'post') {
-                            var filepath = path.join(options.base[0], req.url);
+                            filepath = path.join(options.base[0], req.url);
                             if (fs.existsSync(filepath)) {
                                 fs.createReadStream(filepath).pipe(res);
                                 return;
@@ -82,47 +111,19 @@ module.exports = function(grunt) {
 
                     return middlewares;
                 }
+            },
+            test : {
+                options : {
+                    livereload: false
+                }
+            },
+            dev : {
+                options : {
+                    livereload: true
+                }
             }
         }
     });
-
-    /*
-     * Single file test
-     */
-    qunit.single = {
-        options : {
-            console: true,
-            force:   false,
-            urls:    [testUrl + grunt.option('test')]
-        }
-    };
-
-
-    /*
-     * Tao extension tests
-     */
-
-    var testRunners = root + '/tao/views/js/test/**/test.html';
-    var testFiles = root + '/tao/views/js/test/**/test.js';
-
-    //extract unit tests
-    var extractTests = function extractTests(){
-        return grunt.file.expand([testRunners]).map(function(path){
-            return path.replace(root, testUrl);
-        });
-    };
-
-    /**
-     * tests to run
-     */
-    qunit.taotest = {
-        options : {
-            console : true,
-            urls : extractTests()
-        }
-    };
-
-    grunt.config('qunit', qunit);
 
     // test task
     grunt.registerTask('taotest', ['qunit:taotest']);

--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -1,17 +1,17 @@
 module.exports = function(grunt) {
     'use strict';
 
-    var root        = grunt.option('root');
-    var testPort    = grunt.option('testPort');
-    var testUrl     = grunt.option('testUrl');
-    var reportOutput= grunt.option('reports');
-    var ext         = require(root + '/tao/views/build/tasks/helpers/extensions')(grunt, root);
-    var fs          = require('fs');
-    var path        = require('path');
+    var root           = grunt.option('root');
+    var testPort       = grunt.option('testPort');
+    var testUrl        = grunt.option('testUrl');
+    var livereloadPort = grunt.option('livereloadPort');
+    var reportOutput   = grunt.option('reports');
+    var ext            = require(root + '/tao/views/build/tasks/helpers/extensions')(grunt, root);
+    var fs             = require('fs');
+    var path           = require('path');
+    var baseUrl        = 'http://' + testUrl + ':' + testPort;
+    var testRunners    = root + '/tao/views/js/test/**/test.html';
 
-    var baseUrl     = 'http://' + testUrl + ':' + testPort;
-
-    var testRunners = root + '/tao/views/js/test/**/test.html';
 
     //extract unit tests  from FS to URL
     var extractTests = function extractTests(){
@@ -119,7 +119,7 @@ module.exports = function(grunt) {
             },
             dev : {
                 options : {
-                    livereload: true
+                    livereload: livereloadPort
                 }
             }
         }


### PR DESCRIPTION
1. Grunt merge style refactoring
2. Use a configurable `testUrl` : `grunt connect:test:keepalive --testUrl=0.0.0.0 --testPort=1234`
3. Enable livereload on test server, triggered by watch:
  - `grunt connect:dev watch:taosass`
  - Then open a test, for example http://127.0.0.1:8082/tao/views/js/test/ui/tooltip/test.html 
  - Modify a SCSS file
  - The test will reload automatically once the CSS compilation is done