### PR TITLE
Fix/tao 3610 mediaplayer volume position

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.54.0',
+    'version' => '7.54.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.9.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -647,7 +647,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.47.0');
         }
 
-        $this->skip('7.47.0', '7.54.0');
+        $this->skip('7.47.0', '7.54.1');
 
     }
 

--- a/views/js/ui/mediaplayer.js
+++ b/views/js/ui/mediaplayer.js
@@ -93,7 +93,7 @@ define([
      * above the bar.
      * @type {Number}
      */
-    var volumePositionThreshold = 150;
+    var volumePositionThreshold = 200;
 
     /**
      * Some default values
@@ -1701,7 +1701,7 @@ define([
                 if(!overing && !self.$volumeControl.hasClass('up') && !self.$volumeControl.hasClass('down')) {
                     overing = true;
                     position = self.$controls[0].getBoundingClientRect();
-                    if(position && position.y && position.y < volumePositionThreshold){
+                    if(position && position.top && position.top < volumePositionThreshold){
                         self.$volumeControl.addClass('down');
                     } else {
                         self.$volumeControl.addClass('up');


### PR DESCRIPTION
- use `getClientBoundingRect.top` instead of `y` because webkits and IEs seems to not support it.
- increase the threshold to balance the display above or below to 200px to avoid overflow 