### PR TITLE
Fix/improve logger

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.69.4',
+    'version' => '7.69.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -688,7 +688,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.69.0');
         }
       
-        $this->skip('7.69.0', '7.69.4');
+        $this->skip('7.69.0', '7.69.5');
 
     }
 

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -127,7 +127,7 @@ define([
     /**
      * Create a logger
      */
-    var eventifierLogger = loggerFactory('eventifier');
+    var eventifierLogger = loggerFactory('core/eventifier');
 
     /**
      * Create an async callstack
@@ -413,7 +413,7 @@ define([
                             return acc;
                         }, getHandlerObject());
 
-                    logger.debug({event : eventName, args : args}, 'trigger %s', eventName);
+                    logger.trace({event : eventName, args : args}, 'trigger %s', eventName);
 
                     if(mergedHandlers){
 

--- a/views/js/core/logger/api.js
+++ b/views/js/core/logger/api.js
@@ -112,7 +112,7 @@ define([
      * Creates a logger instance
      *
      * @param {String} name - each logger instance MUST have a name
-     * @param {String|Number} minLevel - the minimum logging level
+     * @param {String|Number} [minLevel] - the minimum logging level
      * @param {Object} [fields] - fields to add to all records
      *
      * @returns {logger} a new logger instance
@@ -124,6 +124,11 @@ define([
 
         if(!_.isString(name) || _.isEmpty(name)){
             throw new TypeError('A logger needs a name');
+        }
+
+        if(_.isPlainObject(minLevel) && typeof field === 'undefined'){
+            fields = minLevel;
+            minLevel = defaultLevel;
         }
 
         baseRecord = _.defaults(fields || {}, {

--- a/views/js/test/core/logger/api/test.js
+++ b/views/js/test/core/logger/api/test.js
@@ -276,6 +276,30 @@ define(['core/logger/api'], function(loggerFactory){
         logger.debug('something');
     });
 
+    QUnit.test('optional min level', function(assert){
+        var logger;
+        var moo = {
+            a : false,
+            b : [-1, -12]
+        };
+        QUnit.expect(3);
+
+        loggerFactory.register({
+            log : function log(message){
+                assert.equal(message.foo, 'bar', 'the foo field match');
+                assert.equal(message.msg, 'something', 'the level match');
+                assert.deepEqual(message.moo, moo, 'the moo field match');
+            }
+        });
+
+        logger = loggerFactory('foo', {
+            foo : 'bar',
+            moo : moo
+        });
+        logger.trace('nothing');
+        logger.warn('something');
+    });
+
     QUnit.test('fields override', function(assert){
         var logger;
         QUnit.expect(4);


### PR DESCRIPTION
from 
```js
var logger = loggerFactory('name', loggerFactory.levels.info, options);
```
to 
```js
var logger = loggerFactory('name', options);
```
when you don't want to set a default level.

I've also lowered the level of eventifiers' trigger logs from `debug` to `trace`