### PR TITLE
Feature/tao 3496 data proxy

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.69.7',
+    'version' => '7.70.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -711,6 +711,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('7.69.7');
         }
+        $this->skip('7.69.7', '7.70.0');
     }
 
     private function migrateFsAccess() {

--- a/views/js/core/dataProvider/proxy.js
+++ b/views/js/core/dataProvider/proxy.js
@@ -30,8 +30,6 @@ define([
 
     var _defaults = {};
 
-    var _slice = [].slice;
-
     /**
      * Defines a CRUD proxy bound to a particular adapter. Each adapter will have to provide the following API:
      *
@@ -259,7 +257,7 @@ define([
          * @throws Error
          */
         function delegate(fnName) {
-            var request = {command: fnName, params: _slice.call(arguments, 1)};
+            var request = {command: fnName, params: Array.prototype.slice.call(arguments, 1)};
             if (!initialized && fnName !== 'init') {
                 return Promise.reject(new Error('Proxy is not properly initialized or has been destroyed!'));
             }

--- a/views/js/core/dataProvider/proxy.js
+++ b/views/js/core/dataProvider/proxy.js
@@ -263,12 +263,17 @@ define([
             if (!initialized && fnName !== 'init') {
                 return Promise.reject(new Error('Proxy is not properly initialized or has been destroyed!'));
             }
-            return delegateProxy.apply(null, arguments).then(function (data) {
-                if (middlewares) {
-                    return middlewares.apply(request, data);
-                }
-                return data;
-            });
+            return delegateProxy.apply(null, arguments)
+                .then(function (data) {
+                    if (middlewares) {
+                        return middlewares.apply(request, data);
+                    }
+                    return data;
+                })
+                .catch(function (err) {
+                    proxy.trigger('error', err);
+                    return Promise.reject(err);
+                });
         }
 
 

--- a/views/js/core/dataProvider/proxy.js
+++ b/views/js/core/dataProvider/proxy.js
@@ -1,0 +1,279 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/delegator',
+    'core/eventifier',
+    'core/promise',
+    'core/providerRegistry',
+    'core/tokenHandler'
+], function (_, delegator, eventifier, Promise, providerRegistry, tokenHandlerFactory) {
+    'use strict';
+
+    var _defaults = {};
+
+    var _slice = [].slice;
+
+    /**
+     * Defines a CRUD proxy bound to a particular adapter. Each adapter will have to provide the following API:
+     *
+     * `init(config, params)`
+     * `destroy()`
+     * `create(params)`
+     * `read(params)`
+     * `write(params)`
+     * `remove(params)`
+     * `action(name, params)`
+     *
+     * @param {String} proxyName - The name of the proxy adapter to use in the returned proxy instance
+     * @param {middlewareHandler} [middlewares] - An optional middlewares handler
+     * @returns {proxy} - The proxy instance, bound to the selected proxy adapter
+     */
+    function crudProxyFactory(proxyName, middlewares) {
+
+        var proxyAdapter = crudProxyFactory.getProvider(proxyName);
+        var tokenHandler = tokenHandlerFactory();
+        var extraParams = {};
+        var initialized = false;
+        var initConfig;
+
+        /**
+         * @typedef {proxy}
+         */
+        var proxy = eventifier({
+            /**
+             * Initializes the proxy
+             * @param {Object} [config] - Some optional config depending of implementation,
+             *                            this object will be forwarded to the proxy adapter
+             * @returns {Promise} - Returns a promise that provide the proxy.
+             *                      The proxy will be fully initialized on resolve.
+             *                      Any error will be provided if rejected.
+             * @fires init
+             */
+            init: function init(config) {
+                initConfig = _.defaults({}, config, _defaults);
+
+                /**
+                 * @event init
+                 * @param {Promise} promise
+                 * @param {Object} params
+                 */
+                return delegate('init', initConfig).then(function () {
+                    // If the delegate call succeed the proxy is initialized.
+                    initialized = true;
+                    return proxy;
+                });
+            },
+
+            /**
+             * Uninstalls the proxy
+             * @returns {Promise} - Returns a promise. The proxy will be fully uninstalled on resolve.
+             *                      Any error will be provided if rejected.
+             * @fires destroy
+             */
+            destroy: function destroy() {
+                /**
+                 * @event destroy
+                 * @param {Promise} promise
+                 */
+                return delegate('destroy').then(function () {
+                    // The proxy is now destroyed. A call to init() is mandatory to be able to use it again.
+                    initialized = false;
+                    initConfig = null;
+                    extraParams = {};
+                });
+            },
+
+            /**
+             * Creates data
+             * @param {Object} [params] - An optional list of parameters
+             * @returns {Promise} - Returns a promise. The data will be provided on resolve.
+             *                      Any error will be provided if rejected.
+             * @fires create
+             */
+            create: function create(params) {
+                /**
+                 * @event create
+                 * @param {Promise} promise
+                 * @param {Object} params
+                 */
+                return delegate('create', getParams(params));
+            },
+
+            /**
+             * Reads data
+             * @param {Object} [params] - An optional list of parameters
+             * @returns {Promise} - Returns a promise. The data will be provided on resolve.
+             *                      Any error will be provided if rejected.
+             * @fires read
+             */
+            read: function read(params) {
+                /**
+                 * @event read
+                 * @param {Promise} promise
+                 * @param {Object} params
+                 */
+                return delegate('read', getParams(params));
+            },
+
+            /**
+             * Writes data
+             * @param {Object} [params] - An optional list of parameters
+             * @returns {Promise} - Returns a promise. The data will be provided on resolve.
+             *                      Any error will be provided if rejected.
+             * @fires write
+             */
+            write: function write(params) {
+                /**
+                 * @event write
+                 * @param {Promise} promise
+                 * @param {Object} params
+                 */
+                return delegate('write', getParams(params));
+            },
+
+            /**
+             * Removes data
+             * @param {Object} [params] - An optional list of parameters
+             * @returns {Promise} - Returns a promise. The data will be provided on resolve.
+             *                      Any error will be provided if rejected.
+             * @fires remove
+             */
+            remove: function remove(params) {
+                /**
+                 * @event remove
+                 * @param {Promise} promise
+                 * @param {Object} params
+                 */
+                return delegate('remove', getParams(params));
+            },
+
+            /**
+             * Call a particular action
+             * @param {String} name - The name of the action to call
+             * @param {Object} [params] - An optional list of parameters
+             * @returns {Promise} - Returns a promise. The data will be provided on resolve.
+             *                      Any error will be provided if rejected.
+             * @fires action
+             */
+            action: function action(name, params) {
+                /**
+                 * @event action
+                 * @param {Promise} promise
+                 * @param {String} action
+                 * @param {Object} params
+                 */
+                return delegate('action', name, getParams(params));
+            },
+
+            /**
+             * Add extra parameters that will be added to the next request
+             * @param {Object} params - the extra parameters
+             * @returns {proxy}
+             */
+            addExtraParams: function addExtraParams(params) {
+                if (_.isPlainObject(params)) {
+                    _.merge(extraParams, params);
+                }
+                return this;
+            },
+
+            /**
+             * Gets the security token handler
+             * @returns {tokenHandler}
+             */
+            getTokenHandler: function getTokenHandler() {
+                return tokenHandler;
+            },
+
+            /**
+             * Gets the config object
+             * @returns {Object}
+             */
+            getConfig: function getConfig() {
+                return initConfig;
+            },
+
+            /**
+             * Gets the middlewares handler
+             * @returns {middlewareHandler}
+             */
+            getMiddlewares: function getMidlewares() {
+                return middlewares;
+            },
+
+            /**
+             * Sets the middlewares handler
+             * @param {middlewareHandler} [handler] - An optional middlewares handler
+             * @returns {proxy}
+             */
+            setMiddlewares: function setMidlewares(handler) {
+                middlewares = handler;
+                return this;
+            }
+        });
+
+        var delegateProxy = delegator(proxy, proxyAdapter, {
+            name: 'proxy',
+            wrapper: function proxyWrapper(response) {
+                return Promise.resolve(response);
+            }
+        });
+
+        /**
+         * Gets parameters merged with extra parameters
+         * @param {Object} [params]
+         * @return {Object}
+         * @private
+         */
+        function getParams(params) {
+            var mergedParams = _.merge({}, params, extraParams);
+            extraParams = {};
+            return mergedParams;
+        }
+
+        /**
+         * Delegates the call to the proxy implementation and apply the middleware.
+         *
+         * @param {String} fnName - The name of the delegated method to call
+         * @returns {Promise} - The delegated method must return a promise
+         * @private
+         * @throws Error
+         */
+        function delegate(fnName) {
+            var request = {command: fnName, params: _slice.call(arguments, 1)};
+            if (!initialized && fnName !== 'init') {
+                return Promise.reject(new Error('Proxy is not properly initialized or has been destroyed!'));
+            }
+            return delegateProxy.apply(null, arguments).then(function (data) {
+                if (middlewares) {
+                    return middlewares.apply(request, data);
+                }
+                return data;
+            });
+        }
+
+
+        return proxy;
+    }
+
+    return providerRegistry(crudProxyFactory);
+});

--- a/views/js/core/dataProvider/proxy/ajax.js
+++ b/views/js/core/dataProvider/proxy/ajax.js
@@ -84,7 +84,7 @@ define([
          * @param {Boolean} [config.noCache] - Prevent the request to be cached by the client (default: true)
          * @param {Boolean} [config.noToken] - Prevent the request to be use the security token when available (default: false)
          */
-        init: function ajaxInit(config) {
+        init: function init(config) {
             // Will request the server for the wanted action.
             // May reject the request if the action is not implemented.
             this.processRequest = function processRequest(action, params, method) {
@@ -145,7 +145,7 @@ define([
         /**
          * Cleans up the instance when destroying
          */
-        destroy: function htmlDataDestroy() {
+        destroy: function destroy() {
             this.processRequest = null;
         },
 
@@ -153,7 +153,7 @@ define([
          * Requests the server for a create action
          * @param {Object} params
          */
-        create: function ajaxCreate(params) {
+        create: function create(params) {
             return this.processRequest('create', params, 'POST');
         },
 
@@ -161,7 +161,7 @@ define([
          * Requests the server for a read action
          * @param {Object} params
          */
-        read: function ajaxRead(params) {
+        read: function read(params) {
             return this.processRequest('read', params, 'GET');
         },
 
@@ -169,7 +169,7 @@ define([
          * Requests the server for a write action
          * @param {Object} params
          */
-        write: function ajaxWrite(params) {
+        write: function write(params) {
             return this.processRequest('write', params, 'POST');
         },
 
@@ -177,17 +177,17 @@ define([
          * Requests the server for a remove action
          * @param {Object} params
          */
-        remove: function ajaxRemove(params) {
+        remove: function remove(params) {
             return this.processRequest('remove', params, 'GET');
         },
 
         /**
          * Requests the server using a particular action
-         * @param {String} action
+         * @param {String} actionName
          * @param {Object} params
          */
-        action: function ajaxAction(action, params) {
-            return this.processRequest(action, params, 'POST');
+        action: function action(actionName, params) {
+            return this.processRequest(actionName, params, 'POST');
         }
     };
 });

--- a/views/js/core/dataProvider/proxy/ajax.js
+++ b/views/js/core/dataProvider/proxy/ajax.js
@@ -1,0 +1,193 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/dataProvider/request',
+    'core/promise'
+], function (_, request, Promise) {
+    'use strict';
+
+    var _defaults = {
+        noCache: true,
+        noToken: false,
+        actions: {}
+    };
+
+    /**
+     * Builds a reject descriptor for a particular action context
+     * @param {String} type
+     * @param {String} action
+     * @param {Object} params
+     * @returns {Promise}
+     */
+    function rejectAction(type, action, params) {
+        return Promise.reject({
+            success: false,
+            type: type,
+            action: action,
+            params: params
+        });
+    }
+
+    /**
+     * Defines an AJAX proxy implementation.
+     * Will request a server to fetch data.
+     */
+    return {
+        name: 'ajax',
+
+        /**
+         * Initializes the proxy, sets the implemented actions.
+         *
+         * @param {Object} config
+         * @param {Object} config.actions - The list of supported actions.
+         * Each action is represented by a name and a descriptor. The descriptor can be either a string (URL), or an
+         * object. When the descriptor is an object, it must provide an URL, optionally a request method. It can also
+         * provide a callback that will validate the parameters. A full descriptor looks like:
+         * ```
+         * {
+         *      url: "http://my.url/to/call",
+         *      method: "POST", // or "GET", or other accepted HTTP method
+         *      validate: function(params) {
+         *          // should return false if at least a parameter is not valid
+         *      }
+         * }
+         * ```
+         *
+         * The following actions have dedicated API, and should be implemented,
+         * otherwise a reject will be made when calling them:
+         * - 'create' (POST)
+         * - 'read'   (GET)
+         * - 'write'  (POST)
+         * - 'remove' (GET)
+         *
+         * Other actions are applied with POST method by default. You can override the method in each action descriptor.
+         *
+         * @param {Boolean} [config.noCache] - Prevent the request to be cached by the client (default: true)
+         * @param {Boolean} [config.noToken] - Prevent the request to be use the security token when available (default: false)
+         */
+        init: function ajaxInit(config) {
+            // Will request the server for the wanted action.
+            // May reject the request if the action is not implemented.
+            this.processRequest = function processRequest(action, params, method) {
+                var descriptor = config.actions[action];
+                var headers = {};
+                var tokenHandler = this.getTokenHandler();
+                var token;
+
+                if (_.isString(descriptor)) {
+                    descriptor = {
+                        url: descriptor
+                    };
+                }
+
+                if (descriptor && descriptor.url) {
+                    if (_.isFunction(descriptor.validate) && descriptor.validate(params) === false) {
+                        // invalid parameter
+                        return rejectAction('invalid', action, params);
+                    }
+                } else {
+                    // action not implemented
+                    return rejectAction('notimplemented', action, params);
+                }
+
+                if (config.noCache) {
+                    params = _.merge({_: (new Date).getTime()}, params);
+                }
+
+                if (!config.noToken) {
+                    token = tokenHandler.getToken();
+                    if (token) {
+                        headers['X-Auth-Token'] = token;
+                    }
+                }
+
+                return request(descriptor.url, params, descriptor.method || method, headers)
+                    .then(function(data) {
+                        if (data && data.token) {
+                            tokenHandler.setToken(data.token);
+                        }
+                        return data;
+                    })
+                    .catch(function(err) {
+                        var t = err.response && (err.response.token || (err.response.data && err.response.data.token));
+                        if (t) {
+                            tokenHandler.setToken(t);
+                        } else if (!config.noToken) {
+                            tokenHandler.setToken(token);
+                        }
+
+                        return Promise.reject(err);
+                    });
+            };
+
+            _.defaults(config, _defaults);
+        },
+
+        /**
+         * Cleans up the instance when destroying
+         */
+        destroy: function htmlDataDestroy() {
+            this.processRequest = null;
+        },
+
+        /**
+         * Requests the server for a create action
+         * @param {Object} params
+         */
+        create: function ajaxCreate(params) {
+            return this.processRequest('create', params, 'POST');
+        },
+
+        /**
+         * Requests the server for a read action
+         * @param {Object} params
+         */
+        read: function ajaxRead(params) {
+            return this.processRequest('read', params, 'GET');
+        },
+
+        /**
+         * Requests the server for a write action
+         * @param {Object} params
+         */
+        write: function ajaxWrite(params) {
+            return this.processRequest('write', params, 'POST');
+        },
+
+        /**
+         * Requests the server for a remove action
+         * @param {Object} params
+         */
+        remove: function ajaxRemove(params) {
+            return this.processRequest('remove', params, 'GET');
+        },
+
+        /**
+         * Requests the server using a particular action
+         * @param {String} action
+         * @param {Object} params
+         */
+        action: function ajaxAction(action, params) {
+            return this.processRequest(action, params, 'POST');
+        }
+    };
+});

--- a/views/js/core/dataProvider/request.js
+++ b/views/js/core/dataProvider/request.js
@@ -39,10 +39,10 @@ define([
      * Create a new error based on the given response
      * @param {Object} response - the server body response as plain object
      * @param {String} fallbackMessage - the error message in case the response isn't correct
-     * @param {XMLHttpRequest} xhr - the response header
+     * @param {Number} httpCode - the response HTTP code
      * @returns {Error} the new error
      */
-    var createError = function createError(response, fallbackMessage, xhr){
+    var createError = function createError(response, fallbackMessage, httpCode){
         var err;
         if(response && response.errorCode){
             err = new Error(response.errorCode + ' : ' + (response.errorMsg || response.errorMessage));
@@ -50,8 +50,8 @@ define([
         } else {
             err = new Error(fallbackMessage);
         }
-        if (xhr && xhr.status) {
-            err.code = xhr.status;
+        if (httpCode) {
+            err.code = httpCode;
         }
         return err;
     };
@@ -90,7 +90,7 @@ define([
                 }
 
                 //the server has handled the error
-                return reject(createError(response, 'No response', xhr));
+                return reject(createError(response, 'No response', xhr.status));
             })
             .fail(function(xhr){
                 var response;
@@ -100,7 +100,7 @@ define([
                     _.noop();
                 }
 
-                return reject(createError(response, xhr.status + ' : ' + xhr.statusText, xhr));
+                return reject(createError(response, xhr.status + ' : ' + xhr.statusText, xhr.status));
             });
         });
     };

--- a/views/js/core/dataProvider/request.js
+++ b/views/js/core/dataProvider/request.js
@@ -57,9 +57,10 @@ define([
      * @param {String} url - the endpoint full url
      * @param {Object} [data] - additional parameters
      * @param {String} [method = 'GET'] - the HTTP method
+     * @param {Object} [headers] - the HTTP header
      * @returns {Promise} that resolves with data or reject if something went wrong
      */
-    return function request(url, data, method){
+    return function request(url, data, method, headers){
         return new Promise(function(resolve, reject){
 
             if(_.isEmpty(url)){
@@ -70,6 +71,7 @@ define([
                 url: url,
                 type: method || 'GET',
                 dataType: 'json',
+                headers: headers,
                 data : data
             })
             .done(function(response, status, xhr){

--- a/views/js/core/dataProvider/request.js
+++ b/views/js/core/dataProvider/request.js
@@ -39,15 +39,19 @@ define([
      * Create a new error based on the given response
      * @param {Object} response - the server body response as plain object
      * @param {String} fallbackMessage - the error message in case the response isn't correct
+     * @param {XMLHttpRequest} xhr - the response header
      * @returns {Error} the new error
      */
-    var createError = function createError(response, fallbackMessage){
+    var createError = function createError(response, fallbackMessage, xhr){
         var err;
         if(response && response.errorCode){
             err = new Error(response.errorCode + ' : ' + (response.errorMsg || response.errorMessage));
             err.response = response;
         } else {
             err = new Error(fallbackMessage);
+        }
+        if (xhr && xhr.status) {
+            err.code = xhr.status;
         }
         return err;
     };
@@ -86,7 +90,7 @@ define([
                 }
 
                 //the server has handled the error
-                return reject(createError(response, 'No response'));
+                return reject(createError(response, 'No response', xhr));
             })
             .fail(function(xhr){
                 var response;
@@ -96,7 +100,7 @@ define([
                     _.noop();
                 }
 
-                return reject(createError(response, xhr.status + ' : ' + xhr.statusText));
+                return reject(createError(response, xhr.status + ' : ' + xhr.statusText, xhr));
             });
         });
     };

--- a/views/js/test/core/dataProvider/mocks/requestMock.js
+++ b/views/js/test/core/dataProvider/mocks/requestMock.js
@@ -1,0 +1,47 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'core/eventifier',
+    'core/promise'
+], function (eventifier, Promise) {
+    'use strict';
+
+    /**
+     * Request content using events
+     * @param {String} url
+     * @param {Object} [params]
+     * @param {String} [method = 'GET']
+     * @param {Object} [headers]
+     * @returns {Promise} that resolves with data or reject if something went wrong
+     */
+    function requestMock(url, params, method, headers) {
+        return new Promise(function(resolve, reject){
+            requestMock.api
+                .on('success', resolve)
+                .on('failure', reject)
+                .trigger('request', url, params, method || 'GET', headers || {});
+        });
+    }
+
+    requestMock.api = eventifier();
+
+    return requestMock;
+});

--- a/views/js/test/core/dataProvider/proxy/ajax/test.html
+++ b/views/js/test/core/dataProvider/proxy/ajax/test.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Core - DataProvider AJAX Proxy</title>
+        <base href="../../../../../../" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="core/dataProvider/proxy/ajax.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //some mocks
+                requirejs.config({
+                    "paths": {
+                        "core/dataProvider/request" : "test/core/dataProvider/mocks/requestMock"
+                    }
+                });
+
+                //load the test
+                require(['test/core/dataProvider/proxy/ajax/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/core/dataProvider/proxy/ajax/test.js
+++ b/views/js/test/core/dataProvider/proxy/ajax/test.js
@@ -1,0 +1,663 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/promise',
+    'core/dataProvider/request',
+    'core/dataProvider/proxy',
+    'core/dataProvider/proxy/ajax'
+], function (_, Promise, requestMock, proxyFactory, ajaxProvider) {
+    'use strict';
+
+    var tokenCasesSuccess, tokenCasesFailure;
+    var ajaxProviderApi = [
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'create'},
+        {title: 'read'},
+        {title: 'write'},
+        {title: 'remove'},
+        {title: 'action'}
+    ];
+
+
+    QUnit.module('ajaxProvider', {
+        setup: function () {
+            proxyFactory.clearProviders();
+            proxyFactory.registerProvider('ajax', ajaxProvider);
+            requestMock.api.removeAllListeners();
+        }
+    });
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(1);
+
+        assert.equal(typeof ajaxProvider, 'object', "The proxy/ajax module exposes an object");
+    });
+
+
+    QUnit
+        .cases(ajaxProviderApi)
+        .test('instance API ', function (data, assert) {
+            QUnit.expect(1);
+            assert.equal(typeof ajaxProvider[data.title], 'function', 'The proxy/ajax provider exposes a "' + data.title + '" function');
+        });
+
+
+    QUnit.asyncTest('ajax.init()', function (assert) {
+        var initConfig = {};
+        var expectedConfig = {
+            noCache: true,
+            noToken: false,
+            actions: {}
+        };
+        var result, proxy;
+
+        QUnit.expect(9);
+
+        proxy = proxyFactory('ajax');
+        result = proxy
+            .on('init', function (promise, config) {
+                assert.ok(true, 'The proxyFactory has fired the "init" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "init" event');
+                assert.deepEqual(config, expectedConfig, 'The proxyFactory has provided the config object through the "init" event');
+            })
+            .init(initConfig);
+
+        assert.ok(result instanceof Promise, 'The proxyFactory.init() method has returned a promise');
+
+        result
+            .then(function () {
+                assert.ok(true, 'The promise should be resolved');
+                assert.deepEqual(proxy.getConfig(), expectedConfig, 'The proxyFactory has provided the config object through the "init" event');
+
+                assert.equal(typeof proxy.processRequest, 'function', 'Internal method should exist');
+
+                return proxy.destroy();
+            })
+            .then(function() {
+                assert.ok(true, 'The promise should be resolved');
+                assert.equal(proxy.processRequest, null, 'Internal method should be destroyed');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('ajax.create()', function (assert) {
+        var proxy;
+        var expectedParams = {
+            foo: 'bar'
+        };
+        var expectedUrl = 'http://foo.bar/create';
+        var expectedMethod = 'PUT';
+        var expectedResponse = {
+            success: true,
+            data: {
+                list: [1, 2, 3]
+            }
+        };
+        var initConfig = {
+            actions: {
+                create: {
+                    url: expectedUrl,
+                    method: expectedMethod
+                }
+            }
+        };
+
+        QUnit.expect(10);
+
+        proxy = proxyFactory('ajax')
+            .on('create', function (promise, params) {
+                assert.ok(true, 'The proxyFactory has fired the "create" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "create" event');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "create" event');
+            });
+
+        proxy.create()
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        requestMock.api.on('request', function(url, params, method) {
+            assert.equal(url, expectedUrl, 'The url is correct');
+            assert.equal(method, expectedMethod, 'The HTTP method is correct');
+            delete params._;
+            assert.deepEqual(params, expectedParams, 'The expected parameters have been provided');
+            requestMock.api.trigger('success', expectedResponse);
+        });
+
+        proxy.init(initConfig)
+            .then(function () {
+                var result = proxy.create(expectedParams);
+
+                assert.ok(result instanceof Promise, 'The proxyFactory.create() method has returned a promise');
+
+                return result;
+            })
+            .then(function (response) {
+                assert.ok(true, 'The promise should be resolved');
+                assert.deepEqual(response, expectedResponse, 'The expected responses have been provided');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('ajax.read()', function (assert) {
+        var proxy;
+        var expectedParams = {
+            foo: 'bar'
+        };
+        var expectedUrl = 'http://foo.bar/read';
+        var expectedMethod = 'GET';
+        var expectedResponse = {
+            success: true,
+            data: {
+                list: [1, 2, 3]
+            }
+        };
+        var initConfig = {
+            actions: {
+                read: expectedUrl
+            }
+        };
+
+        QUnit.expect(10);
+
+        proxy = proxyFactory('ajax')
+            .on('read', function (promise, params) {
+                assert.ok(true, 'The proxyFactory has fired the "read" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "read" event');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "read" event');
+            });
+
+        proxy.read()
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        requestMock.api.on('request', function(url, params, method) {
+            assert.equal(url, expectedUrl, 'The url is correct');
+            assert.equal(method, expectedMethod, 'The HTTP method is correct');
+            delete params._;
+            assert.deepEqual(params, expectedParams, 'The expected parameters have been provided');
+            requestMock.api.trigger('success', expectedResponse);
+        });
+
+        proxy.init(initConfig)
+            .then(function () {
+                var result = proxy.read(expectedParams);
+
+                assert.ok(result instanceof Promise, 'The proxyFactory.read() method has returned a promise');
+
+                return result;
+            })
+            .then(function (response) {
+                assert.ok(true, 'The promise should be resolved');
+                assert.deepEqual(response, expectedResponse, 'The expected responses have been provided');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('ajax.write()', function (assert) {
+        var proxy;
+        var expectedParams = {
+            foo: 'bar'
+        };
+        var wrongParams = {
+            wrong: 'wrong'
+        };
+        var expectedUrl = 'http://foo.bar/write';
+        var expectedMethod = 'POST';
+        var expectedResponse = {
+            success: true,
+            data: {
+                list: [1, 2, 3]
+            }
+        };
+        var expectedError = {
+            success: false,
+            type: 'invalid',
+            action: 'write',
+            params: wrongParams
+        };
+        var initConfig = {
+            actions: {
+                write: {
+                    url: expectedUrl,
+                    method: expectedMethod,
+                    validate: function(params) {
+                        return _.isPlainObject(params) && !!params.foo;
+                    }
+                }
+            }
+        };
+
+        QUnit.expect(12);
+
+        proxy = proxyFactory('ajax')
+            .on('write', function (promise, params) {
+                assert.ok(true, 'The proxyFactory has fired the "write" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "write" event');
+                promise.then(function() {
+                    assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "write" event');
+                });
+            });
+
+        proxy.write()
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        requestMock.api.on('request', function(url, params, method) {
+            assert.equal(url, expectedUrl, 'The url is correct');
+            assert.equal(method, expectedMethod, 'The HTTP method is correct');
+            delete params._;
+            assert.deepEqual(params, expectedParams, 'The expected parameters have been provided');
+            requestMock.api.trigger('success', expectedResponse);
+        });
+
+        proxy.init(initConfig)
+            .then(function () {
+                return proxy.write(wrongParams)
+                    .then(function() {
+                        assert.ok(false, 'The promise should be rejected');
+                    })
+                    .catch(function (err) {
+                        assert.deepEqual(err, expectedError, 'The expected error descriptor should be provided');
+
+                        return proxy.write(expectedParams);
+                    })
+                    .then(function (response) {
+                        assert.ok(true, 'The promise should be resolved');
+                        assert.deepEqual(response, expectedResponse, 'The expected responses have been provided');
+                        QUnit.start();
+                    });
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('ajax.remove()', function (assert) {
+        var proxy;
+        var expectedParams = {
+            foo: 'bar'
+        };
+        var expectedUrl = 'http://foo.bar/remove';
+        var expectedMethod = 'GET';
+        var expectedResponse = {
+            success: true
+        };
+        var initConfig = {
+            actions: {
+                remove: expectedUrl
+            }
+        };
+
+        QUnit.expect(10);
+
+        proxy = proxyFactory('ajax')
+            .on('remove', function (promise, params) {
+                assert.ok(true, 'The proxyFactory has fired the "remove" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "remove" event');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "remove" event');
+            });
+
+        proxy.remove()
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        requestMock.api.on('request', function(url, params, method) {
+            assert.equal(url, expectedUrl, 'The url is correct');
+            assert.equal(method, expectedMethod, 'The HTTP method is correct');
+            delete params._;
+            assert.deepEqual(params, expectedParams, 'The expected parameters have been provided');
+            requestMock.api.trigger('success', expectedResponse);
+        });
+
+        proxy.init(initConfig)
+            .then(function () {
+                var result = proxy.remove(expectedParams);
+
+                assert.ok(result instanceof Promise, 'The proxyFactory.remove() method has returned a promise');
+
+                return result;
+            })
+            .then(function (response) {
+                assert.ok(true, 'The promise should be resolved');
+                assert.deepEqual(response, expectedResponse, 'The expected responses have been provided');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('ajax.action()', function (assert) {
+        var proxy;
+        var expectedParams = {
+            foo: 'bar'
+        };
+        var expectedUrl = 'http://foo.bar/foo';
+        var expectedMethod = 'GET';
+        var expectedAction = 'foo';
+        var expectedResponse = {
+            success: true
+        };
+        var expectedError = {
+            success: false,
+            type: 'notimplemented',
+            action: 'unknown',
+            params: {}
+        };
+        var initConfig = {
+            actions: {
+                foo: {
+                    url: expectedUrl,
+                    method: expectedMethod
+                }
+            }
+        };
+
+        QUnit.expect(13);
+
+        proxy = proxyFactory('ajax')
+            .on('action', function (promise, action, params) {
+                assert.ok(true, 'The proxyFactory has fired the "action" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "action" event');
+                promise.then(function() {
+                    assert.equal(action, expectedAction, 'The proxyFactory has provided the action name through the "action" event');
+                    assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "action" event');
+                });
+            });
+
+        proxy.action()
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        requestMock.api.on('request', function(url, params, method) {
+            assert.equal(url, expectedUrl, 'The url is correct');
+            assert.equal(method, expectedMethod, 'The HTTP method is correct');
+            delete params._;
+            assert.deepEqual(params, expectedParams, 'The expected parameters have been provided');
+            requestMock.api.trigger('success', expectedResponse);
+        });
+
+        proxy.init(initConfig)
+            .then(function () {
+                return proxy.action('unknown')
+                    .then(function() {
+                        assert.ok(false, 'The promise should be rejected');
+                    })
+                    .catch(function (err) {
+                        assert.deepEqual(err, expectedError, 'The expected error descriptor should be provided');
+
+                        return proxy.action(expectedAction, expectedParams);
+                    })
+                    .then(function (response) {
+                        assert.ok(true, 'The promise should be resolved');
+                        assert.deepEqual(response, expectedResponse, 'The expected response have been provided');
+                        QUnit.start();
+                    });
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    tokenCasesSuccess = [{
+        title: 'send',
+        url: 'http://foo.bar/read',
+        method: 'GET',
+        token: 'foo#token1',
+        params: {
+            foo: 'bar'
+        },
+        response: {
+            success: true,
+            data: {
+                list: [1, 2, 3]
+            }
+        }
+    }, {
+        title: 'receive',
+        url: 'http://foo.bar/read',
+        method: 'GET',
+        token: 'foo#token1',
+        expectedToken: 'foo#token2',
+        params: {
+            foo: 'bar'
+        },
+        response: {
+            success: true,
+            data: {
+                token: 'foo#token2',
+                list: [1, 2, 3]
+            }
+        }
+    }];
+
+    QUnit
+        .cases(tokenCasesSuccess)
+        .asyncTest('token handling on success ', function (data, assert) {
+            var proxy;
+            var initConfig = {
+                actions: {
+                    read: data.url
+                }
+            };
+
+            QUnit.expect(12);
+
+            proxy = proxyFactory('ajax')
+                .on('read', function (promise, params) {
+                    assert.ok(true, 'The proxyFactory has fired the "read" event');
+                    assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "read" event');
+                    assert.deepEqual(params, data.params, 'The proxyFactory has provided the params through the "read" event');
+                });
+
+            proxy.read()
+                .then(function () {
+                    assert.ok(false, 'The proxy must be initialized');
+                })
+                .catch(function () {
+                    assert.ok(true, 'The proxy must be initialized');
+                });
+
+            requestMock.api.on('request', function(url, params, method, headers) {
+                assert.equal(url, data.url, 'The url is correct');
+                assert.equal(method, data.method, 'The HTTP method is correct');
+                delete params._;
+                assert.deepEqual(params, data.params, 'The expected parameters have been provided');
+                assert.equal(headers['X-Auth-Token'], data.token, 'The expected security token have been provided');
+                requestMock.api.trigger('success', data.response.data);
+            });
+
+            proxy.init(initConfig)
+                .then(function () {
+                    proxy.getTokenHandler().setToken(data.token);
+                    return proxy.read(data.params);
+                })
+                .then(function (response) {
+                    assert.ok(true, 'The promise should be resolved');
+                    assert.deepEqual(response, data.response.data, 'The expected responses have been provided');
+                    assert.equal(response.token, data.expectedToken, 'A security token has been provided');
+                    assert.equal(proxy.getTokenHandler().getToken(), data.expectedToken, 'The right security token has been set');
+                    QUnit.start();
+                })
+                .catch(function (err) {
+                    assert.ok(false, 'The promise should not be rejected');
+                    console.error(err);
+                    QUnit.start();
+                });
+        });
+
+
+    tokenCasesFailure = [{
+        title: 'response',
+        url: 'http://foo.bar/read',
+        method: 'GET',
+        token: 'foo#token1',
+        expectedToken: 'foo#token2',
+        params: {
+            foo: 'bar'
+        },
+        response: {
+            success: false,
+            token: 'foo#token2',
+            data: {
+                list: [1, 2, 3]
+            }
+        }
+    }, {
+        title: 'response data',
+        url: 'http://foo.bar/read',
+        method: 'GET',
+        token: 'foo#token1',
+        expectedToken: 'foo#token2',
+        params: {
+            foo: 'bar'
+        },
+        response: {
+            success: false,
+            data: {
+                token: 'foo#token2',
+                list: [1, 2, 3]
+            }
+        }
+    }, {
+        title: 'no token',
+        url: 'http://foo.bar/read',
+        method: 'GET',
+        token: 'foo#token1',
+        expectedToken: 'foo#token1',
+        params: {
+            foo: 'bar'
+        },
+        response: {
+            success: false,
+            data: {
+                list: [1, 2, 3]
+            }
+        }
+    }];
+
+    QUnit
+        .cases(tokenCasesFailure)
+        .asyncTest('token handling on error ', function (data, assert) {
+            var proxy;
+            var initConfig = {
+                actions: {
+                    read: data.url
+                }
+            };
+
+            QUnit.expect(11);
+
+            proxy = proxyFactory('ajax')
+                .on('read', function (promise, params) {
+                    assert.ok(true, 'The proxyFactory has fired the "read" event');
+                    assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "read" event');
+                    assert.deepEqual(params, data.params, 'The proxyFactory has provided the params through the "read" event');
+                });
+
+            proxy.read()
+                .then(function () {
+                    assert.ok(false, 'The proxy must be initialized');
+                })
+                .catch(function () {
+                    assert.ok(true, 'The proxy must be initialized');
+                });
+
+            requestMock.api.on('request', function(url, params, method, headers) {
+                var err = new Error('Failure');
+                err.response = data.response;
+
+                assert.equal(url, data.url, 'The url is correct');
+                assert.equal(method, data.method, 'The HTTP method is correct');
+                delete params._;
+                assert.deepEqual(params, data.params, 'The expected parameters have been provided');
+                assert.equal(headers['X-Auth-Token'], data.token, 'The expected security token have been provided');
+
+                requestMock.api.trigger('failure', err);
+            });
+
+            proxy.init(initConfig)
+                .then(function () {
+                    proxy.getTokenHandler().setToken(data.token);
+                    return proxy.read(data.params);
+                })
+                .then(function () {
+                    assert.ok(false, 'The promise should not be resolved');
+                    QUnit.start();
+                })
+                .catch(function (err) {
+                    assert.ok(true, 'The promise should be rejected');
+                    assert.deepEqual(err.response, data.response, 'The expected responses have been provided');
+                    assert.equal(proxy.getTokenHandler().getToken(), data.expectedToken, 'The right security token has been set');
+                    QUnit.start();
+                });
+        });
+});

--- a/views/js/test/core/dataProvider/proxy/api/test.html
+++ b/views/js/test/core/dataProvider/proxy/api/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Core - DataProvider Proxy</title>
+        <base href="../../../../../../" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="core/dataProvider/proxy.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['test/core/dataProvider/proxy/api/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/core/dataProvider/proxy/api/test.js
+++ b/views/js/test/core/dataProvider/proxy/api/test.js
@@ -1,0 +1,586 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/promise',
+    'core/dataProvider/proxy'
+], function (_, Promise, proxyFactory) {
+    'use strict';
+
+    var defaultProxy = {
+        init: _.noop,
+        destroy: _.noop,
+        create: _.noop,
+        read: _.noop,
+        write: _.noop,
+        remove: _.noop,
+        action: _.noop
+    };
+
+    var proxyApi = [
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'create'},
+        {title: 'read'},
+        {title: 'write'},
+        {title: 'remove'},
+        {title: 'action'},
+        {title: 'addExtraParams'},
+        {title: 'getTokenHandler'},
+        {title: 'getConfig'},
+        {title: 'getMiddlewares'},
+        {title: 'setMiddlewares'}
+    ];
+
+
+    QUnit.module('proxyFactory', {
+        setup: function () {
+            proxyFactory.clearProviders();
+        }
+    });
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(5);
+
+        assert.equal(typeof proxyFactory, 'function', "The proxyFactory module exposes a function");
+        assert.equal(typeof proxyFactory.registerProvider, 'function', "The proxyFactory module exposes a registerProvider method");
+        assert.equal(typeof proxyFactory.getProvider, 'function', "The proxyFactory module exposes a getProvider method");
+
+        proxyFactory.registerProvider('default', defaultProxy);
+
+        assert.equal(typeof proxyFactory(), 'object', "The proxyFactory factory produces an object");
+        assert.notStrictEqual(proxyFactory(), proxyFactory(), "The proxyFactory factory provides a different object on each call");
+    });
+
+
+    QUnit
+        .cases(proxyApi)
+        .test('instance API ', function (data, assert) {
+            var instance;
+            proxyFactory.registerProvider('default', defaultProxy);
+            instance = proxyFactory('default');
+            QUnit.expect(1);
+            assert.equal(typeof instance[data.title], 'function', 'The proxyFactory instance exposes a "' + data.title + '" function');
+        });
+
+
+    QUnit.asyncTest('proxy.init()', function (assert) {
+        var initConfig = {};
+        var result, proxy;
+
+        QUnit.expect(9);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            init: function (config) {
+                assert.ok(true, 'The proxyFactory has delegated the call');
+                assert.deepEqual(config, initConfig, 'The proxyFactory has provided the config object as a parameter');
+                return Promise.resolve();
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default');
+        result = proxy
+            .on('init', function (promise, config) {
+                assert.ok(true, 'The proxyFactory has fired the "init" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "init" event');
+                assert.deepEqual(config, initConfig, 'The proxyFactory has provided the config object through the "init" event');
+            })
+            .init(initConfig);
+
+        assert.ok(result instanceof Promise, 'The proxyFactory.init() method has returned a promise');
+
+        result
+            .then(function (resolvedProxy) {
+                assert.ok(true, 'The promise should be resolved');
+                assert.deepEqual(proxy.getConfig(), initConfig, 'The proxyFactory has provided the config object');
+                assert.equal(resolvedProxy, proxy, 'The promise has been resolved with the initialized proxy');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('proxy.destroy()', function (assert) {
+        var proxy;
+
+        QUnit.expect(5);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            destroy: function () {
+                assert.ok(true, 'The proxyFactory has delegated the call');
+                return Promise.resolve();
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default')
+            .on('destroy', function (promise) {
+                assert.ok(true, 'The proxyFactory has fired the "destroy" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "destroy" event');
+            });
+
+        proxy.init()
+            .then(function () {
+                var result = proxy.destroy();
+
+                assert.ok(result instanceof Promise, 'The proxyFactory.destroy() method has returned a promise');
+
+                return result;
+            })
+            .then(function () {
+                assert.ok(true, 'The promise should be resolved');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+
+    });
+
+
+    QUnit.asyncTest('proxy.create()', function (assert) {
+        var proxy;
+        var expectedParams = {
+            foo: 'bar'
+        };
+
+        QUnit.expect(8);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            create: function (params) {
+                assert.ok(true, 'The proxyFactory has delegated the call');
+                assert.deepEqual(params, expectedParams, 'The delegated method received the expected parameters');
+                return Promise.resolve();
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default')
+            .on('create', function (promise, params) {
+                assert.ok(true, 'The proxyFactory has fired the "create" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "create" event');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "create" event');
+            });
+
+        proxy.create()
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        proxy.init()
+            .then(function () {
+                var result = proxy.create(expectedParams);
+
+                assert.ok(result instanceof Promise, 'The proxyFactory.create() method has returned a promise');
+
+                return result;
+            })
+            .then(function () {
+                assert.ok(true, 'The promise should be resolved');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('proxy.read()', function (assert) {
+        var proxy;
+        var expectedParams = {
+            foo: 'bar'
+        };
+
+        QUnit.expect(8);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            read: function (params) {
+                assert.ok(true, 'The proxyFactory has delegated the call');
+                assert.deepEqual(params, expectedParams, 'The delegated method received the expected parameters');
+                return Promise.resolve();
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default')
+            .on('read', function (promise, params) {
+                assert.ok(true, 'The proxyFactory has fired the "read" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "read" event');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "read" event');
+            });
+
+        proxy.read()
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        proxy.init()
+            .then(function () {
+                var result = proxy.read(expectedParams);
+
+                assert.ok(result instanceof Promise, 'The proxyFactory.read() method has returned a promise');
+
+                return result;
+            })
+            .then(function () {
+                assert.ok(true, 'The promise should be resolved');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('proxy.write()', function (assert) {
+        var proxy;
+        var expectedParams = {
+            foo: 'bar'
+        };
+
+        QUnit.expect(8);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            write: function (params) {
+                assert.ok(true, 'The proxyFactory has delegated the call');
+                assert.deepEqual(params, expectedParams, 'The delegated method received the expected parameters');
+                return Promise.resolve();
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default')
+            .on('write', function (promise, params) {
+                assert.ok(true, 'The proxyFactory has fired the "write" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "write" event');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "write" event');
+            });
+
+        proxy.write()
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        proxy.init()
+            .then(function () {
+                var result = proxy.write(expectedParams);
+
+                assert.ok(result instanceof Promise, 'The proxyFactory.write() method has returned a promise');
+
+                return result;
+            })
+            .then(function () {
+                assert.ok(true, 'The promise should be resolved');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('proxy.remove()', function (assert) {
+        var proxy;
+        var expectedParams = {
+            foo: 'bar'
+        };
+
+        QUnit.expect(8);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            remove: function (params) {
+                assert.ok(true, 'The proxyFactory has delegated the call');
+                assert.deepEqual(params, expectedParams, 'The delegated method received the expected parameters');
+                return Promise.resolve();
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default')
+            .on('remove', function (promise, params) {
+                assert.ok(true, 'The proxyFactory has fired the "remove" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "remove" event');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "remove" event');
+            });
+
+        proxy.remove()
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        proxy.init()
+            .then(function () {
+                var result = proxy.remove(expectedParams);
+
+                assert.ok(result instanceof Promise, 'The proxyFactory.remove() method has returned a promise');
+
+                return result;
+            })
+            .then(function () {
+                assert.ok(true, 'The promise should be resolved');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('proxy.action()', function (assert) {
+        var proxy;
+        var expectedAction = 'fooBar';
+        var expectedParams = {
+            foo: 'bar'
+        };
+
+        QUnit.expect(10);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            action: function (action, params) {
+                assert.ok(true, 'The proxyFactory has delegated the call');
+                assert.equal(action, expectedAction, 'The proxyFactory has provided the action name');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params');
+                return Promise.resolve();
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default')
+            .on('action', function (promise, action, params) {
+                assert.ok(true, 'The proxyFactory has fired the "action" event');
+                assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "action" event');
+                assert.equal(action, expectedAction, 'The proxyFactory has provided the action through the "action" event');
+                assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "action" event');
+            });
+
+        proxy.action(expectedAction, expectedParams)
+            .then(function () {
+                assert.ok(false, 'The proxy must be initialized');
+            })
+            .catch(function () {
+                assert.ok(true, 'The proxy must be initialized');
+            });
+
+        proxy.init()
+            .then(function () {
+                var result = proxy.action(expectedAction, expectedParams);
+
+                assert.ok(result instanceof Promise, 'The proxyFactory.action() method has returned a promise');
+
+                return result;
+            })
+            .then(function () {
+                assert.ok(true, 'The promise should be resolved');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('proxy.addExtraParams()', function (assert) {
+        var expectedAction = 'fooBar';
+        var expectedParams = {
+            foo: 'bar'
+        };
+        var extraParams = {
+            noz: 'moo'
+        };
+        var extraParamsSet = false;
+        var proxy;
+
+        QUnit.expect(14);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            read: function () {
+                return Promise.resolve();
+            },
+            write: function () {
+                return Promise.resolve();
+            },
+            action: function () {
+                return Promise.resolve();
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default');
+
+        proxy.init()
+            .then(function () {
+                proxy
+                    .on('read', function (promise, params) {
+                        assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "action" event');
+                        if (extraParamsSet) {
+                            assert.deepEqual(params, _.merge({}, expectedParams, extraParams), 'The proxyFactory has provided the params through the "read" event with extra parameters');
+
+                            extraParamsSet = false;
+                            proxy.read(expectedParams);
+                        } else {
+                            assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "read" event without extra parameters');
+
+                            proxy.addExtraParams(extraParams);
+                            extraParamsSet = true;
+                            proxy.write(expectedParams);
+                        }
+                    })
+                    .on('write', function (promise, params) {
+                        assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "action" event');
+                        if (extraParamsSet) {
+                            assert.deepEqual(params, _.merge({}, expectedParams, extraParams), 'The proxyFactory has provided the params through the "write" event with extra parameters');
+
+                            extraParamsSet = false;
+                            proxy.write(expectedParams);
+                        } else {
+                            assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "write" event without extra parameters');
+
+                            proxy.addExtraParams(extraParams);
+                            extraParamsSet = true;
+                            proxy.action(expectedAction, expectedParams);
+                        }
+                    })
+                    .on('action', function (promise, action, params) {
+                        assert.ok(promise instanceof Promise, 'The proxyFactory has provided the promise through the "action" event');
+                        assert.equal(action, expectedAction, 'The proxyFactory has provided the action through the "action" event');
+
+                        if (extraParamsSet) {
+                            assert.deepEqual(params, _.merge({}, expectedParams, extraParams), 'The proxyFactory has provided the params through the "action" event with extra parameters');
+
+                            extraParamsSet = false;
+                            proxy.action(expectedAction, expectedParams);
+                        } else {
+                            assert.deepEqual(params, expectedParams, 'The proxyFactory has provided the params through the "action" event without extra parameters');
+
+                            QUnit.start();
+                        }
+                    });
+
+                proxy.addExtraParams(extraParams);
+                extraParamsSet = true;
+                return proxy.read(expectedParams);
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.test('proxy.getTokenHandler()', function (assert) {
+        var proxy, securityToken;
+
+        proxyFactory.registerProvider('default', defaultProxy);
+        proxy = proxyFactory('default');
+        securityToken = proxy.getTokenHandler();
+
+        QUnit.expect(3);
+
+        assert.equal(typeof securityToken, 'object', 'The proxy has built a securityToken handler');
+        assert.equal(typeof securityToken.getToken, 'function', 'The securityToken handler has a getToken method');
+        assert.equal(typeof securityToken.setToken, 'function', 'The securityToken handler has a setToken method');
+    });
+
+
+    QUnit.asyncTest('proxy with middleware', function (assert) {
+        var proxy;
+        var current;
+        var expectedParams = {
+            foo: 'bar'
+        };
+        var expectedData = {
+            success: true,
+            list: [1, 2, 3]
+        };
+        var expectedResponse = _.merge({
+            record: expectedParams
+        }, expectedData);
+
+        var middleware = {
+            use: function () {
+            },
+            apply: function (request, response) {
+                var params = current === 'init' ? [{}] : [expectedParams];
+                assert.deepEqual(request, {command: current, params: params}, "The request command has been set");
+                assert.deepEqual(response, expectedData, "The response has been provided");
+
+                response.record = expectedParams;
+                return response;
+            }
+        };
+
+        QUnit.expect(7);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            init: function () {
+                current = 'init';
+                return expectedData;
+            },
+            read: function () {
+                current = 'read';
+                return expectedData;
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default', middleware);
+
+        proxy.init()
+            .then(function () {
+                assert.equal(proxy.getMiddlewares(), middleware, 'The proxy should return the registered middleware handler');
+
+                return proxy.read(expectedParams);
+            })
+            .then(function (response) {
+                assert.deepEqual(response, expectedResponse, "The correct response has been read");
+                proxy.setMiddlewares(null);
+                assert.equal(proxy.getMiddlewares(), null, 'The middleware handler has been changed');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+});

--- a/views/js/test/core/dataProvider/proxy/api/test.js
+++ b/views/js/test/core/dataProvider/proxy/api/test.js
@@ -583,4 +583,39 @@ define([
                 QUnit.start();
             });
     });
+
+
+    QUnit.asyncTest('proxy #error', function (assert) {
+        var proxy;
+        var expectedError = new Error("Test");
+
+        QUnit.expect(5);
+
+        proxyFactory.registerProvider('default', _.defaults({
+            read: function () {
+                assert.ok(true, 'The proxyFactory has delegated the call');
+                return Promise.reject(expectedError);
+            }
+        }, defaultProxy));
+
+        proxy = proxyFactory('default')
+            .on('error', function (err) {
+                assert.ok(true, 'The proxyFactory has fired the "error" event');
+                assert.deepEqual(err, expectedError, 'The proxyFactory has provided the error through the "error" event');
+            });
+
+        proxy.init()
+            .then(function () {
+                return proxy.read();
+            })
+            .then(function () {
+                assert.ok(false, 'The promise should be rejected');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(true, 'The promise should be rejected');
+                assert.deepEqual(err, expectedError, 'The proxyFactory has provided the error');
+                QUnit.start();
+            });
+    });
 });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3496

Add data handling components:
- The `core/dataProvider/proxy` module provides a common API to serve several implementations, with respect to a CRUD architecture.
- The `core/dataProvider/proxy/ajax` module implements an AJAX proxy that provides a request handler to get/set data from/to a server
