### PR TITLE
Fix/tao 3540 movable cursors

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.45.5',
+    'version' => '7.45.6',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -637,7 +637,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.35.0');
         }
 
-        $this->skip('7.35.0', '7.45.5');
+        $this->skip('7.35.0', '7.45.6');
     }
 
     private function migrateFsAccess() {

--- a/views/js/ui/movableComponent.js
+++ b/views/js/ui/movableComponent.js
@@ -166,11 +166,12 @@ define([
         specs = _.defaults(specs || {}, movableComponent);
 
         return component(specs, defaults).on('render', function () {
-            var self = this;
-            var $element = this.getElement();
-            var element = $element[0];
+            var self       = this;
+            var $element   = this.getElement();
+            var element    = $element[0];
             var $container = this.getContainer();
-            var container = $container[0];
+            var container  = $container[0];
+            var rootNode   = document.querySelector('html');
 
             this.setSize(this.config.width, this.config.height)
                 .place();
@@ -216,6 +217,16 @@ define([
                     self.setState('sizing', false);
                     self.trigger('resizeend');
                 });
+
+            //fix cursor issue with interact <= 1.2.6
+            //cursor remains in moving/sizing by only clicking
+            $element.on('click', function(){
+                _.delay(function(){
+                    if(!self.is('sizing') && !self.is('moving') && rootNode){
+                        rootNode.style.cursor = 'default';
+                    }
+                }, 25);
+            });
         });
     }
 


### PR DESCRIPTION
Updating interact.js to the master branch led was not acceptable (too much unstable). So the issue is fixed at the level of `ui/movableComponent`.

The fix should go away as soon as a stable version of interact is released with the given fix.

To test, open a test with a the masking area plugin, click on the border without resizing or inside without moving. 
