### PR TITLE
from helpers#_url to util/url#route

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.11.0',
+    'version' => '7.12.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.0.1',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -563,7 +563,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('6.1.0');
         }
 
-        $this->skip('6.1.0', '7.11.0');
+        $this->skip('6.1.0', '7.12.0');
     }
 
     private function migrateFsAccess() {

--- a/views/js/helpers.js
+++ b/views/js/helpers.js
@@ -1,5 +1,7 @@
 /*
  * Helpers
+ *
+ * @deprecated Do not use it anymore. Only here for backward compat.
  */
 define([
     'lodash',
@@ -8,7 +10,7 @@ define([
     'layout/loading-bar',
     'jqueryui'
 ], function (_, $, context, loadingBar) {
-
+    'use strict';
 
     var Helpers = {
         init: function () {
@@ -195,7 +197,7 @@ define([
          * apply effect to elements that are only present
          */
         _autoFx: function () {
-            
+
             console.warn('deprecated');
             setTimeout(function () {
                 $(".auto-highlight").effect("highlight", {color: "#9FC9FF"}, 2500);
@@ -262,7 +264,7 @@ define([
          * @return {boolean}
          */
         isFlashPluginEnabled: function () {
-            return   (typeof navigator.plugins !== "undefined" && typeof navigator.plugins["Shockwave Flash"] === "object") || 
+            return   (typeof navigator.plugins !== "undefined" && typeof navigator.plugins["Shockwave Flash"] === "object") ||
                      (window.ActiveXObject && (new window.ActiveXObject("ShockwaveFlash.ShockwaveFlash")) !== false);
         },
 
@@ -278,9 +280,10 @@ define([
 
         /**
          * simple _url implementation, requires layout_header to set some global variables
+         * @deprecated use util/url#route instead
          */
         _url: function (action, controller, extension, params) {
-    
+
             var url;
 
             if(typeof action !== 'string' || typeof controller !== 'string' || typeof extension !== 'string'){

--- a/views/js/test/util/url/test.html
+++ b/views/js/test/util/url/test.html
@@ -8,7 +8,7 @@
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
-        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-only="util/url.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking" data-cover-only="util/url.js"></script>
         <script type="text/javascript">
 
             //don't start the test now


### PR DESCRIPTION
It's time to deprecate `helpers#_url` and move it into it's obvious location : `util/url#route`

The file `helpers` looks changed because I've converted the encoding but I've only added the `use strict` statement and the `@deprecated`tags.