### PR TITLE
Fix/tao 5300 prevent undefined root node

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '13.5.2',
+    'version' => '13.5.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=4.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -936,7 +936,7 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
         
       
-        $this->skip('13.2.0', '13.5.2');
+        $this->skip('13.2.0', '13.5.3');
     }
 
     private function migrateFsAccess() {

--- a/views/js/ui/highlighter.js
+++ b/views/js/ui/highlighter.js
@@ -303,11 +303,13 @@ define([
         function getHighlightIndex() {
             var highlightIndex = [];
             var rootNode = getContainer();
-            rootNode.normalize();
+            if(rootNode){
+                rootNode.normalize();
 
-            textNodesIndex = 0;
+                textNodesIndex = 0;
 
-            buildHighlightIndex(rootNode, highlightIndex);
+                buildHighlightIndex(rootNode, highlightIndex);
+            }
             return highlightIndex;
         }
 
@@ -385,11 +387,13 @@ define([
          */
         function highlightFromIndex(highlightIndex) {
             var rootNode = getContainer();
-            rootNode.normalize();
+            if(rootNode){
+                rootNode.normalize();
 
-            textNodesIndex = 0;
+                textNodesIndex = 0;
 
-            restoreHighlight(rootNode, highlightIndex);
+                restoreHighlight(rootNode, highlightIndex);
+            }
         }
 
         /**


### PR DESCRIPTION
Just prevent throwing an error when the rootNode is not available (this could be the case if the node is not yet available or being replaced).