### PR TITLE
Fix the CustomEvent emitter under IE

### DIFF
--- a/views/js/core/customEvent.js
+++ b/views/js/core/customEvent.js
@@ -32,11 +32,17 @@ define([], function () {
      */
     if (window.CustomEvent) {
         createEvent = function createEventUsingCustomEvent(eventName, data) {
-            var event = new CustomEvent(eventName, {
-                detail: data,
-                bubbles: true,
-                cancelable: true
-            });
+            var event;
+            try {
+                event = new CustomEvent(eventName, {
+                    detail: data,
+                    bubbles: true,
+                    cancelable: true
+                });
+            } catch (e) {
+                event = document.createEvent('CustomEvent');
+                event.initCustomEvent(eventName, true, true, data);
+            }
             return event;
         };
     } else if (document.createEvent) {


### PR DESCRIPTION
Prevent this error to occur under Internet Explorer when triggering a custom event: `"Object doesn't support this action"`.