### PR TITLE
Fix/tao 4500 csrf token recreated for subsequent deletes

### DIFF
--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -311,7 +311,7 @@ class tao_actions_Main extends tao_actions_CommonModule
         $tokenService = $this->getServiceManager()->get(TokenService::SERVICE_ID);
         $tokenName = $tokenService->getTokenName();
         $token = $tokenService->createToken();
-        $this->setCookie($tokenName, $token);
+        $this->setCookie($tokenName, $token, null, '/');
         $this->setData('xsrf-token-name', $tokenName);
 
         //creates the URL of the action used to configure the client side

--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -720,6 +720,8 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule {
 
         if ( $tokenService->checkToken($token) ) {
             $tokenService->revokeToken($token);
+            $newToken = $tokenService->createToken();
+            $this->setCookie($tokenName, $newToken, null, '/');
             return true;
         }
 

--- a/actions/class.Users.php
+++ b/actions/class.Users.php
@@ -199,6 +199,8 @@ class tao_actions_Users extends tao_actions_CommonModule
             ]);
         } else {
             $tokenService->revokeToken($token);
+            $newToken = $tokenService->createToken();
+            $this->setCookie($tokenName, $newToken, null, '/');
         }
 
         $deleted = false;

--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '10.26.0',
+    'version' => '10.26.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.36.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -879,7 +879,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('10.25.0');
         }
 
-        $this->skip('10.25.0', '10.26.0');
+        $this->skip('10.25.0', '10.26.1');
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
@Alroniks an issue was found where subsequent deletes would fail because the csrf token was revoked on the initial delete. This fixes the issue by issuing a new token and sending it back via a cookie.