### PR TITLE
Fix/mime detection

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '10.0.0',
+    'version' => '10.0.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.27.0',

--- a/models/classes/websource/BaseWebsource.php
+++ b/models/classes/websource/BaseWebsource.php
@@ -121,6 +121,25 @@ implements Websource
      */
     public function getMimetype($filePath)
     {
-        return \tao_helpers_File::getMimeType($filePath);
+		$mimeType = $this->getFileSystem()->getMimetype($filePath);
+
+		$pathParts = pathinfo($filePath);
+		if(isset($pathParts['extension'])){
+			//manage bugs in finfo
+			switch($pathParts['extension']){
+				case 'css':
+					//for css files mimetype can be 'text/plain' due to bug in finfo (see more: https://bugs.php.net/bug.php?id=53035)
+					if($mimeType === 'text/plain'|| $mimeType === 'text/x-asm'){
+						return $mimeType = 'text/css';
+					}
+					break;
+				case 'svg':
+					if($mimeType === 'text/plain'){
+						return $mimeType = 'image/svg+xml';
+					}
+					break;
+			}
+		}
+		return $mimeType;
     }
 }

--- a/models/classes/websource/BaseWebsource.php
+++ b/models/classes/websource/BaseWebsource.php
@@ -121,12 +121,6 @@ implements Websource
      */
     public function getMimetype($filePath)
     {
-        $mimeType = $this->getFileSystem()->getMimetype($filePath);
-        //for css files mimetype can be 'text/plain' due to bug in finfo (see more: https://bugs.php.net/bug.php?id=53035)
-        $pathParts = pathinfo($filePath);
-        if (($mimeType === 'text/plain'|| $mimeType === 'text/x-asm') && isset($pathParts['extension']) && $pathParts['extension'] === 'css') {
-            $mimeType = 'text/css';
-        }
-        return $mimeType;
+        return \tao_helpers_File::getMimeType($filePath);
     }
 }

--- a/models/classes/websource/BaseWebsource.php
+++ b/models/classes/websource/BaseWebsource.php
@@ -1,23 +1,23 @@
 <?php
 /**
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *               
- * 
+ *
+ *
  */
 namespace oat\tao\model\websource;
 
@@ -121,25 +121,25 @@ implements Websource
      */
     public function getMimetype($filePath)
     {
-		$mimeType = $this->getFileSystem()->getMimetype($filePath);
+        $mimeType = $this->getFileSystem()->getMimetype($filePath);
 
-		$pathParts = pathinfo($filePath);
-		if(isset($pathParts['extension'])){
-			//manage bugs in finfo
-			switch($pathParts['extension']){
-				case 'css':
-					//for css files mimetype can be 'text/plain' due to bug in finfo (see more: https://bugs.php.net/bug.php?id=53035)
-					if($mimeType === 'text/plain'|| $mimeType === 'text/x-asm'){
-						return $mimeType = 'text/css';
-					}
-					break;
-				case 'svg':
-					if($mimeType === 'text/plain'){
-						return $mimeType = 'image/svg+xml';
-					}
-					break;
-			}
-		}
-		return $mimeType;
+        $pathParts = pathinfo($filePath);
+        if (isset($pathParts['extension'])) {
+            //manage bugs in finfo
+            switch ($pathParts['extension']) {
+                case 'css':
+                    //for css files mimetype can be 'text/plain' due to bug in finfo (see more: https://bugs.php.net/bug.php?id=53035)
+                    if ($mimeType === 'text/plain' || $mimeType === 'text/x-asm') {
+                        return $mimeType = 'text/css';
+                    }
+                    break;
+                case 'svg':
+                    if ($mimeType === 'text/plain') {
+                        return $mimeType = 'image/svg+xml';
+                    }
+                    break;
+            }
+        }
+        return $mimeType;
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -787,7 +787,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('9.2.0');
         }
 
-        $this->skip('9.2.0', '10.0.0');
+        $this->skip('9.2.0', '10.0.1');
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
The mimetype detection issue by the filesystem getMimetype() is not limited to css files.
We have another issue with the PCI audio recording where svg files are interpreted as text/plain instead of image/svg+xml. To prevent further issue, I replaced it with the TAO's file helper.