### PR TITLE
Fix/tao 3950 navigator space key

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '7.81.1',
+    'version' => '7.81.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -721,7 +721,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('7.74.0');
         }
 
-        $this->skip('7.74.0', '7.81.1');
+        $this->skip('7.74.0', '7.81.2');
     }
 
     private function migrateFsAccess() {

--- a/views/js/test/ui/keyNavigation/test.html
+++ b/views/js/test/ui/keyNavigation/test.html
@@ -8,7 +8,7 @@
         <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
-        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="ui/keyNavigation"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="ui/keyNavigation/navi"></script>
 
         <script  type="text/javascript">
             QUnit.config.autostart = false;

--- a/views/js/test/ui/keyNavigation/test.html
+++ b/views/js/test/ui/keyNavigation/test.html
@@ -22,9 +22,18 @@
     <body>
         <div id="qunit"></div>
         <div id="qunit-fixture">
-            <div class="nav" data-id="A">A</div>
-            <div class="nav" data-id="B">B</div>
-            <div class="nav" data-id="C">C</div>
+            <nav class="nav-1">
+                <div class="nav" data-id="A">A</div>
+                <div class="nav" data-id="B">B</div>
+                <div class="nav" data-id="C">C</div>
+            </nav>
+            <nav class="nav-2">
+                <div class="nav" data-id="A">A</div>
+                <div class="nav" data-id="B">B</div>
+                <div class="nav" data-id="C">C
+                    <div><textarea></textarea></div>
+                </div>
+            </nav>
         </div>
     </body>
 </html>

--- a/views/js/test/ui/keyNavigation/test.js
+++ b/views/js/test/ui/keyNavigation/test.js
@@ -58,11 +58,12 @@ define([
             assert.equal(typeof navigator[data.name], 'function', 'The navigator exposes a "' + data.name + '" function');
         });
 
+
     QUnit.module('Dom navigable element');
 
     QUnit.asyncTest('activate', function(assert){
         var navigator;
-        var $container = $('#qunit-fixture');
+        var $container = $('#qunit-fixture .nav-1');
         var $navigables = $container.find('.nav');
         var navigables = navigableDomElement.createFromDoms($navigables);
 
@@ -86,7 +87,7 @@ define([
 
     QUnit.asyncTest('navigate with API', function(assert){
         var navigator;
-        var $container = $('#qunit-fixture');
+        var $container = $('#qunit-fixture .nav-1');
         var $navigables = $container.find('.nav');
         var navigables = navigableDomElement.createFromDoms($navigables);
 
@@ -126,7 +127,7 @@ define([
 
     QUnit.asyncTest('navigate with keyboard', function(assert){
         var navigator;
-        var $container = $('#qunit-fixture');
+        var $container = $('#qunit-fixture .nav-1');
         var $navigables = $container.find('.nav');
         var navigables = navigableDomElement.createFromDoms($navigables);
 
@@ -175,7 +176,7 @@ define([
 
     QUnit.test('isFocused', function(assert){
         var navigator;
-        var $container = $('#qunit-fixture');
+        var $container = $('#qunit-fixture .nav-1');
         var $navigables = $container.find('.nav');
         var navigables = navigableDomElement.createFromDoms($navigables);
 
@@ -194,7 +195,7 @@ define([
 
     QUnit.asyncTest('loop', function(assert){
         var navigator;
-        var $container = $('#qunit-fixture');
+        var $container = $('#qunit-fixture .nav-1');
         var $navigables = $container.find('.nav');
         var navigables = navigableDomElement.createFromDoms($navigables);
 
@@ -238,7 +239,7 @@ define([
 
     QUnit.asyncTest('keep state off', function(assert){
         var navigator;
-        var $container = $('#qunit-fixture');
+        var $container = $('#qunit-fixture .nav-1');
         var $navigables = $container.find('.nav');
         var navigables = navigableDomElement.createFromDoms($navigables);
 
@@ -277,7 +278,7 @@ define([
 
     QUnit.asyncTest('keep state on', function(assert){
         var navigator;
-        var $container = $('#qunit-fixture');
+        var $container = $('#qunit-fixture .nav-1');
         var $navigables = $container.find('.nav');
         var navigables = navigableDomElement.createFromDoms($navigables);
 
@@ -314,6 +315,55 @@ define([
 
         navigator.activate();
     });
+
+    QUnit.asyncTest('activate with space', function(assert){
+        var navigator;
+        var $container = $('#qunit-fixture .nav-2');
+        var $navigables = $container.find('.nav');
+        var navigables = navigableDomElement.createFromDoms($navigables);
+
+        var $textarea  = $('textarea', $container);
+        QUnit.expect(7);
+
+        assert.equal(navigables.length, 3, 'navigable element created');
+
+        navigator = keyNavigator({
+            keepState : true,
+            elements : navigables
+        })
+        .on('right', function(){
+            this.next();
+        })
+        .on('activate', function(cursor){
+            assert.equal(cursor.position, 2, 'activated position is ok');
+            assert.equal(cursor.navigable.getElement().data('id'), 'C', 'navigable element in cursor is correct');
+
+            assert.equal($textarea.length, 1, 'The textarea element exists');
+
+            this.on('blur', function(){
+                assert.ok(false, 'Hitting the space key should not blur the active element');
+            });
+
+            $textarea.simulate('keydown', {keyCode: 32});//space-> should not blur
+            $textarea.simulate('keyup', {keyCode: 32});//space
+
+            setTimeout(function(){
+                QUnit.start();
+            }, 10);
+        });
+
+        navigator.focus();
+        assert.equal($(document.activeElement).data('id'), 'A', 'focus on first');
+
+        $(document.activeElement).simulate('keydown', {keyCode: 39});//right
+        assert.equal($(document.activeElement).data('id'), 'B', 'focus on second');
+
+        $(document.activeElement).simulate('keydown', {keyCode: 39});//right
+        assert.equal($(document.activeElement).data('id'), 'C', 'focus on third');
+
+        $(document.activeElement).simulate('keyup', {keyCode: 32});//space -> activate
+    });
+
 
     QUnit.module('Group navigable element');
 

--- a/views/js/ui/keyNavigation/navigator.js
+++ b/views/js/ui/keyNavigation/navigator.js
@@ -173,9 +173,9 @@ define([
             }
         }
 
-         _.each(navigables, function(navigable){
+        _.each(navigables, function(navigable){
                 //check if it is a valid navigable element
-                navigable.init();
+            navigable.init();
         });
 
         if(config.group){
@@ -439,8 +439,9 @@ define([
             navigable.getElement()
                 //requires a keyup event to make unselecting radio button work with space bar
                 .on('keyup'+_ns, function keyupSpace(e){
+                    var $target = $(e.target);
                     var keyCode = e.keyCode ? e.keyCode : e.charCode;
-                    if(keyCode === 32){//space bar
+                    if(keyCode === 32 && !$target.is(':input')){//space bar
                         e.preventDefault();
                         keyNavigator.activate(e.target);
                     }

--- a/views/js/ui/keyNavigation/navigator.js
+++ b/views/js/ui/keyNavigation/navigator.js
@@ -421,18 +421,22 @@ define([
                     keyNavigator.trigger(key);
                 })
                 .add('enter', function(e){
-                    keyNavigator.activate(e.target);
-                }, {
-                    propagate : false,
-                    prevent : true
+                    if($(e.target).is(':text,textarea')){
+                        e.stopPropagation();
+                    } else {
+                        e.preventDefault();
+                        keyNavigator.activate(e.target);
+                    }
                 })
                 .add('up down left right', function(e, key){
                     var $target = $(e.target);
-                    if( !$target.is('img,:text,textarea') && !$target.hasClass('key-navigation-scrollable')){
-                        //prevent scrolling of parent element
-                        e.preventDefault();
+                    if(!$target.is(':text,textarea')){
+                        if( !$target.is('img') && !$target.hasClass('key-navigation-scrollable')){
+                            //prevent scrolling of parent element
+                            e.preventDefault();
+                        }
+                        keyNavigator.trigger(key);
                     }
-                    keyNavigator.trigger(key);
                 }, {
                     propagate : false
                 });

--- a/views/js/ui/keyNavigation/navigator.js
+++ b/views/js/ui/keyNavigation/navigator.js
@@ -427,7 +427,8 @@ define([
                     prevent : true
                 })
                 .add('up down left right', function(e, key){
-                    if(e.target.tagName !== 'IMG' && !$(e.target).hasClass('key-navigation-scrollable')){
+                    var $target = $(e.target);
+                    if( !$target.is('img,:text,textarea') && !$target.hasClass('key-navigation-scrollable')){
                         //prevent scrolling of parent element
                         e.preventDefault();
                     }
@@ -439,11 +440,15 @@ define([
             navigable.getElement()
                 //requires a keyup event to make unselecting radio button work with space bar
                 .on('keyup'+_ns, function keyupSpace(e){
-                    var $target = $(e.target);
                     var keyCode = e.keyCode ? e.keyCode : e.charCode;
-                    if(keyCode === 32 && !$target.is(':input')){//space bar
-                        e.preventDefault();
-                        keyNavigator.activate(e.target);
+                    if(keyCode === 32){
+                        //if an inner element is an input we let the space work
+                        if(e.target !== this && $(e.target).is(':input')){
+                            e.stopPropagation();
+                        } else {
+                            e.preventDefault();
+                            keyNavigator.activate(e.target);
+                        }
                     }
                 })
                 //listen to blurred navigable element


### PR DESCRIPTION
When hitting the space bar within a navigable element like a text field, we don't activate the navigable in order to let people write content. 
This can be tested within any test that have both the navigator configured on the action bar and the comment plugin activated : 

 - Open the comment 
- Write anything with a space
- The element is closed (blured) 