### PR TITLE
Feature/tao 3496 data broker

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.69.7',
+    'version' => '7.70.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -709,7 +709,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->getServiceManager()->register(NotificationServiceInterface::SERVICE_ID, $queue);
 
-            $this->setVersion('7.69.7');
+            $this->setVersion('7.70.0');
         }
     }
 

--- a/views/js/core/dataProvider/dataBroker.js
+++ b/views/js/core/dataProvider/dataBroker.js
@@ -1,0 +1,221 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/eventifier',
+    'core/promise',
+    'core/middleware'
+], function (_, eventifier, Promise, middlewareHandlerFactory) {
+    'use strict';
+
+    var _defaults = {};
+
+    /**
+     * Implements a data broker that will serve data using proxies (readonly).
+     * Each time a data is requested, the data broker will first request a default proxy,
+     * then fallback to a more specific one. This behaviors allows, for instance,
+     * to target both DOM content data and remote data.
+     *
+     * @param {Object} config - Some optional config entries
+     * @param {middlewareHandler} [config.middlewares] - An optional middlewares handler that will be set to every provider.
+     *                                                   When this option is missing a default instance is created.
+     * @returns {dataBroker}
+     */
+    function dataBrokerFactory(config) {
+        var initConfig = _.defaults({}, config, _defaults);
+        var providers = {};
+        var middlewares;
+
+        /**
+         * @typedef {dataBroker}
+         */
+        var dataBroker = eventifier({
+            /**
+             * Cleans up and destroys the instance.
+             * @fires destroy
+             */
+            destroy: function destroy() {
+                /**
+                 * @event destroy
+                 */
+                dataBroker.trigger('destroy');
+                initConfig = null;
+                providers = null;
+            },
+
+            /**
+             * Gets a registered data provider.
+             * @param {String} name
+             * @returns {proxy}
+             */
+            getProvider: function getProvider(name) {
+                return providers && providers[name];
+            },
+
+            /**
+             * Tells if a provider has been registered.
+             * @param {String} name
+             * @returns {Boolean}
+             */
+            hasProvider: function hasProvider(name) {
+                return !!dataBroker.getProvider(name);
+            },
+
+            /**
+             * Adds a data provider. It should at least implement a `read()` method.
+             * A data provider must be related to a particular entry.
+             * @param {String|Object} name - The name of the provider, or the provider itself (in that case it must contains its name)
+             * @param {proxy} [provider] - The provider to register.
+             * @returns {dataBroker}
+             * @throws {TypeError} if the name is missing or if the provider is invalid
+             * @fires addprovider
+             */
+            addProvider: function addProvider(name, provider) {
+                if (_.isPlainObject(name)) {
+                    provider = name;
+                    name = provider.name;
+                }
+
+                if (!name || !_.isString(name)) {
+                    throw new TypeError('Yous must provide a name for the provider!');
+                }
+
+                if (!_.isPlainObject(provider) || !_.isFunction(provider.read)) {
+                    throw new TypeError('Yous must provide a valid provider!');
+                }
+
+                providers[name] = provider;
+
+                if (_.isFunction(provider.setMiddlewares)) {
+                    provider.setMiddlewares(middlewares);
+                }
+
+                /**
+                 * @event addprovider
+                 * @param {String} name
+                 * @param {Object} provider
+                 */
+                dataBroker.trigger('addprovider', name, provider);
+                return this;
+            },
+
+            /**
+             * Read data using a particular provider.
+             * @param {String} name
+             * @param {Object} [params]
+             * @returns {Promise}
+             * @fires readprovider
+             */
+            readProvider: function readProvider(name, params) {
+                var provider = dataBroker.getProvider(name);
+                if (provider) {
+                    /**
+                     * @event readprovider
+                     * @param {String} name
+                     * @param {Object} params
+                     */
+                    dataBroker.trigger('readprovider', name, params);
+
+                    return provider.read(params);
+                }
+                return Promise.reject();
+            },
+
+            /**
+             * Reads data for a particular entry using the registered providers.
+             * First tries the default provider, then if an error occurs or
+             * if no data was found, call the targeted provider.
+             * @param {String} entry
+             * @param {Object} [params]
+             * @returns {Promise}
+             * @fires read
+             * @fires data
+             */
+            read: function read(entry, params) {
+                if (!dataBroker.hasProvider(entry)) {
+                    return Promise.reject({
+                        success: false,
+                        type: 'notimplemented',
+                        action: entry,
+                        params: params
+                    });
+                }
+
+                /**
+                 * @event read
+                 * @param {String} entry
+                 * @param {Object} params
+                 */
+                dataBroker.trigger('read', entry, params);
+
+                return dataBroker.readProvider('default', _.merge({target: entry}, params))
+                    .catch(function(err) {
+                        if (err) {
+                            return Promise.reject(err);
+                        }
+                    })
+                    .then(function(data) {
+                        if (!data || !_.size(data)) {
+                            return dataBroker.readProvider(entry, params);
+                        }
+                        return data;
+                    })
+                    .then(function(data) {
+                        /**
+                         * @event data
+                         * @param {Object} data
+                         * @param {String} entry
+                         * @param {Object} params
+                         */
+                        dataBroker.trigger('data', data, entry, params);
+                        return data;
+                    });
+            },
+
+            /**
+             * Gets the config object
+             * @returns {Object}
+             */
+            getConfig: function getConfig() {
+                return initConfig;
+            },
+
+            /**
+             * Gets the middlewares handler
+             * @returns {middlewareHandler}
+             */
+            getMiddlewares: function getMiddlewares() {
+                return middlewares;
+            }
+        });
+
+        if (initConfig.middlewares &&
+            (!_.isPlainObject(initConfig.middlewares) || !_.isFunction(initConfig.middlewares.apply))) {
+            throw new TypeError('You must provide a valid middlewares handler');
+        }
+
+        middlewares = initConfig.middlewares || middlewareHandlerFactory();
+
+        return dataBroker;
+    }
+
+    return dataBrokerFactory;
+});

--- a/views/js/core/dataProvider/dataBroker.js
+++ b/views/js/core/dataProvider/dataBroker.js
@@ -108,6 +108,12 @@ define([
                     provider.setMiddlewares(middlewares);
                 }
 
+                if (_.isFunction(provider.on)) {
+                    provider.off('error.dataBroker').on('error.dataBroker', function(err) {
+                        dataBroker.trigger('error', err);
+                    });
+                }
+
                 /**
                  * @event addprovider
                  * @param {String} name

--- a/views/js/test/core/dataProvider/dataBroker/mock/middleware.js
+++ b/views/js/test/core/dataProvider/dataBroker/mock/middleware.js
@@ -1,0 +1,43 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define(['core/eventifier', 'core/promise'], function (eventifier, Promise) {
+    'use strict';
+
+    function mockMiddlewareFactory() {
+        return {
+            use: function use(command, callback) {
+                mockMiddlewareFactory.trigger('use', command, callback);
+                return this;
+            },
+
+            apply: function apply(request, response, context) {
+                return new Promise(function(resolve, reject) {
+                    mockMiddlewareFactory
+                        .trigger('apply', request, response, context)
+                        .on('resolve', resolve)
+                        .on('reject', reject);
+                });
+            }
+        };
+    }
+
+    return eventifier(mockMiddlewareFactory);
+});

--- a/views/js/test/core/dataProvider/dataBroker/test.html
+++ b/views/js/test/core/dataProvider/dataBroker/test.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Core - DataBroker</title>
+        <base href="../../../../../" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="core/dataProvider/dataBroker.js"></script>
+
+        <script  type="text/javascript">
+
+             //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //some mocks
+                requirejs.config({
+                    "paths": {
+                        "core/dataProvider/request" : "test/core/dataProvider/mocks/requestMock"
+                    }
+                });
+
+                //load the test
+                require(['test/core/dataProvider/dataBroker/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/core/dataProvider/dataBroker/test.html
+++ b/views/js/test/core/dataProvider/dataBroker/test.html
@@ -21,7 +21,7 @@
                 //some mocks
                 requirejs.config({
                     "paths": {
-                        "core/dataProvider/request" : "test/core/dataProvider/mocks/requestMock"
+                        "core/middleware" : "test/core/dataProvider/dataBroker/mock/middleware"
                     }
                 });
 

--- a/views/js/test/core/dataProvider/dataBroker/test.js
+++ b/views/js/test/core/dataProvider/dataBroker/test.js
@@ -150,6 +150,7 @@ define([
         var expectedParams = {
             foo: 'bar'
         };
+        var expectedError = new Error("Test");
         var successProvider = {
             name: 'success',
             read: function(params) {
@@ -160,12 +161,25 @@ define([
             name: 'failure',
             read: function(params) {
                 return Promise.reject(params);
+            },
+            off: function(name) {
+                assert.equal(name, 'error.dataBroker', 'The dataBroker has cleaned the error channel');
+                return this;
+            },
+            on: function(name, cb) {
+                assert.equal(name, 'error.dataBroker', 'The dataBroker is listening to the error channel');
+                assert.equal(typeof cb, 'function', 'The dataBroker has registered an error handler');
+                cb(expectedError);
+                return this;
             }
         };
 
-        QUnit.expect(11);
+        QUnit.expect(15);
 
         dataBroker = dataBrokerFactory()
+            .on('error', function(err) {
+                assert.equal(err, expectedError, 'The dataBroker has caught the right error');
+            })
             .addProvider(successProvider)
             .addProvider(failureProvider)
             .on('readprovider', function(name, params) {

--- a/views/js/test/core/dataProvider/dataBroker/test.js
+++ b/views/js/test/core/dataProvider/dataBroker/test.js
@@ -1,0 +1,391 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+define([
+    'lodash',
+    'core/promise',
+    'core/dataProvider/dataBroker'
+], function (_, Promise, dataBrokerFactory) {
+    'use strict';
+
+    var readCases;
+    var readErrorCases;
+    var dataBrokerApi = [
+        {title: 'destroy'},
+        {title: 'getProvider'},
+        {title: 'hasProvider'},
+        {title: 'addProvider'},
+        {title: 'readProvider'},
+        {title: 'read'},
+        {title: 'getConfig'},
+        {title: 'getMiddlewares'}
+    ];
+
+
+    QUnit.module('dataBroker');
+
+
+    QUnit.test('module', function (assert) {
+        QUnit.expect(3);
+
+        assert.equal(typeof dataBrokerFactory, 'function', "The dataBroker module exposes a function");
+        assert.equal(typeof dataBrokerFactory(), 'object', "The dataBroker factory produces an object");
+        assert.notStrictEqual(dataBrokerFactory(), dataBrokerFactory(), "The dataBroker factory provides a different object on each call");
+    });
+
+
+    QUnit
+        .cases(dataBrokerApi)
+        .test('instance API ', function (data, assert) {
+            var instance = dataBrokerFactory();
+            QUnit.expect(1);
+            assert.equal(typeof instance[data.title], 'function', 'The dataBroker instance exposes a "' + data.title + '" function');
+        });
+
+
+    QUnit.asyncTest('factory', function (assert) {
+        var initConfig = {
+            foo: 'bar',
+            middlewares: {
+                use: _.noop,
+                apply: _.noop
+            }
+        };
+        var expectedConfig = {
+            foo: 'bar',
+            middlewares: {
+                use: _.noop,
+                apply: _.noop
+            }
+        };
+        var dataBroker;
+
+        QUnit.expect(6);
+
+        assert.throws(function() {
+            dataBrokerFactory({middlewares: {}});
+        }, 'Should throw an error if a wrong middlewares handler is provided');
+
+        dataBroker = dataBrokerFactory(initConfig)
+            .on('destroy', function () {
+                assert.ok(true, 'The dataBroker has triggered the `destroy` event');
+                QUnit.start();
+            });
+
+        assert.equal(typeof dataBroker, 'object', "The dataBroker factory produces an object");
+
+        assert.deepEqual(dataBroker.getConfig(), expectedConfig, 'The dataBroker instance has the expected config');
+        assert.deepEqual(dataBroker.getMiddlewares(), initConfig.middlewares, 'The dataBroker instance has the expected middlewares handler');
+
+        dataBroker.destroy();
+
+        assert.equal(dataBroker.getConfig(), null, 'The dataBroker has been destroyed');
+    });
+
+
+    QUnit.asyncTest('dataBroker.addProvider()', function (assert) {
+        var dataBroker;
+        var fooProvider = {
+            name: 'foo',
+            read: function() {},
+            setMiddlewares: function(m) {
+                this.middlewares = m;
+            }
+        };
+
+        QUnit.expect(14);
+
+        dataBroker = dataBrokerFactory()
+            .on('addprovider', function (name, provider) {
+                assert.ok(true, 'The dataBroker has triggered the `addprovider` event');
+                assert.equal(name, fooProvider.name, 'The dataProvider has added the expected provider name');
+                assert.equal(provider, fooProvider, 'The dataProvider has added the expected provider');
+                QUnit.start();
+            });
+
+        assert.equal(typeof dataBroker, 'object', "The dataBroker factory produces an object");
+
+        assert.throws(function() {
+            dataBroker.addProvider();
+        }, "The addProvider() method should throw an error if no provider nor name was provided");
+
+        assert.throws(function() {
+            dataBroker.addProvider('foo');
+        }, "The addProvider() method should throw an error if no provider was provided");
+
+        assert.throws(function() {
+            dataBroker.addProvider('', fooProvider);
+        }, "The addProvider() method should throw an error if the name is empty");
+
+        assert.equal(false, dataBroker.hasProvider('foo'), "The dataBroker does not have provider");
+        assert.equal(null, dataBroker.getProvider('foo'), "The provider 'foo' does not exists");
+        assert.equal(typeof fooProvider.middlewares, 'undefined', "The provider 'foo' does not have a middlewares");
+
+        assert.equal(dataBroker.addProvider(fooProvider), dataBroker, 'The addProvider() method returns the instance');
+
+        assert.equal(true, dataBroker.hasProvider('foo'), "The dataBroker now have provider");
+        assert.equal(fooProvider, dataBroker.getProvider('foo'), "The provider 'foo' now exists");
+        assert.equal(fooProvider.middlewares, dataBroker.getMiddlewares(), "The provider 'foo' now have a middlewares");
+
+    });
+
+
+    QUnit.asyncTest('dataBroker.readProvider()', function (assert) {
+        var dataBroker;
+        var expectedParams = {
+            foo: 'bar'
+        };
+        var successProvider = {
+            name: 'success',
+            read: function(params) {
+                return Promise.resolve(params);
+            }
+        };
+        var failureProvider = {
+            name: 'failure',
+            read: function(params) {
+                return Promise.reject(params);
+            }
+        };
+
+        QUnit.expect(8);
+
+        dataBroker = dataBrokerFactory()
+            .addProvider(successProvider)
+            .addProvider(failureProvider)
+            .on('readprovider', function(name, params) {
+                assert.ok(_.indexOf(['success', 'failure'], name) >= 0, "The `readprovider` event has been triggered as expected");
+                assert.equal(typeof params, 'object', "The params have been provided to the event");
+            });
+
+        assert.equal(typeof dataBroker, 'object', "The dataBroker factory produces an object");
+
+        dataBroker.readProvider('unknown')
+            .then(function() {
+                assert.ok(false, "Unkwnown provider should raise error!");
+                QUnit.start();
+            })
+            .catch(function() {
+                assert.ok(true, "Unkwnown provider should raise error!");
+
+                return dataBroker.readProvider('failure', expectedParams);
+            })
+            .then(function() {
+                assert.ok(false, "This provider should always reject the request!");
+                QUnit.start();
+            })
+            .catch(function(err) {
+                assert.deepEqual(err, expectedParams, "Should provide the expected reason");
+
+                return dataBroker.readProvider('success', expectedParams);
+            })
+            .then(function(data) {
+                assert.deepEqual(data, expectedParams, "Should provide the expected data");
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.ok(false, 'The promise should not be rejected');
+                console.error(err);
+                QUnit.start();
+            });
+    });
+
+
+    readCases = [{
+        title: 'data in default',
+        expected: {
+            foo: 'bar'
+        },
+        params: {},
+        defaultProvider: {
+            read: function() {
+                return Promise.resolve({
+                    foo: 'bar'
+                });
+            }
+        },
+        dataProvider: {
+            read: function() {
+                return Promise.reject();
+            }
+        }
+    }, {
+        title: 'data not in default',
+        expected: {
+            foo: 'bar'
+        },
+        params: {},
+        defaultProvider: {
+            read: function() {
+                return Promise.resolve();
+            }
+        },
+        dataProvider: {
+            read: function() {
+                return Promise.resolve({
+                    foo: 'bar'
+                });
+            }
+        }
+    }, {
+        title: 'default cannot serve data',
+        expected: {
+            foo: 'bar'
+        },
+        params: {},
+        defaultProvider: {
+            read: function() {
+                return Promise.reject();
+            }
+        },
+        dataProvider: {
+            read: function() {
+                return Promise.resolve({
+                    foo: 'bar'
+                });
+            }
+        }
+    }];
+
+    QUnit
+        .cases(readCases)
+        .asyncTest('dataBroker.read() ', function (data, assert) {
+            var dataBroker;
+
+            QUnit.expect(9);
+
+            dataBroker = dataBrokerFactory()
+                .addProvider('default', data.defaultProvider)
+                .addProvider('data', data.dataProvider)
+                .on('read', function (name, params) {
+                    assert.ok(_.indexOf(['default', 'data'], name) >= 0, "The `read` event has been triggered as expected");
+                    assert.deepEqual(params, data.params, "The params have been provided to the event");
+                })
+                .on('data', function (response, name, params) {
+                    assert.ok(_.indexOf(['default', 'data'], name) >= 0, "The `data` event has been triggered as expected");
+                    assert.deepEqual(params, data.params, "The params have been provided to the event");
+                    assert.equal(typeof response, 'object', "Data has been provided");
+                });
+
+            assert.equal(typeof dataBroker, 'object', "The dataBroker factory produces an object");
+
+            dataBroker.read('unknown', data.params)
+                .then(function() {
+                    assert.ok(false, "Unknown provider should raise error!");
+                    QUnit.start();
+                })
+                .catch(function(err) {
+                    assert.ok(true, "Unknown provider should raise error!");
+                    assert.deepEqual(err, {
+                        success: false,
+                        type: 'notimplemented',
+                        action: 'unknown',
+                        params: data.params
+                    }, "The dataBroker has has thrown the expected error");
+
+                    return dataBroker.read('data', data.params);
+                })
+                .then(function(response) {
+                    assert.deepEqual(response, data.expected, "Should provide the expected data");
+                    QUnit.start();
+                })
+                .catch(function (err) {
+                    assert.ok(false, 'The promise should not be rejected');
+                    console.error(err);
+                    QUnit.start();
+                });
+        });
+
+
+    readErrorCases = [{
+        title: 'default provider raises error',
+        expected: {
+            success: false,
+            message: 'oops'
+        },
+        params: {},
+        defaultProvider: {
+            read: function() {
+                return Promise.reject({
+                    success: false,
+                    message: 'oops'
+                });
+            }
+        },
+        dataProvider: {
+            read: function() {
+                return Promise.resolve({
+                    foo: 'bar'
+                });
+            }
+        }
+    }, {
+        title: 'data provider raises error',
+        expected: {
+            success: false,
+            message: 'oops'
+        },
+        params: {},
+        defaultProvider: {
+            read: function() {
+                return Promise.reject();
+            }
+        },
+        dataProvider: {
+            read: function() {
+                return Promise.reject({
+                    success: false,
+                    message: 'oops'
+                });
+            }
+        }
+    }];
+
+    QUnit
+        .cases(readErrorCases)
+        .asyncTest('dataBroker.read() #error ', function (data, assert) {
+            var dataBroker;
+
+            QUnit.expect(4);
+
+            dataBroker = dataBrokerFactory()
+                .addProvider('default', data.defaultProvider)
+                .addProvider('data', data.dataProvider)
+                .on('read', function (name, params) {
+                    assert.ok(_.indexOf(['default', 'data'], name) >= 0, "The `read` event has been triggered as expected");
+                    assert.deepEqual(params, data.params, "The params have been provided to the event");
+                })
+                .on('data', function () {
+                    assert.ok(false, "Should not trigger the `data` event");
+                });
+
+            assert.equal(typeof dataBroker, 'object', "The dataBroker factory produces an object");
+
+            dataBroker.read('data', data.params)
+                .then(function() {
+                    assert.ok(false, "The provider should raise error!");
+                    QUnit.start();
+                })
+                .catch(function(err) {
+                    assert.deepEqual(err, data.expected, "Should provide the expected error");
+                    QUnit.start();
+                });
+        });
+});


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3496

Requires: https://github.com/oat-sa/tao-core/pull/1204

Add data handling components:
- The `core/dataProvider/dataBroker` module manages a list of data providers.