### PR TITLE
Fix/tao 5007 multiple datatables with pagination on single page

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '12.14.0',
+    'version' => '12.14.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=4.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '12.14.1',
+    'version' => '12.14.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=4.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -914,7 +914,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('12.2.2');
         }
 
-        $this->skip('12.2.2', '12.14.1');
+        $this->skip('12.2.2', '12.14.2');
     }
 
     private function migrateFsAccess() {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -914,7 +914,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('12.2.2');
         }
 
-        $this->skip('12.2.2', '12.14.0');
+        $this->skip('12.2.2', '12.14.1');
     }
 
     private function migrateFsAccess() {

--- a/views/js/ui/pagination.js
+++ b/views/js/ui/pagination.js
@@ -158,7 +158,7 @@ define(['jquery', 'lodash', 'i18n', 'ui/component', 'ui/pagination/paginationStr
 
                 activePage = calculateActivePage(config.activePage || 1, totalPages);
 
-                provider = paginationStrategy(config.mode);
+                provider = paginationStrategy(config.mode).init();
 
                 provider.render(this.getContainer());
                 this.setPage(this.getActivePage());

--- a/views/js/ui/pagination/providers/pages.js
+++ b/views/js/ui/pagination/providers/pages.js
@@ -27,137 +27,139 @@ define([
 ], function ($, _, __, tpl, pageTpl) {
     'use strict';
 
-    var $paginationTpl;
+    return {
+        init : function () {
+            var $paginationTpl;
 
-    var generatePage = function generatePage(page) {
-        return $(pageTpl({page: page}));
-    };
+            var generatePage = function generatePage(page) {
+                return $(pageTpl({page: page}));
+            };
 
-    var separator = function separator() {
-        var $page = generatePage('...');
-        $page.addClass('separator');
-        return $page;
-    };
+            var separator = function separator() {
+                var $page = generatePage('...');
+                $page.addClass('separator');
+                return $page;
+            };
 
-    var generatePart = function generatePart(from, to, activePage) {
-        var i, pages = [], $page;
+            var generatePart = function generatePart(from, to, activePage) {
+                var i, pages = [], $page;
 
-        for (i = from; i <= to; i++) {
-            $page = generatePage(i);
-            if (i === activePage) {
-                $page.addClass('active');
-            }
-            pages.push($page);
-        }
-
-        return pages;
-    };
-
-    var generatePages = function generatePages(page, total) {
-        var pages = [];
-
-        if (total <= 7) {
-            pages = pages.concat(generatePart(1, total, page));
-        } else {
-            if (page < 5) {
-                pages = pages.concat(generatePart(1, 5, page));
-                pages = pages.concat(separator());
-                pages = pages.concat(generatePart(total, total, page));
-            } else {
-                if ( page >= total-3 ) {
-                    pages = pages.concat(generatePart(1, 1, page));
-                    pages = pages.concat(separator());
-                    pages = pages.concat(generatePart(total-3, total, page));
-                } else {
-                    pages = pages.concat(generatePart(1, 1, page));
-                    pages = pages.concat(separator());
-                    pages = pages.concat(generatePart(page-1, page+1, page));
-                    pages = pages.concat(separator());
-                    pages = pages.concat(generatePart(total, total, page));
+                for (i = from; i <= to; i++) {
+                    $page = generatePage(i);
+                    if (i === activePage) {
+                        $page.addClass('active');
+                    }
+                    pages.push($page);
                 }
-            }
+
+                return pages;
+            };
+
+            var generatePages = function generatePages(page, total) {
+                var pages = [];
+
+                if (total <= 7) {
+                    pages = pages.concat(generatePart(1, total, page));
+                } else {
+                    if (page < 5) {
+                        pages = pages.concat(generatePart(1, 5, page));
+                        pages = pages.concat(separator());
+                        pages = pages.concat(generatePart(total, total, page));
+                    } else {
+                        if ( page >= total-3 ) {
+                            pages = pages.concat(generatePart(1, 1, page));
+                            pages = pages.concat(separator());
+                            pages = pages.concat(generatePart(total-3, total, page));
+                        } else {
+                            pages = pages.concat(generatePart(1, 1, page));
+                            pages = pages.concat(separator());
+                            pages = pages.concat(generatePart(page-1, page+1, page));
+                            pages = pages.concat(separator());
+                            pages = pages.concat(generatePart(total, total, page));
+                        }
+                    }
+                }
+
+                return pages;
+            };
+
+            var dropPages = function dropPages() {
+                $('.page', $paginationTpl).remove();
+            };
+
+            var bindPages = function bindPages(list) {
+                var $point = pagination.forwardButton();
+                _.each(list, function($page) {
+                    $page.insertBefore($point);
+                });
+            };
+
+            var pagination = {
+                render: function render($container) {
+                    $paginationTpl = $(tpl());
+                    $container.append($paginationTpl);
+                },
+                forwardButton: function forwardButton() {
+                    return $('.next', $paginationTpl);
+                },
+                backwardButton: function backwardButton() {
+                    return $('.previous', $paginationTpl);
+                },
+                pageButtons: function pageButton() {
+                    return $('.page', $paginationTpl);
+                },
+                firstPageButton: function lastPageButton() {
+                    return $('.first-page', $paginationTpl);
+                },
+                lastPageButton: function lastPageButton() {
+                    return $('.last-page', $paginationTpl);
+                },
+                setPages: function setPages(page, total) {
+                    var pages = generatePages(page, total);
+
+                    dropPages();
+                    bindPages(pages);
+                },
+                disableButton: function disableButton($btn) {
+                    if (!$btn.hasClass('disabled')) {
+                        $btn.addClass('disabled');
+                    }
+                },
+                enableButton: function enableButton($btn) {
+                    if ($btn.hasClass('disabled')) {
+                        $btn.removeClass('disabled');
+                    }
+                },
+                destroy: function destroy() {
+                    $paginationTpl.remove();
+                },
+                disable: function enable() {
+                    var self = this;
+                    this.disableButton(this.backwardButton());
+                    this.disableButton(this.firstPageButton());
+
+                    $('.page', $paginationTpl).each(function(){
+                        self.disableButton( $(this) );
+                    });
+
+                    this.disableButton(this.lastPageButton());
+                    this.disableButton(this.forwardButton());
+                },
+                enable: function disable() {
+                    var self = this;
+                    this.enableButton(this.backwardButton());
+                    this.enableButton(this.firstPageButton());
+
+                    $('.page', $paginationTpl).each(function(){
+                        self.enableButton( $(this) );
+                    });
+
+                    this.enableButton(this.lastPageButton());
+                    this.enableButton(this.forwardButton());
+                }
+            };
+
+            return pagination;
         }
-
-        return pages;
     };
-
-    var dropPages = function dropPages() {
-        $('.page', $paginationTpl).remove();
-    };
-
-    var bindPages = function bindPages(list) {
-        var $point = pagination.forwardButton();
-        _.each(list, function($page) {
-            $page.insertBefore($point);
-        });
-    };
-
-    var pagination = {
-        init: function init() {
-        },
-        render: function render($container) {
-            $paginationTpl = $(tpl());
-            $container.append($paginationTpl);
-        },
-        forwardButton: function forwardButton() {
-            return $('.next', $paginationTpl);
-        },
-        backwardButton: function backwardButton() {
-            return $('.previous', $paginationTpl);
-        },
-        pageButtons: function pageButton() {
-            return $('.page', $paginationTpl);
-        },
-        firstPageButton: function lastPageButton() {
-            return $('.first-page', $paginationTpl);
-        },
-        lastPageButton: function lastPageButton() {
-            return $('.last-page', $paginationTpl);
-        },
-        setPages: function setPages(page, total) {
-            var pages = generatePages(page, total);
-
-            dropPages();
-            bindPages(pages);
-        },
-        disableButton: function disableButton($btn) {
-            if (!$btn.hasClass('disabled')) {
-                $btn.addClass('disabled');
-            }
-        },
-        enableButton: function enableButton($btn) {
-            if ($btn.hasClass('disabled')) {
-                $btn.removeClass('disabled');
-            }
-        },
-        destroy: function destroy() {
-            $paginationTpl.remove();
-        },
-        disable: function enable() {
-            var self = this;
-            this.disableButton(this.backwardButton());
-            this.disableButton(this.firstPageButton());
-
-            $('.page', $paginationTpl).each(function(){
-                self.disableButton( $(this) );
-            });
-
-            this.disableButton(this.lastPageButton());
-            this.disableButton(this.forwardButton());
-        },
-        enable: function disable() {
-            var self = this;
-            this.enableButton(this.backwardButton());
-            this.enableButton(this.firstPageButton());
-
-            $('.page', $paginationTpl).each(function(){
-                self.enableButton( $(this) );
-            });
-
-            this.enableButton(this.lastPageButton());
-            this.enableButton(this.forwardButton());
-        }
-    };
-
-    return pagination;
 });

--- a/views/js/ui/pagination/providers/simple.js
+++ b/views/js/ui/pagination/providers/simple.js
@@ -26,53 +26,55 @@ define([
 ], function ($, _, __, tpl) {
     'use strict';
 
-    var $paginationTpl;
-
     var pagination = {
         init: function init() {
+            var $paginationTpl;
+
+            return {
+                render: function render($container) {
+                    $paginationTpl = $(tpl());
+                    $container.append($paginationTpl);
+                },
+                forwardButton: function forwardButton() {
+                    return $('.icon-forward', $paginationTpl).parents('button');
+                },
+                backwardButton: function backwardButton() {
+                    return $('.icon-backward', $paginationTpl).parents('button');
+                },
+                setPages: function setPages(page, total) {
+                    $('.page', $paginationTpl).text(page);
+                    $('.total', $paginationTpl).text(total);
+                },
+                disableButton: function disableButton($btn) {
+                    $btn.attr('disabled', 'disabled');
+                },
+                enableButton: function enableButton($btn) {
+                    if ($btn.attr('disabled')){
+                        $btn.removeAttr('disabled');
+                    }
+                },
+                pageButtons: function pageButton() {
+                    return false;
+                },
+                firstPageButton: function lastPageButton() {
+                    return false;
+                },
+                lastPageButton: function lastPageButton() {
+                    return false;
+                },
+                destroy: function destroy() {
+                    $paginationTpl.remove();
+                },
+                disable: function disable() {
+                    this.disableButton(this.backwardButton());
+                    this.disableButton(this.forwardButton());
+                },
+                enable: function enable() {
+                    this.enableButton(this.backwardButton());
+                    this.enableButton(this.forwardButton());
+                }
+            };
         },
-        render: function render($container) {
-            $paginationTpl = $(tpl());
-            $container.append($paginationTpl);
-        },
-        forwardButton: function forwardButton() {
-            return $('.icon-forward', $paginationTpl).parents('button');
-        },
-        backwardButton: function backwardButton() {
-            return $('.icon-backward', $paginationTpl).parents('button');
-        },
-        setPages: function setPages(page, total) {
-            $('.page', $paginationTpl).text(page);
-            $('.total', $paginationTpl).text(total);
-        },
-        disableButton: function disableButton($btn) {
-            $btn.attr('disabled', 'disabled');
-        },
-        enableButton: function enableButton($btn) {
-            if ($btn.attr('disabled')){
-                $btn.removeAttr('disabled');
-            }
-        },
-        pageButtons: function pageButton() {
-            return false;
-        },
-        firstPageButton: function lastPageButton() {
-            return false;
-        },
-        lastPageButton: function lastPageButton() {
-            return false;
-        },
-        destroy: function destroy() {
-            $paginationTpl.remove();
-        },
-        disable: function disable() {
-            this.disableButton(this.backwardButton());
-            this.disableButton(this.forwardButton());
-        },
-        enable: function enable() {
-            this.enableButton(this.backwardButton());
-            this.enableButton(this.forwardButton());
-        }
     };
 
     return pagination;


### PR DESCRIPTION
Bugfix - NCCER
Jira: https://oat-sa.atlassian.net/browse/TAO-5007

The ticket is misinforming (as Hans will agree). The issue is that multiple datatables on a single page override the other's pagination element.

To test:
- go to page https://nccersso.taocloud.org/taoNccerDelivery/PaperTests/index
- create enough tests to allow pagination (currently set to be 5)
- do the action 'generate pdf' (this will set the pagination to override variables to focus on the 'print jobs' table)
- click 'next' on 'list tests' table
- the pagination for 'print jobs' table will match the pagination of the 'list tests' table