### PR TITLE
Fix/type hinting php 5

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '12.1.0',
+    'version' => '12.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=4.0.0',

--- a/models/classes/service/class.ServiceCallHelper.php
+++ b/models/classes/service/class.ServiceCallHelper.php
@@ -30,7 +30,7 @@ class tao_models_classes_service_ServiceCallHelper
     
     const CACHE_PREFIX_PARAM_NAME = 'tao_service_param_';
     
-    public static function getBaseUrl( string $serviceDefinitionId) {
+    public static function getBaseUrl($serviceDefinitionId) {
         
         try {
             $url = common_cache_FileCache::singleton()->get(self::CACHE_PREFIX_URL.urlencode($serviceDefinitionId));

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -903,7 +903,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('10.29.0');
         }
 
-        $this->skip('10.29.0', '12.1.0');
+        $this->skip('10.29.0', '12.1.1');
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
Using type hinting of type string produces a 'catchable fatal error' in php 5.6