### PR TITLE
Fix/tao 3496 history forward

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.81.0',
+    'version' => '7.81.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -721,7 +721,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.74.0');
         }
 
-        $this->skip('7.74.0', '7.81.0');
+        $this->skip('7.74.0', '7.81.1');
     }
 
     private function migrateFsAccess() {

--- a/views/js/core/historyRouter.js
+++ b/views/js/core/historyRouter.js
@@ -68,13 +68,16 @@ define([
             },
 
             /**
-             * Forwards to another controller. Does not change the current location nor the history,
-             * only loads the target controller.
+             * Forwards to another controller. Does not change the current location, just loads the target controller.
+             * Will replace the current history state by an obfuscated version that displays the current location but
+             * internally routes to the provided URL.
              * @param {String} url
              * @returns {Promise}
              */
             forward: function forward(url) {
-                return this.dispatch(url, false);
+                var state = _.isString(url) ? { url : url } : url;
+                history.replaceState(state, '', window.location + '');
+                return this.dispatch(state, false);
             },
 
             /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3496

Fix an issue occurring when a route has been forwarded and the user goes back on the history. Without this patch, a wrong state is restored. Now the `forward` action keep track of both the forwarded URL and the displayed state.

The issue is reproducible in the context of LTI proctoring.