### PR TITLE
Fix/tao 4561 media drag drop

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '10.25.1',
+    'version' => '10.25.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.34.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -877,7 +877,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('10.25.0');
         }
 
-        $this->skip('10.25.0', '10.25.1');
+        $this->skip('10.25.0', '10.25.2');
     }
 
     private function migrateFsAccess() {

--- a/views/js/layout/tree.js
+++ b/views/js/layout/tree.js
@@ -386,7 +386,7 @@ define([
                         refNode = tree.parent(refNode);
                     }
 
-                    if (! (refNode instanceof $)) {
+                    if (!(refNode instanceof $) && !(refNode instanceof window.HTMLElement)) {
                         $.tree.rollback(rollback);
                         return false;
                     }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4561

Fix an issue of the treeView component preventing to move an element into an empty container.

To test, open a page containing a treeview, usually any index page in the authoring, create a class and try to move an existing element into it.