### PR TITLE
ignore PCI and PCI content from ESLint

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.69.4',
+    'version' => '7.69.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -688,7 +688,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.69.0');
         }
       
-        $this->skip('7.69.0', '7.69.4');
+        $this->skip('7.69.0', '7.69.5');
 
     }
 

--- a/views/build/grunt/lint.js
+++ b/views/build/grunt/lint.js
@@ -16,6 +16,8 @@ module.exports = function(grunt) {
         '!' + extensionRoot + 'views/js/test/**/*.js',
         '!' + extensionRoot + 'views/js/lib/**/*.js',
         '!' + extensionRoot + 'views/js/portableSharedLibraries/**/*.js',
+        '!' + extensionRoot + 'views/js/pciCreator/dev/**/*.js',
+        '!' + extensionRoot + 'views/js/picCreator/dev/**/*.js',
         '!' + extensionRoot + 'views/js/**/jquery.*.js'
     ];
 


### PR DESCRIPTION
Ignore the PCI and PIC runtimes from ESLint, since the code is considererd as content and might include external libraries we exclude it from the source code analysis.

To test please compare
```
cd tao/views/build
npm run lint -- --extension=qtiItemPci
```
the report will be in  `views/build/reports/qtiItemPci-checkstyle.xml`