### PR TITLE
Fix/tao 3147 pdf chrome issue

### DIFF
--- a/views/js/ui/documentViewer/providers/pdfViewer.js
+++ b/views/js/ui/documentViewer/providers/pdfViewer.js
@@ -396,8 +396,8 @@ define([
                                 self.pdf.refresh();
                             });
 
-                            self.controls.navigation.on('click', function (e) {
-                                movePage(Number($(e.target).data('direction')) || 1);
+                            self.controls.navigation.on('click', function () {
+                                movePage(Number($(this).data('direction')) || 1);
                             });
 
                             self.controls.pageNum

--- a/views/js/ui/documentViewer/providers/pdfViewer.js
+++ b/views/js/ui/documentViewer/providers/pdfViewer.js
@@ -369,6 +369,10 @@ define([
                             // PDF.js installed
                             $element.html($(pdfTpl(self.config)));
 
+                            // Disable the streaming mode: the file needs to be fully loaded before display.
+                            // This will prevent "Bad offset" error under Chrome and IE, but will slow down the first display.
+                            pdfjs.PDFJS.disableRange = true;
+
                             self.controls = {
                                 bar: $element.find('.pdf-bar'),
                                 navigation: $element.find('.navigation'),


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3147

Fix the render issue of PDF under Chrome/Safari and IE.

Fix page navigation issue.

You will need PDF.js installed.
Report to this page to install it: http://forge.taotesting.com/projects/tao/wiki/Install_PDFjs_viewer

Steps to reproduce:
- Create an item and add some interaction to it.
- Attach a PDF file to this item by editing the prompt and inserting a media file (this file needs to be big enough to be streamed).
- A document viewer is inserted, but you do not see any content, and the console display a "Bad offset" error