### PR TITLE
fixed forum link

### DIFF
--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -263,7 +263,7 @@ class Layout{
             case 'demoA':
             case 'beta':
             case 'demoB':
-                $message = __('Please report bugs, ideas, comments or feedback in the TAO Forum');
+                $message = __('Please report bugs, ideas, comments or feedback on the TAO Forum');
                 break;
         }
         return $message;

--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -248,7 +248,7 @@ class Layout{
             case 'demoA':
             case 'beta':
             case 'demoB':
-                $link = 'http://forge.taotesting.com/projects/tao';
+                $link = 'https://forum.taocloud.org/';
                 break;
         }
 
@@ -263,7 +263,7 @@ class Layout{
             case 'demoA':
             case 'beta':
             case 'demoB':
-                $message = __('Please report bugs, ideas, comments or feedback on the TAO Forge');
+                $message = __('Please report bugs, ideas, comments or feedback in the TAO Forum');
                 break;
         }
         return $message;

--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '8.3.0',
+    'version' => '8.3.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -773,7 +773,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('8.2.0');
         }
 
-        $this->skip('8.2.0', '8.3.0');
+        $this->skip('8.2.0', '8.3.1');
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
On a vanilla TAO installation

- checkout this branch
- change `/tao/includes/constants.php#49` temporarily to `define('TAO_RELEASE_STATUS', 'alpha');`
- browse the site, paying attention to the bottom/right corner

The link should no longer point to the forge but rather to the forum