### PR TITLE
Feature/middleware promises

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.76.0',
+    'version' => '7.77.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -732,7 +732,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $action->__invoke([]);
             $this->setVersion('7.74.0');
         }
-        $this->skip('7.74.0', '7.76.0');
+        $this->skip('7.74.0', '7.77.0');
     }
 
     private function migrateFsAccess() {

--- a/views/js/test/core/middleware/test.js
+++ b/views/js/test/core/middleware/test.js
@@ -205,7 +205,7 @@ define([
     });
 
 
-    QUnit.asyncTest('middlewares.apply() #break', function (assert) {
+    QUnit.asyncTest('middlewares.apply() #break direct', function (assert) {
         var middlewares = middlewaresHandlerFactory();
         var request = {
             command: 'read',
@@ -233,6 +233,56 @@ define([
                 assert.deepEqual(res, response, 'The response has been provided');
                 assert.deepEqual(this, context, 'The right context has been set');
                 return false;
+            })
+            .use('refresh', function () {
+                assert.ok(false, 'The refresh middleware should not be called');
+                return Promise.reject();
+            })
+            .apply(request, response, context)
+            .then(function () {
+                assert.ok(false, 'The promise should be rejected');
+                QUnit.start();
+            })
+            .catch(function (err) {
+                assert.deepEqual(err, response, 'The error has been provided');
+                QUnit.start();
+            });
+    });
+
+
+    QUnit.asyncTest('middlewares.apply() #break promise', function (assert) {
+        var middlewares = middlewaresHandlerFactory();
+        var request = {
+            command: 'read',
+            params: {
+                foo: 'bar'
+            }
+        };
+        var response = {
+            success: false,
+            message: "oups"
+        };
+        var context = {
+            name: 'foo'
+        };
+
+        QUnit.expect(5);
+
+        middlewares
+            .use(function () {
+                assert.ok(false, 'The global middleware should not be called');
+            })
+            .use('read', function (req, res) {
+                assert.ok(true, 'The read middleware has been called');
+                assert.deepEqual(req, request, 'The request has been provided');
+                assert.deepEqual(res, response, 'The response has been provided');
+                assert.deepEqual(this, context, 'The right context has been set');
+
+                return new Promise(function(resolve) {
+                    setTimeout(function() {
+                        resolve(false);
+                    }, 300);
+                });
             })
             .use('refresh', function () {
                 assert.ok(false, 'The refresh middleware should not be called');

--- a/views/js/test/core/middleware/test.js
+++ b/views/js/test/core/middleware/test.js
@@ -71,23 +71,24 @@ define([
         QUnit.expect(9);
 
         middlewares
-            .use(function (req, res, next) {
+            .use(function (req, res) {
                 assert.ok(true, 'The global middleware has been called');
                 assert.deepEqual(req, request, 'The request has been provided');
                 assert.deepEqual(res, response, 'The response has been provided');
                 assert.deepEqual(this, context, 'The right context has been set');
-                next();
+                return new Promise(function(resolve) {
+                   setTimeout(resolve, 300);
+                });
             })
-            .use('read', function (req, res, next) {
+            .use('read', function (req, res) {
                 assert.ok(true, 'The read middleware has been called');
                 assert.deepEqual(req, request, 'The request has been provided');
                 assert.deepEqual(res, response, 'The response has been provided');
                 assert.deepEqual(this, context, 'The right context has been set');
-                next();
             })
-            .use('refresh', function (req, res, next) {
+            .use('refresh', function () {
                 assert.ok(false, 'The refresh middleware should not be called');
-                next(false);
+                return Promise.reject();
             })
             .apply(request, response, context)
             .then(function (res) {
@@ -127,20 +128,20 @@ define([
         QUnit.expect(5);
 
         middlewares
-            .use(function (req, res, next) {
+            .use(function () {
                 assert.ok(false, 'The global middleware should not be called');
-                next();
+                return Promise.reject();
             })
-            .use('read', function (req, res, next) {
+            .use('read', function (req, res) {
                 assert.ok(true, 'The read middleware has been called');
                 assert.deepEqual(req, request, 'The request has been provided');
                 assert.deepEqual(res, response, 'The response has been provided');
                 assert.deepEqual(this, context, 'The right context has been set');
-                next(error);
+                return Promise.reject(error);
             })
-            .use('refresh', function (req, res, next) {
+            .use('refresh', function () {
                 assert.ok(false, 'The refresh middleware should not be called');
-                next(false);
+                return Promise.reject();
             })
             .apply(request, response, context)
             .then(function () {
@@ -173,23 +174,24 @@ define([
         QUnit.expect(9);
 
         middlewares
-            .use(function (req, res, next) {
+            .use(function (req, res) {
                 assert.ok(true, 'The global middleware has been called');
                 assert.deepEqual(req, request, 'The request has been provided');
                 assert.deepEqual(res, response, 'The response has been provided');
                 assert.deepEqual(this, context, 'The right context has been set');
-                next();
+                return new Promise(function(resolve) {
+                    setTimeout(resolve, 300);
+                });
             })
-            .use('read', function (req, res, next) {
+            .use('read', function (req, res) {
                 assert.ok(true, 'The read middleware has been called');
                 assert.deepEqual(req, request, 'The request has been provided');
                 assert.deepEqual(res, response, 'The response has been provided');
                 assert.deepEqual(this, context, 'The right context has been set');
-                next();
             })
-            .use('refresh', function (req, res, next) {
+            .use('refresh', function () {
                 assert.ok(false, 'The refresh middleware should not be called');
-                next(false);
+                return Promise.reject();
             })
             .apply(request, response, context)
             .then(function () {
@@ -203,7 +205,7 @@ define([
     });
 
 
-    QUnit.asyncTest('middlewares.apply() #missing next', function (assert) {
+    QUnit.asyncTest('middlewares.apply() #break', function (assert) {
         var middlewares = middlewaresHandlerFactory();
         var request = {
             command: 'read',
@@ -212,42 +214,37 @@ define([
             }
         };
         var response = {
-            success: true,
-            data: {
-                list: [1, 2, 3]
-            }
+            success: false,
+            message: "oups"
         };
         var context = {
             name: 'foo'
         };
-        var to = setTimeout(function() {
-            assert.ok(true, 'The next has never be called...');
-            QUnit.start();
-        }, 500);
 
-        QUnit.expect(3);
+        QUnit.expect(5);
 
         middlewares
             .use(function () {
-                assert.ok(true, 'The global middleware has been called');
+                assert.ok(false, 'The global middleware should not be called');
             })
-            .use('read', function (req, res, next) {
+            .use('read', function (req, res) {
                 assert.ok(true, 'The read middleware has been called');
-                next();
+                assert.deepEqual(req, request, 'The request has been provided');
+                assert.deepEqual(res, response, 'The response has been provided');
+                assert.deepEqual(this, context, 'The right context has been set');
+                return false;
             })
-            .use('refresh', function (req, res, next) {
+            .use('refresh', function () {
                 assert.ok(false, 'The refresh middleware should not be called');
-                next(false);
+                return Promise.reject();
             })
             .apply(request, response, context)
             .then(function () {
-                assert.ok(false, 'The promise should not be rejected');
-                clearTimeout(to);
+                assert.ok(false, 'The promise should be rejected');
                 QUnit.start();
             })
-            .catch(function () {
-                assert.ok(false, 'The promise should not be rejected');
-                clearTimeout(to);
+            .catch(function (err) {
+                assert.deepEqual(err, response, 'The error has been provided');
                 QUnit.start();
             });
     });


### PR DESCRIPTION
Remove the use of async and use promises instead of callbacks.
The behavior is now:
- each middleware is called in order
- the next middleware is called just after the current one has returned
- a middleware can have asynchronous behavior, in that case it should return a promise to defer the call to the next
- a middleware can break the chain either by returning `false` or a promise that resolve `false`
- any error in the middlewares will break the chain

The advantage is there is no more infinite wait if the `next()` callback is never invoked, like in the previous implementation. Obviously, an unresolved promise can still block the chain.