### PR TITLE
Fix/tao 3496 error response

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.81.0',
+    'version' => '7.81.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -721,7 +721,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.74.0');
         }
 
-        $this->skip('7.74.0', '7.81.0');
+        $this->skip('7.74.0', '7.81.1');
     }
 
     private function migrateFsAccess() {

--- a/views/js/core/dataProvider/request.js
+++ b/views/js/core/dataProvider/request.js
@@ -46,10 +46,10 @@ define([
         var err;
         if(response && response.errorCode){
             err = new Error(response.errorCode + ' : ' + (response.errorMsg || response.errorMessage));
-            err.response = response;
         } else {
             err = new Error(fallbackMessage);
         }
+        err.response = response;
         if (httpCode) {
             err.code = httpCode;
         }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3496

When using the `dataProvider/request` module, an error is triggered if the response contains `success=false`. However this response is not provided with the error, making difficult to react precisely to the error. This PR fix that.