### PR TITLE
Feature/tao 3496 container

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.69.7',
+    'version' => '7.70.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -709,7 +709,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->getServiceManager()->register(NotificationServiceInterface::SERVICE_ID, $queue);
 
-            $this->setVersion('7.69.7');
+            $this->setVersion('7.70.0');
         }
     }
 

--- a/views/js/test/ui/container/test.html
+++ b/views/js/test/ui/container/test.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Ui Test - Container</title>
+    <base href="../../../../" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="ui/container.js"></script>
+
+    <script  type="text/javascript">
+
+        //don't start the test now
+        QUnit.config.autostart = false;
+
+        //load the config
+        require(['/tao/ClientConfig/config'], function(){
+
+            //load the test
+            require(['test/ui/container/test'], function(){
+
+                //Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture">
+    <div class="container fixture">
+        <div class="child"></div>
+    </div>
+    <div class="paper"></div>
+    <div class="data" data-list="[1, 2, 3]" data-record='{"foo": "bar"}'></div>
+</div>
+</body>
+</html>

--- a/views/js/test/ui/container/test.js
+++ b/views/js/test/ui/container/test.js
@@ -1,0 +1,184 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'jquery',
+    'lodash',
+    'ui/container'
+], function($, _, container) {
+    'use strict';
+
+    var containerApi = [
+        { title : 'init' },
+        { title : 'destroy' },
+        { title : 'hasScope' },
+        { title : 'changeScope' },
+        { title : 'find' },
+        { title : 'write' },
+        { title : 'getData' },
+        { title : 'setData' },
+        { title : 'hasValue' },
+        { title : 'getValue' },
+        { title : 'setValue' },
+        { title : 'getElement' },
+        { title : 'getSelector' }
+    ];
+
+
+    QUnit.module('container');
+
+
+    QUnit.test('module', function(assert) {
+        QUnit.expect(3);
+        assert.equal(typeof container, 'function', "The container module exposes a function");
+        assert.equal(typeof container(), 'object', "The container factory produces an object");
+        assert.notStrictEqual(container(), container(), "The container factory provides a different object on each call");
+    });
+
+
+    QUnit
+        .cases(containerApi)
+        .test('instance API ', function(data, assert) {
+            var instance = container();
+            QUnit.expect(1);
+            assert.equal(typeof instance[data.title], 'function', 'The container instance exposes a "' + data.title + '" function');
+            instance.destroy();
+        });
+
+
+    QUnit.test('init', function(assert) {
+
+        var instance = container();
+
+        QUnit.expect(9);
+
+        assert.equal(typeof instance.getElement(), 'object', 'A container object exists');
+        assert.equal(instance.getElement().length, 1, 'A container has been caught');
+        assert.equal(instance.getSelector(), '.container', 'The default container selector has been set');
+
+        assert.equal(instance.destroy(), instance, 'destroy() returns the instance');
+
+        assert.equal(instance.getElement(), null, 'The container has been destroyed');
+
+        assert.throws(function() {
+            instance.init();
+        }, "The instance should throw an error if no selector is provided");
+
+        assert.throws(function() {
+            instance.init(10);
+        }, "The instance should throw an error if an invalid selector is provided");
+
+        assert.equal(instance.init('.foo'), instance, 'init() returns the instance');
+        assert.equal(instance.getSelector(), '.foo', 'The container selector has been set');
+
+        instance.destroy();
+    });
+
+
+    QUnit.test('scope', function(assert) {
+
+        var instance = container();
+
+        QUnit.expect(8);
+
+        assert.equal(typeof instance.getElement(), 'object', 'A container object exists');
+        assert.equal(instance.getElement().length, 1, 'A container has been caught');
+        assert.equal(instance.getSelector(), '.container', 'The default container selector has been set');
+
+        assert.ok(instance.hasScope('.fixture'), 'The container has the wanted scope');
+        assert.equal(instance.changeScope('.foo'), instance, 'changeScope() returns the instance');
+
+        assert.ok(!instance.hasScope('.fixture'), 'The container does not have the .fixture scope anymore');
+        assert.ok(instance.hasScope('.foo'), 'The container have the .foo scope');
+
+        assert.equal(instance.getElement().attr('class'), 'container foo', 'The container has the expected CSS class');
+
+        instance.destroy();
+    });
+
+
+    QUnit.test('find', function(assert) {
+
+        var instance = container();
+
+        QUnit.expect(5);
+
+        assert.equal(typeof instance.getElement(), 'object', 'A container object exists');
+        assert.equal(instance.getElement().length, 1, 'A container has been caught');
+
+        assert.equal(typeof instance.find('.child'), 'object', 'The searched element exists');
+        assert.equal(instance.find('.child').length, 1, 'The searched element has been caught');
+        assert.equal(instance.find('.child').get(0), $('#qunit-fixture .child').get(0), 'The right element has been caught');
+
+        instance.destroy();
+    });
+
+
+    QUnit.test('write', function(assert) {
+
+        var instance = container('.paper');
+
+        QUnit.expect(6);
+
+        assert.equal(typeof instance.getElement(), 'object', 'A container object exists');
+        assert.equal(instance.getElement().length, 1, 'A container has been caught');
+        assert.equal(instance.getElement().children().length, 0, 'The container is empty');
+
+        assert.equal(instance.write('<div>foo</div>'), instance, 'write() returns the instance');
+
+        assert.equal(instance.getElement().children().length, 1, 'The container is not empty');
+        assert.equal(instance.getElement().html().trim(), '<div>foo</div>', 'The container contains the right content');
+
+        instance.destroy();
+    });
+
+
+    QUnit.test('data', function(assert) {
+
+        var instance = container('.data');
+
+        QUnit.expect(14);
+
+        assert.equal(typeof instance.getElement(), 'object', 'A container object exists');
+        assert.equal(instance.getElement().length, 1, 'A container has been caught');
+
+        assert.deepEqual(instance.getValue('list'), [1, 2, 3], "The 'list' value has been read");
+        assert.deepEqual(instance.getValue('record'), {foo: "bar"}, "The 'record' value has been read");
+
+        assert.equal(instance.setValue('list', ["foo"]), instance, 'The method setValue returns the instance');
+        assert.deepEqual(instance.getValue('list'), ["foo"], "The 'list' value has been changed");
+
+        assert.deepEqual(instance.getData(), {list: ["foo"], record: {foo: "bar"}}, "The values has been read");
+        assert.equal(instance.setData({foo: "bar"}), instance, 'The method setData returns the instance');
+        assert.deepEqual(instance.getData(), {foo: "bar"}, "The values has been changed");
+
+        assert.equal(instance.hasValue('foo'), true, "The container has the value 'foo'");
+        assert.equal(instance.hasValue('bar'), false, "The container does not have the value 'bar");
+
+        instance.setValue('empty', 0);
+        assert.equal(instance.hasValue('empty'), true, "The container has the value 'empty'");
+
+        assert.equal(instance.removeData(), instance, 'The method removeData returns the instance');
+        assert.deepEqual(instance.getData(), {}, "The values has been removed");
+
+        instance.destroy();
+    });
+
+});

--- a/views/js/ui/container.js
+++ b/views/js/ui/container.js
@@ -1,0 +1,206 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'jquery',
+    'lodash'
+], function ($, _) {
+    'use strict';
+
+    /**
+     * Extract CSS class names from a selector
+     * @param {String} selector
+     * @returns {String}
+     */
+    function getCssClass(selector) {
+        var parts;
+
+        parts = [];
+        _.forEach(selector.split(' '), function(elem) {
+            if (elem && elem.charAt(0) === '.') {
+                parts.push(elem.substr(1));
+            }
+        });
+        return parts.join(' ');
+    }
+
+    /**
+     * Defines a container manager
+     * @param {String} [containerSelector] - The CSS selector of the container (default: .container)
+     * @returns {containerManager}
+     */
+    function containerFactory(containerSelector) {
+        var $container;
+        var containerCls;
+
+        /**
+         * @typedef {containerManager}
+         */
+        var containerManager = {
+            /**
+             * Initializes the component.
+             * @param {String} cssScope
+             */
+            init: function init(cssScope) {
+                if (!cssScope || !_.isString(cssScope)) {
+                    throw new TypeError('You must provide a CSS scope for the container manager!');
+                }
+
+                containerCls = getCssClass(cssScope);
+                containerSelector = cssScope;
+
+                $container = $(containerSelector);
+                return this;
+            },
+
+            /**
+             * Cleans up component and release resources
+             */
+            destroy: function destroy() {
+                $container = null;
+                return this;
+            },
+
+            /**
+             * Checks if the container has the wanted scope
+             * @param {String} scope
+             * @returns {Boolean}
+             */
+            hasScope: function hasScope(scope) {
+                return !!($container && $container.is(scope));
+            },
+
+            /**
+             * Changes the scope of the container
+             * @param {String} scope
+             * @returns {containerManager}
+             */
+            changeScope: function changeScope(scope) {
+                if ($container) {
+                    $container
+                        .removeClass()
+                        .addClass(containerCls);
+
+                    if (scope) {
+                        $container.addClass(getCssClass(scope));
+                    }
+                }
+                return this;
+            },
+
+            /**
+             * Find an element that belongs to the container.
+             * @param {String} selector
+             * @returns {jQuery}
+             */
+            find: function find(selector) {
+                return $container.find(selector);
+            },
+
+            /**
+             * Writes content into the container.
+             * @param content
+             * @returns {containerManager}
+             */
+            write: function write(content) {
+                $container.html(content);
+                return this;
+            },
+
+            /**
+             * Gets the data encoded into the DOM.
+             * @returns {Object}
+             */
+            getData: function getData() {
+                return $container.data();
+            },
+
+            /**
+             * Sets the data encoded into the DOM.
+             * @param {Object} data
+             * @returns {containerManager}
+             */
+            setData: function setData(data) {
+                $container.removeData().data(data);
+                return this;
+            },
+
+            /**
+             * Remove the data encoded into the DOM.
+             * @returns {containerManager}
+             */
+            removeData: function removeData() {
+                $container.removeData();
+                return this;
+            },
+
+            /**
+             * Checks whether a value has been encoded into the DOM.
+             * @param {String} name
+             * @returns {Boolean}
+             */
+            hasValue: function hasValue(name) {
+                var data = this.getData();
+                return 'undefined' !== typeof (data && data[name]);
+            },
+
+            /**
+             * Gets a value encoded into the DOM.
+             * @param {String} name
+             * @returns {*}
+             */
+            getValue: function getValue(name) {
+                var data = this.getData();
+                return data && data[name];
+            },
+
+            /**
+             * Encodes into the DOM.
+             * @param {String} name
+             * @param {Object} value
+             * @returns {containerManager}
+             */
+            setValue: function setValue(name, value) {
+                $container.data(name, value);
+                return this;
+            },
+
+            /**
+             * Gets access to the container element
+             * @returns {jQuery}
+             */
+            getElement: function getElement() {
+                return $container;
+            },
+
+            /**
+             * Gets the container's selector
+             * @returns {String}
+             */
+            getSelector: function getSelector() {
+                return containerSelector;
+            }
+        };
+
+        return containerManager.init(containerSelector || '.container');
+    }
+
+    return containerFactory;
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3496

Add a component that manage a container in order to:
- handle the CSS scope
- access to the content
- handle context data in the DOM attributes

This component is intended to be used in the context of a single page application, as the container should not change but the scope and the context.