### PR TITLE
Fix/tao 3430 mediaplayer resize

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '10.3.2',
+    'version' => '10.3.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.27.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -782,7 +782,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('9.2.0');
         }
 
-        $this->skip('9.2.0', '10.3.2');
+        $this->skip('9.2.0', '10.3.3');
     }
 
     private function migrateFsAccess() {

--- a/views/js/ui/mediaplayer.js
+++ b/views/js/ui/mediaplayer.js
@@ -486,6 +486,7 @@ define([
         var player;
         var interval;
         var destroyed;
+        var initWidth, initHeight;
 
         function loopEvents(callback) {
             _.forEach(['onStateChange', 'onPlaybackQualityChange', 'onPlaybackRateChange', 'onError', 'onApiChange'], callback);
@@ -522,6 +523,10 @@ define([
                                     window.console.log(ev, e);
                                 });
                             });
+                        }
+
+                        if (initWidth && initHeight) {
+                            this.setSize(initWidth, initHeight);
                         }
 
                         mediaplayer._onReady();
@@ -625,6 +630,9 @@ define([
                     }
                     if (media) {
                         media.setSize(width, height);
+                    } else {
+                        initWidth = width;
+                        initHeight = height;
                     }
                 },
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-3430

Fix the resize issue occurring when the YT player takes too long time to render.

Steps to reproduce:
1. launch the QTI Example Test and go to the second item, or preview the item "example_1_TAO".
2. refresh the page/preview. It could be better if the console is open, to slow down the loading.
3. you should see the media player displayed with a gap on the right, and the controls moved outside of the box. If no, retry step 2

With the fix, you should see the player loading with a smaller size, at one point, then being resized to the right size.