### PR TITLE
Fix/taskqueue sortorder

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '10.28.0',
+    'version' => '10.28.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=3.37.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -885,6 +885,8 @@ class Updater extends \common_ext_ExtensionUpdater {
             AclProxy::applyRule(new AccessRule('grant', 'http://www.tao.lu/Ontologies/TAO.rdf#BackOfficeRole', ['ext'=>'tao','mod' => 'TaskQueueData']));
             $this->setVersion('10.28.0');
         }
+
+        $this->skip('10.28.0', '10.28.1');
     }
 
     private function migrateFsAccess() {

--- a/views/js/ui/taskQueue/table.js
+++ b/views/js/ui/taskQueue/table.js
@@ -274,6 +274,7 @@ define([
                     .datatable({
                         url: this.config.dataUrl,
                         rows : this.config.rows,
+                        sortorder: 'desc',
                         filtercolumns: {type: this.config.context},
                         status: {
                             empty: __('No Task yet'),


### PR DESCRIPTION
When the amount of task is larger the page size, the new tasks are pushed on the next pages of the taskQueue table.

This PR intends to fix this behavior by setting the default sort order to `desc`. However the sorted column is the `id`, and unfortunately it seems there is no way to choose the `creationDate` column, as this column is not known by the backend.