### PR TITLE
TAO-3167 now tells the server how to handle a file operation

### DIFF
--- a/helpers/form/data/class.UploadFileDescription.php
+++ b/helpers/form/data/class.UploadFileDescription.php
@@ -15,7 +15,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * 
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
- *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
+ *               2009-2016 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
  * 
  */
 
@@ -25,15 +25,14 @@
  * @access public
  * @author Jerome Bogaerts, <jerome@taotesting.com>
  * @package tao
- 
  */
-class tao_helpers_form_data_UploadFileDescription
-    extends tao_helpers_form_data_FileDescription
+class tao_helpers_form_data_UploadFileDescription extends tao_helpers_form_data_FileDescription
 {
-    // --- ASSOCIATIONS ---
+    /** Action form: add */
+    const FORM_ACTION_ADD = 'add';
 
-
-    // --- ATTRIBUTES ---
+    /** Action form: delete */
+    const FORM_ACTION_DELETE = 'delete';
 
     /**
      * The mime/type of the file e.g. text/plain.
@@ -52,7 +51,12 @@ class tao_helpers_form_data_UploadFileDescription
      */
     private $tmpPath = '';
 
-    // --- OPERATIONS ---
+    /**
+     * Allow to specify action to know form purpose
+     *
+     * @var string
+     */
+    private $action;
 
     /**
      * The temporary file path where the file is stored before being moved to
@@ -60,19 +64,19 @@ class tao_helpers_form_data_UploadFileDescription
      *
      * @access public
      * @author Jerome Bogaerts <jerome@taotesting.com>
-     * @param  string name The name of the file e.g. tmpImage.tmp
-     * @param  int size The size of the file in bytes
-     * @param  string type The mime-type of the file e.g. text/plain.
-     * @param  string tmpPath
+     * @param  string $name The name of the file e.g. tmpImage.tmp
+     * @param  int $size The size of the file in bytes
+     * @param  string $type The mime-type of the file e.g. text/plain.
+     * @param  string $tmpPath
+     * @param  string $action
      * @return mixed
      */
-    public function __construct($name, $size, $type, $tmpPath)
+    public function __construct($name, $size, $type, $tmpPath, $action = null)
     {
-        
         parent::__construct($name, $size);
         $this->type = $type;
         $this->tmpPath = $tmpPath;
-        
+        $this->action = is_null($action) ? self::FORM_ACTION_ADD : $action;
     }
 
     /**
@@ -84,13 +88,7 @@ class tao_helpers_form_data_UploadFileDescription
      */
     public function getType()
     {
-        $returnValue = (string) '';
-
-        
-        $returnValue = $this->type;
-        
-
-        return (string) $returnValue;
+        return (string) $this->type;
     }
 
     /**
@@ -102,15 +100,16 @@ class tao_helpers_form_data_UploadFileDescription
      */
     public function getTmpPath()
     {
-        $returnValue = (string) '';
-
-        
-        $returnValue = $this->tmpPath;
-        
-
-        return (string) $returnValue;
+        return (string) $this->tmpPath;
     }
 
+    /**
+     * Return action form
+     *
+     * @return string
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
 }
-
-?>

--- a/helpers/form/elements/xhtml/class.GenerisAsyncFile.php
+++ b/helpers/form/elements/xhtml/class.GenerisAsyncFile.php
@@ -139,20 +139,19 @@ class tao_helpers_form_elements_xhtml_GenerisAsyncFile
      */
     public function buildDeleterBehaviour()
     {
-        $returnValue = (string) '';
-
-        
-        $deleteButtonId = $this->buildDeleteButtonId();
-         
-        $returnValue .= '$(document).ready(function() {';
-        $returnValue .= '	$("#' . $deleteButtonId . '").click(function() {';
-        $returnValue .= '		$("#' . $this->buildWidgetContainerId() . '").empty();';
-        $returnValue .= '		' . $this->buildUploaderBehaviour(true);
-        $returnValue .= '	});';
-        $returnValue .= '});';
-        
-
-        return (string) $returnValue;
+        return '$(document).ready(function() {
+                    $("#' . $this->buildDeleteButtonId() . '").click(function() {
+                        var $form = $(this).parents("form"),
+                            $fileHandling = $form.find("[name=\'file_handling\']");
+                        if(!$fileHandling.length) {
+                            $fileHandling = $("<input>", { name: "file_handling", type: "hidden" });
+                            $form.prepend($fileHandling); 
+                        }
+                        $fileHandling.val("delete");
+                        $("#' . $this->buildWidgetContainerId() . '").empty();
+                        ' . $this->buildUploaderBehaviour(true) . '
+                    });
+                });';
     }
 
     /**
@@ -254,7 +253,19 @@ class tao_helpers_form_elements_xhtml_GenerisAsyncFile
 
 					 }).on("upload.uploader", function(e, file, result){
 					 	if ( result && result.uploaded ){
-							$(e.target).append($("<input type=\'hidden\' name=\'' . $this->getName() . '\'/>").val(result.data));
+					 	    var $container = $(e.target);
+                            var $form = $container.parents("form");
+                            var $fileHandling = $form.find("[name=\'file_handling\']");                      
+							$container.append($("<input type=\'hidden\' name=\'' . $this->getName() . '\'/>").val(result.data));
+							
+                            if(!$fileHandling.length) {
+                                $fileHandling = $("<input>", { name: "file_handling", type: "hidden" });
+                                $form.prepend($fileHandling); 
+                                $fileHandling.val("add");
+                            }
+                            else {
+                                $fileHandling.val("replace");
+                            }                        
 						}
 					 })
 			});';

--- a/helpers/form/elements/xhtml/class.GenerisAsyncFile.php
+++ b/helpers/form/elements/xhtml/class.GenerisAsyncFile.php
@@ -142,12 +142,12 @@ class tao_helpers_form_elements_xhtml_GenerisAsyncFile
         return '$(document).ready(function() {
                     $("#' . $this->buildDeleteButtonId() . '").click(function() {
                         var $form = $(this).parents("form"),
-                            $fileHandling = $form.find("[name=\'file_handling\']");
+                            $fileHandling = $form.find("[name=\'' . $this->getName() . '\']");
                         if(!$fileHandling.length) {
-                            $fileHandling = $("<input>", { name: "file_handling", type: "hidden" });
+                            $fileHandling = $("<input>", { name: "' . $this->getName() . '", type: "hidden" });
                             $form.prepend($fileHandling); 
                         }
-                        $fileHandling.val("delete");
+                        $fileHandling.val("{\\"action\\":\\"delete\\"}");
                         $("#' . $this->buildWidgetContainerId() . '").empty();
                         ' . $this->buildUploaderBehaviour(true) . '
                     });
@@ -255,17 +255,8 @@ class tao_helpers_form_elements_xhtml_GenerisAsyncFile
 					 	if ( result && result.uploaded ){
 					 	    var $container = $(e.target);
                             var $form = $container.parents("form");
-                            var $fileHandling = $form.find("[name=\'file_handling\']");                      
+                            var $fileHandling = $form.find("[name=\'file_handling\']");
 							$container.append($("<input type=\'hidden\' name=\'' . $this->getName() . '\'/>").val(result.data));
-							
-                            if(!$fileHandling.length) {
-                                $fileHandling = $("<input>", { name: "file_handling", type: "hidden" });
-                                $form.prepend($fileHandling); 
-                                $fileHandling.val("add");
-                            }
-                            else {
-                                $fileHandling.val("replace");
-                            }                        
 						}
 					 })
 			});';

--- a/helpers/form/elements/xhtml/class.GenerisAsyncFile.php
+++ b/helpers/form/elements/xhtml/class.GenerisAsyncFile.php
@@ -15,7 +15,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * 
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
- *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
+ *               2009-2016 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
  * 
  */
 
@@ -27,16 +27,8 @@
  * @package tao
  
  */
-class tao_helpers_form_elements_xhtml_GenerisAsyncFile
-    extends tao_helpers_form_elements_GenerisAsyncFile
+class tao_helpers_form_elements_xhtml_GenerisAsyncFile extends tao_helpers_form_elements_GenerisAsyncFile
 {
-    // --- ASSOCIATIONS ---
-
-
-    // --- ATTRIBUTES ---
-
-    // --- OPERATIONS ---
-
     /**
      * Short description of method feed
      *
@@ -47,13 +39,17 @@ class tao_helpers_form_elements_xhtml_GenerisAsyncFile
     public function feed()
     {
         if (isset($_POST[$this->name])) {
-    		$struct = json_decode($_POST[$this->name], true);
-    		if($struct !== false){
-    			$desc = new tao_helpers_form_data_UploadFileDescription(	$struct['name'],
-    					$struct['size'],
-    					$struct['type'],
-    					$struct['uploaded_file']);
-    			$this->setValue($desc);
+
+            $structure = json_decode($_POST[$this->name], true);
+    		if($structure !== false) {
+    			$description = new tao_helpers_form_data_UploadFileDescription(
+                    array_key_exists('name' , $structure) ? $structure['name'] : null,
+                    array_key_exists('size' , $structure) ? $structure['size'] : null,
+                    array_key_exists('type' , $structure) ? $structure['type'] : null,
+                    array_key_exists('uploaded_file' , $structure) ? $structure['uploaded_file'] : null,
+                    array_key_exists('action' , $structure) ? $structure['action'] : null
+                );
+    			$this->setValue($description);
     		}
     		else{
     			// else, no file was selected by the end user.
@@ -73,16 +69,16 @@ class tao_helpers_form_elements_xhtml_GenerisAsyncFile
      */
     public function render()
     {
-        $returnValue = (string) '';
-
-        
-        $widgetName = $this->buildWidgetName();
         $widgetContainerId = $this->buildWidgetContainerId();
         
-        $returnValue .= "<label class='form_desc' for='{$this->name}'>". _dh($this->getDescription())."</label>";
+        $returnValue = "<label class='form_desc' for='{$this->name}'>". _dh($this->getDescription())."</label>";
         $returnValue .= "<div id='${widgetContainerId}' class='form-elt-container file-uploader'>";
-        
-        if ($this->value instanceof tao_helpers_form_data_FileDescription && ($file = $this->value->getFile()) != null){
+
+        if ($this->value instanceof tao_helpers_form_data_UploadFileDescription
+            && $this->value->getAction() == tao_helpers_form_data_UploadFileDescription::FORM_ACTION_DELETE
+        ) {
+            //File deleted, nothing to render
+        } elseif ($this->value instanceof tao_helpers_form_data_FileDescription && ($file = $this->value->getFile()) != null){
         	 
         	// A file is stored or has just been uploaded.
         	$shownFileName = $this->value->getName();

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.12.0',
+    'version' => '7.12.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.0.1',

--- a/models/classes/dataBinding/class.GenerisFormDataBinder.php
+++ b/models/classes/dataBinding/class.GenerisFormDataBinder.php
@@ -1,6 +1,4 @@
 <?php
-use oat\oatbox\service\ServiceManager;
-use oat\generis\model\fileReference\FileReferenceSerializer;
 /**  
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -18,7 +16,7 @@ use oat\generis\model\fileReference\FileReferenceSerializer;
  * 
  * Copyright (c) 2002-2008 (original work) Public Research Centre Henri Tudor & University of Luxembourg (under the project TAO & TAO2);
  *               2008-2010 (update and modification) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
- *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
+ *               2009-2016 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
  * 
  */
 
@@ -34,16 +32,12 @@ use oat\generis\model\fileReference\FileReferenceSerializer;
  * @package tao
  
  */
-class tao_models_classes_dataBinding_GenerisFormDataBinder
-    extends tao_models_classes_dataBinding_GenerisInstanceDataBinder
+
+use oat\oatbox\service\ServiceManager;
+use oat\generis\model\fileReference\FileReferenceSerializer;
+
+class tao_models_classes_dataBinding_GenerisFormDataBinder extends tao_models_classes_dataBinding_GenerisInstanceDataBinder
 {
-    // --- ASSOCIATIONS ---
-
-
-    // --- ATTRIBUTES ---
-
-    // --- OPERATIONS ---
-
     /**
      * Simply bind data from a Generis Instance Form to a specific generis class
      *
@@ -66,27 +60,26 @@ class tao_models_classes_dataBinding_GenerisFormDataBinder
     {
         $returnValue = null;
 
-        
+
         try {
         	$instance = parent::bind($data);
-        	
+
         	// Take care of what the generic data binding did not.
 			foreach ($data as $p => $d){
 				$property = new core_kernel_classes_Property($p);
-				
+
 				if ($d instanceof tao_helpers_form_data_UploadFileDescription){
 					$this->bindUploadFileDescription($property, $d);
 				}
 			}
-        	
+
         	$returnValue = $instance;
         }
         catch (common_Exception $e){
         	$msg = "An error occured while binding property values to instance '': " . $e->getMessage();
-        	$instanceUri = $instance->getUri();
         	throw new tao_models_classes_dataBinding_GenerisFormDataBindingException($msg);
         }
-        
+
 
         return $returnValue;
     }
@@ -96,46 +89,73 @@ class tao_models_classes_dataBinding_GenerisFormDataBinder
      *
      * @access protected
      * @author Jerome Bogaerts <jerome@taotesting.com>
-     * @param  Property property The property to bind the data.
-     * @param  UploadFileDescription desc the upload file description.
+     * @param  core_kernel_classes_Property $property The property to bind the data.
+     * @param  tao_helpers_form_data_UploadFileDescription $desc the upload file description.
      * @return void
      */
-    protected function bindUploadFileDescription( core_kernel_classes_Property $property,  tao_helpers_form_data_UploadFileDescription $desc)
-    {
-        
+    protected function bindUploadFileDescription(
+        core_kernel_classes_Property $property,
+        tao_helpers_form_data_UploadFileDescription $desc
+    ) {
         $instance = $this->getTargetInstance();
-        
-        // Delete old files.
-        foreach ($instance->getPropertyValues($property) as $oF) {
-            $referencer = $this->getServiceLocator()->get(FileReferenceSerializer::SERVICE_ID);
-            $oldFile = $referencer->unserialize($oF);
-            $oldFile->delete();
-            $referencer->cleanup($oF);
-            $instance->removePropertyValue($property, $oF);
-        }
-        
-        $name = $desc->getName();
-        $size = $desc->getSize();
-        
-        if (!empty($name) && !empty($size)){
-            // Move the file at the right place.
-            $source = $desc->getTmpPath();
-            $serial = tao_models_classes_TaoService::singleton()->storeUploadedFile($source, $name);
-            tao_helpers_File::remove($source);
 
-            $instance->editPropertyValues($property, $serial);
-
-            // Update the UploadFileDescription with the stored file.
-            $desc->setFile($serial);
+        // If form has delete action, remove file
+        if ($desc->getAction() == tao_helpers_form_data_UploadFileDescription::FORM_ACTION_DELETE) {
+            $this->removeFile($property);
         }
-        
+
+        // If form has add action, remove file & replace by new
+        elseif ($desc->getAction() == tao_helpers_form_data_UploadFileDescription::FORM_ACTION_ADD) {
+            $name = $desc->getName();
+            $size = $desc->getSize();
+
+            if (! empty($name) && ! empty($size)) {
+
+                // Remove old
+                $this->removeFile($property);
+
+                // Move the file at the right place.
+                $source = $desc->getTmpPath();
+                $serial = tao_models_classes_TaoService::singleton()->storeUploadedFile($source, $name);
+                tao_helpers_File::remove($source);
+
+                // Create association between item & file, database side
+                $instance->editPropertyValues($property, $serial);
+
+                // Update the UploadFileDescription with the stored file.
+                $desc->setFile($serial);
+            }
+        }
     }
 
+    /**
+     * Remove file stored into given $property from $targetInstance
+     * - Remove file properties
+     * - Remove physically file
+     * - Remove property link between item & file
+     *
+     * @param core_kernel_classes_Property $property
+     */
+    protected function removeFile(core_kernel_classes_Property $property)
+    {
+        $instance = $this->getTargetInstance();
+        $referencer = $this->getServiceLocator()->get(FileReferenceSerializer::SERVICE_ID);
+
+        foreach ($instance->getPropertyValues($property) as $oldFileSerial) {
+            /** @var \oat\oatbox\filesystem\File $oldFile */
+            $oldFile = $referencer->unserializeFile($oldFileSerial);
+            $oldFile->delete();
+            $referencer->cleanup($oldFileSerial);
+            $instance->removePropertyValue($property, $oldFileSerial);
+        }
+    }
+
+    /**
+     * @return ServiceManager
+     */
     public function getServiceLocator()
     {
         return ServiceManager::getServiceManager();
     }
 
 }
-
-?>

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -563,7 +563,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('6.1.0');
         }
 
-        $this->skip('6.1.0', '7.12.0');
+        $this->skip('6.1.0', '7.12.1');
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
There should be a field in the POST data with the name of a resource as key and `{ action: delete }` as value

PR handles front-end only, server has not been implemented!