### PR TITLE
Fix/tao 4177 fix scratchpad icons

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '8.3.1',
+    'version' => '8.3.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.17.0',

--- a/models/classes/asset/AssetService.php
+++ b/models/classes/asset/AssetService.php
@@ -62,8 +62,10 @@ class AssetService extends ConfigurableService
             $url = $this->getAssetBaseUrl() . FsUtils::normalizePath($asset);
         }
 
+        $isFolder = (substr_compare($url, '/', strlen($url) - 1) === 0);
+
         $buster = $this->getCacheBuster();
-        if($buster != false) {
+        if($buster != false && $isFolder == false) {
             $url .= '?' . self::BUSTER_QUERY_KEY . '=' . urlencode($buster);
         }
 

--- a/models/classes/asset/AssetService.php
+++ b/models/classes/asset/AssetService.php
@@ -48,9 +48,9 @@ class AssetService extends ConfigurableService
     const BUSTER_OPTION_KEY = 'buster';
 
     /**
-     * Get the full URL of an asset
+     * Get the full URL of an asset or a folder
      *
-     * @param string $asset the asset path, relative, from the views folder
+     * @param string $asset the asset or folder path, relative, from the views folder
      * @param string $extensionId  if the asset is relative to an extension base www (optional)
      * @return string the asset URL
      */

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -773,7 +773,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('8.2.0');
         }
 
-        $this->skip('8.2.0', '8.3.1');
+        $this->skip('8.2.0', '8.3.2');
     }
 
     private function migrateFsAccess() {

--- a/test/model/asset/AssetServiceTest.php
+++ b/test/model/asset/AssetServiceTest.php
@@ -61,7 +61,8 @@ class AssetServiceTest extends TaoPhpUnitTestRunner
             ['https://test.taotesting.com/', 'AF034B', 'tao/views/js/lib/require.js', null, 'https://test.taotesting.com/tao/views/js/lib/require.js?buster=AF034B'],
             ['https://test.taotesting.com/', 'éHo?/©', 'js/core/eventifier.js', 'tao', 'https://test.taotesting.com/tao/views/js/core/eventifier.js?buster=%C3%A9Ho%3F%2F%C2%A9'],
             ['https://test.taotesting.com', null, 'tao/views/js/lib/require.js', null, 'https://test.taotesting.com/tao/views/js/lib/require.js?buster='.TAO_VERSION],
-            ['https://test.taotesting.com', false, 'css/tao-main-style.css', 'tao', 'https://test.taotesting.com/tao/views/css/tao-main-style.css']
+            ['https://test.taotesting.com', false, 'css/tao-main-style.css', 'tao', 'https://test.taotesting.com/tao/views/css/tao-main-style.css'],
+            ['https://test.taotesting.com', '7654321', 'js/path/to/library/', 'tao', 'https://test.taotesting.com/tao/views/js/path/to/library/']
         ];
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-4177

The helper Template::js returns a cache busted url even when a folder is passed as a parameter. Thus, when litterallyCanvas tries to load its assets, it requests something like http://xxxx?buster=XXX/icon.png

This PR prevents the cache buster from being added when a folder is requested as an asset