### PR TITLE
Fix/tao 5147 restore report module

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '13.0.0',
+    'version' => '13.0.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=4.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -923,7 +923,7 @@ class Updater extends \common_ext_ExtensionUpdater {
                 $this->setVersion('12.21.6');
         }
 
-        $this->skip('12.21.6', '13.0.0');
+        $this->skip('12.21.6', '13.0.1');
     }
 
     private function migrateFsAccess() {

--- a/views/js/report.js
+++ b/views/js/report.js
@@ -1,0 +1,43 @@
+define(['jquery', 'context', 'i18n'], function($, context, __){
+    'use strict';
+
+    var reportModule = {
+
+        fold: function() {
+            var $content = $('.report > .feedback-nesting-0 > div');
+            var $top = $('.report > .feedback-nesting-0');
+
+            if ($content.css('display') === 'none') {
+                $content.css('display', 'block');
+                $top.css('background-color', 'transparent');
+                $top.css('border-color', 'transparent');
+
+                $('#fold > span.check-txt').text(__('Hide detailed report'));
+            }
+            else {
+                $content.css('display', 'none');
+                if ($top.hasClass('feedback-success')) {
+                    $top.css('border-color', '#3ea76f');
+                    $top.css('background-color', '#e6f4ed');
+                }
+                else if ($top.hasClass('feedback-warning')) {
+                    $top.css('border-color', '#dfbe7b');
+                    $top.css('background-color', '#fbf6ee');
+                }
+                else if ($top.hasClass('feedback-error')) {
+                    $top.css('border-color', '#c74155');
+                    $top.css('background-color', '#f8e7e9');
+                }
+                else {
+                    // info
+                    $top.css('border-color', '#3e7da7');
+                    $top.css('background-color', '#e6eef4');
+                }
+
+                $('#fold > span.check-txt').text(__('Show detailed report'));
+            }
+        }
+    }
+
+    return reportModule;
+});


### PR DESCRIPTION
Restore the module tao/report because it is used also in other extension.
We should plan another attempt to removed it definitely.