### PR TITLE
Fix/websource css mimetype

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '9.3.2',
+    'version' => '9.3.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.27.0',

--- a/models/classes/websource/BaseWebsource.php
+++ b/models/classes/websource/BaseWebsource.php
@@ -124,7 +124,7 @@ implements Websource
         $mimeType = $this->getFileSystem()->getMimetype($filePath);
         //for css files mimetype can be 'text/plain' due to bug in finfo (see more: https://bugs.php.net/bug.php?id=53035)
         $pathParts = pathinfo($filePath);
-        if ($mimeType === 'text/plain' && isset($pathParts['extension']) && $pathParts['extension'] === 'css') {
+        if (($mimeType === 'text/plain'|| $mimeType === 'text/x-asm') && isset($pathParts['extension']) && $pathParts['extension'] === 'css') {
             $mimeType = 'text/css';
         }
         return $mimeType;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -785,7 +785,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('9.2.0');
         }
 
-        $this->skip('9.2.0', '9.3.2');
+        $this->skip('9.2.0', '9.3.3');
 
     }
 


### PR DESCRIPTION
I discovered a strange issue when testing the text reader PCI with the ActionWebSource.
The loading of the file textReaderInteraction.css failed because finfo assume that the mimetype is text/x-asm. After some research, I figure out it is some weakness on the file type detection.
http://stackoverflow.com/questions/23020419/resource-interpreted-as-stylesheet-but-transferred-with-mime-type-text-x-asm
This PR simply adds a new condition to detect css file type.