### PR TITLE
Fix/datatable data ids

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '10.23.1',
+    'version' => '10.23.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.34.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -868,7 +868,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('10.21.0');
         }
 
-        $this->skip('10.21.0', '10.23.1');
+        $this->skip('10.21.0', '10.23.2');
 
     }
 

--- a/views/js/ui/datatable.js
+++ b/views/js/ui/datatable.js
@@ -335,7 +335,7 @@ define([
                             var $btn = $(this);
                             e.preventDefault();
                             if (!$btn.hasClass('disabled')) {
-                                action.apply($btn, [$btn.closest('[data-item-identifier]').data('item-identifier')]);
+                                action.apply($btn, [$btn.closest('[data-item-identifier]').attr('data-item-identifier')]);
                             }
                         });
                 });
@@ -446,7 +446,7 @@ define([
                     currentRow.toggleClass('selected');
 
                     $elt.trigger('selected.' + ns,
-                        _.where(dataset.data, {id: currentRow.data('item-identifier')})
+                        _.where(dataset.data, {id: currentRow.attr('data-item-identifier')})
                     );
                 });
             }
@@ -696,7 +696,7 @@ define([
             var selection = [];
 
             $selected.each(function() {
-                selection.push($(this).data('item-identifier'));
+                selection.push($(this).attr('data-item-identifier'));
             });
 
             return selection;


### PR DESCRIPTION
Using the results extension with Moodle, we had some resutls id that are literraly like  : `'{"data":{"instanceid":"15","userid":"3","typeid":"3","launchid":"846167417"},"hash":"856dc123eb29c0869ed8470c5d31d6ebdf12b0aa709327a208826473884a2a1a"}'` . Yes a string that looks like JSON. This id used in the results datatable is parse and transformed to a JSON object by using the jquery/DOM `.data` function.

This is a hotfix, and I don't know if we should merge it, instead the string should be escaped to be interpreted  as string in the data attr. 