### PR TITLE
Feature/json key value cache

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.70.0',
+    'version' => '7.71.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/models/classes/menu/Action.php
+++ b/models/classes/menu/Action.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA;
  *
  *
  */
@@ -22,9 +22,10 @@
 namespace oat\tao\model\menu;
 
 use oat\oatbox\PhpSerializable;
+use oat\oatbox\ArrayCastable;
 use oat\taoBackOffice\model\menuStructure\Action as iAction;
 
-class Action implements PhpSerializable, iAction
+class Action implements PhpSerializable, ArrayCastable, iAction
 {
     const SERIAL_VERSION = 1392821334;
 
@@ -179,5 +180,31 @@ class Action implements PhpSerializable, iAction
             .\common_Utils::toPHPVariableString($this->data).','
             .\common_Utils::toPHPVariableString(self::SERIAL_VERSION)
         .")";
+    }
+    
+    public function __toArray()
+    {
+        $array = [
+            'data' => $this->data,
+            'serialVersion' => self::SERIAL_VERSION
+        ];
+        
+        if (isset($this->data['icon'])) {
+            $array['data']['icon'] = $this->data['icon']->__toArray();
+        }
+        
+        return $array;
+    }
+    
+    public static function fromArray(array $array)
+    {
+        if (isset($array['data']['icon'])) {
+            $array['data']['icon'] = Icon::fromArray($array['data']['icon']['data'], $array['data']['icon']['structureExtensionId']);
+        }
+        
+        return new static(
+            $array['data'],
+            $array['serialVersion']
+        );
     }
 }

--- a/models/classes/menu/Icon.php
+++ b/models/classes/menu/Icon.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA;
  *
  *
  */
@@ -22,9 +22,10 @@
 namespace oat\tao\model\menu;
 
 use oat\oatbox\PhpSerializable;
+use oat\oatbox\ArrayCastable;
 use tao_models_classes_accessControl_AclProxy;
 
-class Icon implements PhpSerializable
+class Icon implements PhpSerializable, ArrayCastable
 {
     const SERIAL_VERSION = 1392821334;
     
@@ -87,5 +88,14 @@ class Icon implements PhpSerializable
             .\common_Utils::toPHPVariableString($this->data).','
             .\common_Utils::toPHPVariableString(self::SERIAL_VERSION)
         .")";
+    }
+    
+    public function __toArray()
+    {
+        return [
+            'data' => $this->data,
+            'structureExtensionId' => $this->data['ext'],
+            'serialVersion' => self::SERIAL_VERSION
+        ];
     }
 }

--- a/models/classes/menu/MenuService.php
+++ b/models/classes/menu/MenuService.php
@@ -115,10 +115,21 @@ class MenuService {
             } else {
                 //cache management
                 try {
-                    self::$structure = \common_cache_FileCache::singleton()->get(self::CACHE_KEY);
+                    $fromCache = \common_cache_FileCache::singleton()->get(self::CACHE_KEY);
+                    self::$structure = [
+                        'perspectives' => []
+                    ];
+                    
+                    foreach ($fromCache as $key => $perspective) {
+                        self::$structure['perspectives'][$key] = Perspective::fromArray($perspective);
+                    }
                 } catch (\common_cache_NotFoundException $e) {
                     self::$structure = self::buildStructures();
-                    \common_cache_FileCache::singleton()->put(self::$structure, self::CACHE_KEY);
+                    $toCache = self::$structure['perspectives'];
+                    foreach ($toCache as $key => $perspective) {
+                        $toCache[$key] = $perspective->__toArray();
+                    }
+                    \common_cache_FileCache::singleton()->put($toCache, self::CACHE_KEY);
                 }
 
             }

--- a/models/classes/menu/Perspective.php
+++ b/models/classes/menu/Perspective.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA;
  *
  *
  */
@@ -22,8 +22,9 @@
 namespace oat\tao\model\menu;
 
 use oat\oatbox\PhpSerializable;
+use oat\oatbox\ArrayCastable;
 
-class Perspective extends MenuElement implements PhpSerializable
+class Perspective extends MenuElement implements PhpSerializable, ArrayCastable
 {
 
     const GROUP_DEFAULT = 'main';
@@ -200,6 +201,47 @@ class Perspective extends MenuElement implements PhpSerializable
 
     public function getUrl() {
         return _url('index', null, null, array('structure' => $this->getId(), 'ext' => $this->getExtension()));
+    }
+    
+    public function __toArray()
+    {
+        $array = [
+            'data' => [
+                'id' => $this->data['id'],
+                'group' => $this->data['group'],
+                'name' => $this->data['name'],
+                'binding' => $this->data['binding'],
+                'description' => $this->data['description'],
+                'extension' => $this->data['extension'],
+                'level' => $this->data['level'],
+                'icon' => ($this->data['icon'] !== null) ? $this->data['icon']->__toArray() : null
+            ],
+            'children' => [],
+            'serialVersion' => self::SERIAL_VERSION
+        ];
+        
+        foreach ($this->children as $child) {
+            $array['children'][] = $child->__toArray();
+        }
+        
+        return $array;
+    }
+    
+    public static function fromArray(array $array)
+    {
+        if ($array['data']['icon'] !== null) {
+            $array['data']['icon'] = Icon::fromArray($array['data']['icon']['data'], $array['data']['icon']['structureExtensionId']);
+        }
+        
+        foreach ($array['children'] as $key => $child) {
+            $array['children'][$key] = Section::fromArray($child);
+        }
+        
+        return new static(
+            $array['data'],
+            $array['children'],
+            $array['serialVersion']
+        );
     }
 
     public function __toPhpCode()

--- a/models/classes/menu/Section.php
+++ b/models/classes/menu/Section.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA;
  *
  *
  */
@@ -22,10 +22,11 @@
 namespace oat\tao\model\menu;
 
 use oat\oatbox\PhpSerializable;
+use oat\oatbox\ArrayCastable;
 use oat\taoBackOffice\model\menuStructure\ClassActionRegistry;
 use oat\taoBackOffice\model\menuStructure\Action as iAction;
 
-class Section extends MenuElement implements PhpSerializable
+class Section extends MenuElement implements PhpSerializable, ArrayCastable
 {
 
     const SERIAL_VERSION = 1392821334;
@@ -348,5 +349,42 @@ class Section extends MenuElement implements PhpSerializable
         . \common_Utils::toPHPVariableString($this->actions) . ','
         . \common_Utils::toPHPVariableString(self::SERIAL_VERSION)
         . ")";
+    }
+    
+    public function __toArray()
+    {
+        $array = [
+            'data' => $this->data,
+            'trees' => [],
+            'actions' => [],
+            'serialVersion' => self::SERIAL_VERSION
+        ];
+        
+        foreach ($this->trees as $tree) {
+            $array['trees'][] = $tree->__toArray();
+        }
+        
+        foreach ($this->actions as $action) {
+            $array['actions'][] = $action->__toArray();
+        }
+        
+        return $array;
+    }
+    
+    public static function fromArray(array $array) {
+        foreach ($array['trees'] as $key => $tree) {
+            $array['trees'][$key] = Tree::fromArray($tree);
+        }
+        
+        foreach ($array['actions'] as $key => $action) {
+            $array['actions'][$key] = Action::fromArray($action);
+        }
+        
+        return new static(
+            $array['data'],
+            $array['trees'],
+            $array['actions'],
+            $array['serialVersion']
+        );
     }
 }

--- a/models/classes/menu/Tree.php
+++ b/models/classes/menu/Tree.php
@@ -14,7 +14,7 @@ i *
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA;
  *
  *
  */
@@ -22,8 +22,9 @@ i *
 namespace oat\tao\model\menu;
 
 use oat\oatbox\PhpSerializable;
+use oat\oatbox\ArrayCastable;
 
-class Tree  implements PhpSerializable
+class Tree implements PhpSerializable, ArrayCastable
 {
     const SERIAL_VERSION = 1392821334;
     
@@ -75,5 +76,21 @@ class Tree  implements PhpSerializable
             .\common_Utils::toPHPVariableString($this->data).','
             .\common_Utils::toPHPVariableString(self::SERIAL_VERSION)
         .")";
+    }
+    
+    public function __toArray()
+    {
+        return [
+            'data' => $this->data,
+            'serialVersion' => self::SERIAL_VERSION
+        ];
+    }
+    
+    public static function fromArray(array $array)
+    {
+        return new static(
+            $array['data'],
+            $array['serialVersion']
+        );
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -712,7 +712,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.69.7');
         }
 
-        $this->skip('7.69.7', '7.70.0');
+        $this->skip('7.69.7', '7.71.0');
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
**DEPENDS ON https://github.com/oat-sa/generis/pull/311**

Enable "array serialization" for Menu Model in TAO, in order to be "JSON Cacheable". See dependent PR https://github.com/oat-sa/generis/pull/311 for more information about the intent.