### PR TITLE
Feature/tao 5544 add entity encoder

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -36,7 +36,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '14.2.0',
+    'version' => '14.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=4.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -935,7 +935,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('13.2.0');
         }
 
-        $this->skip('13.2.0', '14.2.0');
+        $this->skip('13.2.0', '14.3.0');
     }
 
     private function migrateFsAccess() {

--- a/views/js/core/encoder/encoders.js
+++ b/views/js/core/encoder/encoders.js
@@ -22,7 +22,8 @@ define([
     'core/encoder/float',
     'core/encoder/time',
     'core/encoder/array2str',
-    'core/encoder/str2array'
+    'core/encoder/str2array',
+    'core/encoder/entity'
 ],
 function(
     _,
@@ -31,7 +32,8 @@ function(
     float,
     time,
     array2str,
-    str2array
+    str2array,
+    entity
 ){
     'use strict';
 
@@ -68,13 +70,14 @@ function(
     * Provides multi sources encoding decoding
     * @exports core/encoder/encoders
     */
-    var Encoders =  {
+    var encoders =  {
         number : number,
         float: float,
         time : time,
         boolean : boolean,
         array2str : array2str,
         str2array : str2array,
+        entity : entity,
 
         register : function(name, encode, decode){
             if(!_.isString(name)){
@@ -114,6 +117,6 @@ function(
         }
     };
 
-    return Encoders;
+    return encoders;
 });
 

--- a/views/js/core/encoder/entity.js
+++ b/views/js/core/encoder/entity.js
@@ -1,0 +1,62 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+/**
+ * Simple encoder for XML/HTML entities
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define(function() {
+    'use strict';
+
+    /**
+     * The list of chars to be encoded
+     * @type {String[]}
+     */
+    var guiltyChars = ['&', '<', '>', '"'];
+
+    return {
+
+        /**
+         * Encode a string with guilty chars to the matching html entity codes
+         * @param {String} input
+         * @returns {String} encoded input
+         */
+        encode: function encode(input) {
+            input = input + '';
+
+            return input.split('').map(function(character){
+                return guiltyChars.indexOf(character) > -1 ? '&#' + character.charCodeAt() + ';' : character;
+            }).join('');
+        },
+
+        /**
+         * Decode a string
+         * @param {String} input - with html entity chars
+         * @returns {String} decoded
+         */
+        decode: function decode(input) {
+            input = input + '';
+
+            return input.replace(/&#(\d+);/g, function(matches, code) {
+                return String.fromCharCode(code);
+            });
+        }
+    };
+});

--- a/views/js/test/core/encoder/entity/test.html
+++ b/views/js/test/core/encoder/entity/test.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>TAO Core Test - entity's encoder </title>
+        <base href="../../../../../" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+        <script type="text/javascript" src="js/lib/blanket/blanket.min.js"  data-cover-flag="branchTracking"  data-cover-only="core/encoder/entity.js"></script>
+        <script  type="text/javascript">
+
+            //don't start the test now
+            QUnit.config.autostart = false;
+
+            //load the config
+            require(['/tao/ClientConfig/config'], function(){
+
+                //load the test
+                require(['test/core/encoder/entity/test'], function(){
+
+                    //Tests loaded, run tests
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/core/encoder/entity/test.js
+++ b/views/js/test/core/encoder/entity/test.js
@@ -1,0 +1,66 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+
+/**
+ * Test {@module core/encoder/entity}
+ *
+ */
+define([
+    'core/encoder/entity'
+], function(entity){
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('module', function(assert){
+        assert.equal(typeof entity, 'object', 'The module expose an object');
+        assert.equal(typeof entity.encode, 'function', 'The encode method is available');
+        assert.equal(typeof entity.decode, 'function', 'The decode method is available');
+    });
+
+    QUnit.module('encode');
+
+    QUnit.cases([{
+        title : 'no special chars',
+        input : 'Hello Foo bar world !',
+        output : 'Hello Foo bar world !'
+    }, {
+        title : 'xss',
+        input : 'Hello Foo<script>alert("foo")</script>bar world !',
+        output : 'Hello Foo&#60;script&#62;alert(&#34;foo&#34;)&#60;/script&#62;bar world !'
+    }]).test('encode ', function(data, assert){
+        assert.equal(entity.encode(data.input), data.output);
+    });
+
+    QUnit.module('decode');
+
+    QUnit.cases([{
+        title : 'no special chars',
+        input : 'Hello Foo bar world !',
+        output : 'Hello Foo bar world !'
+    }, {
+        title : 'xss',
+        input : 'Hello Foo&#60;script&#62;alert(&#34;foo&#34;)&#60;/script&#62;bar world !',
+        output : 'Hello Foo<script>alert("foo")</script>bar world !'
+    }]).test('decode ', function(data, assert){
+        assert.equal(entity.decode(data.input), data.output);
+    });
+});
+
+


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-5544

The encoding of XML attributes in the QTI Creator uses `encodeURIComponent` which led to displaying URL encoded data... 

![bad encoding](http://pix.toile-libre.org/upload/original/1510937949.png)

So this PR adds a way to encode (html entity style) attributes that will be included in QTI data (XML attributes).