### PR TITLE
Fix/tao 5671 bulk action shortcuts

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '14.5.0',
+    'version' => '14.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=4.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -947,7 +947,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('14.4.1');
         }
 
-        $this->skip('14.4.1', '14.5.0');
+        $this->skip('14.4.1', '14.6.0');
     }
 
     private function migrateFsAccess() {

--- a/views/js/test/ui/bulkActionPopup/test.js
+++ b/views/js/test/ui/bulkActionPopup/test.js
@@ -290,7 +290,7 @@ define([
 
         var instance = bulkActionPopup(config)
             .on('cancel', function(){
-                assert.ok(true, 'cancelled');
+                assert.ok(true, 'canceled');
                 QUnit.start();
             }).on('destroy', function(){
                 assert.ok(true, 'destroyed');
@@ -362,7 +362,7 @@ define([
 
         var instance = bulkActionPopup(config)
             .on('cancel', function(){
-                assert.ok(true, 'cancelled');
+                assert.ok(true, 'canceled');
                 QUnit.start();
             }).on('destroy', function(){
                 assert.ok(true, 'destroyed');
@@ -435,7 +435,7 @@ define([
 
         var instance = bulkActionPopup(config)
             .on('cancel', function(){
-                assert.ok(true, 'cancelled');
+                assert.ok(true, 'canceled');
                 QUnit.start();
             }).on('destroy', function(){
                 assert.ok(true, 'destroyed');
@@ -527,7 +527,7 @@ define([
 
         var instance = bulkActionPopup(config)
             .on('cancel', function(){
-                assert.ok(true, 'cancelled');
+                assert.ok(true, 'canceled');
                 QUnit.start();
             }).on('destroy', function(){
                 assert.ok(true, 'destroyed');

--- a/views/js/test/ui/bulkActionPopup/test.js
+++ b/views/js/test/ui/bulkActionPopup/test.js
@@ -22,14 +22,15 @@ define([
     'jquery',
     'lodash',
     'ui/bulkActionPopup',
-    'ui/cascadingComboBox'
+    'ui/cascadingComboBox',
+    'lib/simulator/jquery.simulate'
 ], function($, _, bulkActionPopup, cascadingComboBox){
     'use strict';
 
     QUnit.module('Bulk Action Popup');
 
     QUnit.test('render (all options)', function(assert){
-        
+
         var $container = $('#fixture-1');
         var config = {
             renderTo : $container,
@@ -170,16 +171,16 @@ define([
         var $element;
         var instance = bulkActionPopup(config);
         assert.equal($container[0], instance.getContainer()[0], 'container ok');
-        
+
         $element = $container.children('.bulk-action-popup');
         assert.equal($element.length, 1, 'element ok');
         assert.equal($element.find('.applicables li').length, 12, 'allowed resources are displayed');
         assert.equal($element.find('.no-applicables li').length, 4, 'denied resources are displayed');
         assert.equal($element.children('.reason').length, 1, 'the reason box is displayed');
     });
-    
+
     QUnit.test('render (without reason)', function(assert){
-        
+
         var $container = $('#fixture-1');
         var config = {
             renderTo : $container,
@@ -262,17 +263,17 @@ define([
         var $element;
         var instance = bulkActionPopup(config);
         assert.equal($container[0], instance.getContainer()[0], 'container ok');
-        
+
         $element = $container.children('.bulk-action-popup');
         assert.equal($element.length, 1, 'element ok');
         assert.equal($element.find('.applicables li').length, 12, 'allowed resources are displayed');
         assert.equal($element.find('.no-applicables li').length, 4, 'denied resources are displayed');
         assert.equal($element.children('.reason').length, 0, 'the reason box is displayed');
-        
+
     });
-    
-    QUnit.test('cancel', function(assert){
-        
+
+    QUnit.asyncTest('cancel (click)', function(assert){
+
         var $container = $('#fixture-1');
         var config = {
             renderTo : $container,
@@ -287,7 +288,6 @@ define([
             ]
         };
 
-        QUnit.stop(2);
         var instance = bulkActionPopup(config)
             .on('cancel', function(){
                 assert.ok(true, 'cancelled');
@@ -297,6 +297,8 @@ define([
                 QUnit.start();
             });
 
+        QUnit.stop(1);
+
         assert.equal($container[0], instance.getContainer()[0], 'container ok');
         assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
 
@@ -305,7 +307,7 @@ define([
         assert.equal($container.children('.bulk-action-popup').length, 0, 'element is removed');
     });
 
-    QUnit.test('ok', function(assert){
+    QUnit.asyncTest('ok (click)', function(assert){
         var theReason = 'The Reason.';
         var $container = $('#fixture-1');
         var config = {
@@ -321,7 +323,6 @@ define([
             ]
         };
 
-        QUnit.stop(2);
         var instance = bulkActionPopup(config)
             .on('ok', function(state){
                 assert.equal(state.comment, theReason, 'the reason has been sent');
@@ -332,19 +333,233 @@ define([
                 QUnit.start();
             });
 
+        QUnit.stop(1);
+
         assert.equal($container[0], instance.getContainer()[0], 'container ok');
         assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
         $container.find('textarea').text(theReason).change();
-        
+
         $container.find('.done').click();
         assert.equal($container[0], instance.getContainer()[0], 'container is still there');
         assert.equal($container.children('.bulk-action-popup').length, 0, 'element is removed');
     });
 
-    QUnit.test('requiredReasonEmpty', function(assert){
-        
-        QUnit.expect(5);
-        
+    QUnit.asyncTest('cancel (api)', function(assert){
+
+        var $container = $('#fixture-1');
+        var config = {
+            renderTo : $container,
+            actionName : 'Resume Test Session',
+            resourceType : 'test taker',
+            reason : true,
+            allowedResources : [
+                {
+                    id : 'uri_ns#i0000001',
+                    label : 'Test Taker 1'
+                }
+            ]
+        };
+
+        var instance = bulkActionPopup(config)
+            .on('cancel', function(){
+                assert.ok(true, 'cancelled');
+                QUnit.start();
+            }).on('destroy', function(){
+                assert.ok(true, 'destroyed');
+                QUnit.start();
+            });
+
+
+        QUnit.stop(1);
+
+        assert.equal($container[0], instance.getContainer()[0], 'container ok');
+        assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
+
+        instance.cancel();
+        assert.equal($container[0], instance.getContainer()[0], 'container is still there');
+        assert.equal($container.children('.bulk-action-popup').length, 0, 'element is removed');
+    });
+
+    QUnit.asyncTest('ok (api)', function(assert){
+        var theReason = 'The Reason.';
+        var $container = $('#fixture-1');
+        var config = {
+            renderTo : $container,
+            actionName : 'Resume Test Session',
+            resourceType : 'test taker',
+            reason : true,
+            allowedResources : [
+                {
+                    id : 'uri_ns#i0000001',
+                    label : 'Test Taker 1'
+                }
+            ]
+        };
+
+        var instance = bulkActionPopup(config)
+            .on('ok', function(state){
+                assert.equal(state.comment, theReason, 'the reason has been sent');
+                assert.ok(true, 'ok !');
+                QUnit.start();
+            }).on('destroy', function(){
+                assert.ok(true, 'destroyed');
+                QUnit.start();
+            });
+
+        QUnit.stop(1);
+
+        assert.equal($container[0], instance.getContainer()[0], 'container ok');
+        assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
+        $container.find('textarea').text(theReason).change();
+
+        assert.equal(instance.validate(), true, 'The dialog has been validated');
+        assert.equal($container[0], instance.getContainer()[0], 'container is still there');
+        assert.equal($container.children('.bulk-action-popup').length, 0, 'element is removed');
+    });
+
+    QUnit.asyncTest('cancel (shortcut)', function(assert){
+
+        var $container = $('#fixture-1');
+        var config = {
+            renderTo : $container,
+            actionName : 'Resume Test Session',
+            resourceType : 'test taker',
+            reason : true,
+            allowedResources : [
+                {
+                    id : 'uri_ns#i0000001',
+                    label : 'Test Taker 1'
+                }
+            ]
+        };
+
+        var instance = bulkActionPopup(config)
+            .on('cancel', function(){
+                assert.ok(true, 'cancelled');
+                QUnit.start();
+            }).on('destroy', function(){
+                assert.ok(true, 'destroyed');
+                QUnit.start();
+            });
+
+        QUnit.stop(1);
+
+        assert.equal($container[0], instance.getContainer()[0], 'container ok');
+        assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
+
+        $container.simulate('keydown', {
+            charCode: 0,
+            keyCode: 27,
+            which: 27,
+            code: 'esc',
+            key: '',
+            ctrlKey: false,
+            shiftKey: false,
+            altKey: false,
+            metaKey: false
+        });
+        assert.equal($container[0], instance.getContainer()[0], 'container is still there');
+        assert.equal($container.children('.bulk-action-popup').length, 0, 'element is removed');
+    });
+
+    QUnit.asyncTest('ok (shortcut)', function(assert){
+        var theReason = 'The Reason.';
+        var $container = $('#fixture-1');
+        var config = {
+            renderTo : $container,
+            actionName : 'Resume Test Session',
+            resourceType : 'test taker',
+            reason : true,
+            allowedResources : [
+                {
+                    id : 'uri_ns#i0000001',
+                    label : 'Test Taker 1'
+                }
+            ]
+        };
+
+        var instance = bulkActionPopup(config)
+            .on('ok', function(state){
+                assert.equal(state.comment, theReason, 'the reason has been sent');
+                assert.ok(true, 'ok !');
+                QUnit.start();
+            }).on('destroy', function(){
+                assert.ok(true, 'destroyed');
+                QUnit.start();
+            });
+
+        QUnit.stop(1);
+
+        assert.equal($container[0], instance.getContainer()[0], 'container ok');
+        assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
+        $container.find('textarea').text(theReason).change();
+
+        $container.simulate('keydown', {
+            charCode: 0,
+            keyCode: 13,
+            which: 13,
+            code: 'enter',
+            key: '',
+            ctrlKey: false,
+            shiftKey: false,
+            altKey: false,
+            metaKey: false
+        });
+        assert.equal($container[0], instance.getContainer()[0], 'container is still there');
+        assert.equal($container.children('.bulk-action-popup').length, 0, 'element is removed');
+    });
+
+    QUnit.asyncTest('disabled shortcut', function(assert){
+        var $container = $('#fixture-1');
+        var config = {
+            renderTo : $container,
+            actionName : 'Resume Test Session',
+            resourceType : 'test taker',
+            reason : true,
+            allowShortcuts: false,
+            allowedResources : [
+                {
+                    id : 'uri_ns#i0000001',
+                    label : 'Test Taker 1'
+                }
+            ]
+        };
+
+        var instance = bulkActionPopup(config)
+            .on('cancel', function(){
+                assert.ok(true, 'cancelled');
+                QUnit.start();
+            }).on('destroy', function(){
+                assert.ok(true, 'destroyed');
+                QUnit.start();
+            });
+
+        QUnit.stop(1);
+
+        assert.equal($container[0], instance.getContainer()[0], 'container ok');
+        assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
+
+        $container.simulate('keydown', {
+            charCode: 0,
+            keyCode: 27,
+            which: 27,
+            code: 'esc',
+            key: '',
+            ctrlKey: false,
+            shiftKey: false,
+            altKey: false,
+            metaKey: false
+        });
+        assert.equal($container[0], instance.getContainer()[0], 'container is still there');
+        assert.equal($container.children('.bulk-action-popup').length, 1, 'element has not been removed');
+
+        instance.cancel();
+        assert.equal($container[0], instance.getContainer()[0], 'container is still there');
+        assert.equal($container.children('.bulk-action-popup').length, 0, 'element is removed');
+    });
+
+    QUnit.test('requiredReasonEmpty (click)', function(assert){
+
         var theReason = '';
         var $container = $('#fixture-1');
         var config = {
@@ -362,7 +577,9 @@ define([
         };
 
         var instance = bulkActionPopup(config);
-        
+
+        QUnit.expect(5);
+
         assert.equal($container[0], instance.getContainer()[0], 'container ok');
         assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
         $container.find('textarea').text(theReason).change();
@@ -374,9 +591,40 @@ define([
         assert.equal($container.find('.feedback-error', $container).length, 1, 'the interaction has error');
     });
 
-    QUnit.test('requiredReasonFilled', function(assert){
+    QUnit.test('requiredReasonEmpty (api)', function(assert){
 
-        QUnit.expect(5);
+        var theReason = '';
+        var $container = $('#fixture-1');
+        var config = {
+            renderTo: $container,
+            actionName: 'Resume Test Session',
+            resourceType: 'test taker',
+            reason: true,
+            requiredReason: true,
+            allowedResources: [
+                {
+                    id : 'uri_ns#i0000001',
+                    label : 'Test Taker 1'
+                }
+            ]
+        };
+
+        var instance = bulkActionPopup(config);
+
+        QUnit.expect(6);
+
+        assert.equal($container[0], instance.getContainer()[0], 'container ok');
+        assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
+        $container.find('textarea').text(theReason).change();
+
+        assert.equal(instance.validate(), false, 'The dialog cannot be validated');
+        assert.equal($container[0], instance.getContainer()[0], 'container is still there');
+        assert.equal($container.children('.bulk-action-popup').length, 1, 'element is not removed');
+
+        assert.equal($container.find('.feedback-error', $container).length, 1, 'the interaction has error');
+    });
+
+    QUnit.test('requiredReasonFilled (click)', function(assert){
 
         var theReason = 'reason';
         var $container = $('#fixture-1');
@@ -396,11 +644,45 @@ define([
 
         var instance = bulkActionPopup(config);
 
+        QUnit.expect(5);
+
         assert.equal($container[0], instance.getContainer()[0], 'container ok');
         assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
         $container.find('textarea').text(theReason).change();
 
         $container.find('.done').click();
+        assert.equal($container[0], instance.getContainer()[0], 'container is still there');
+        assert.equal($container.find('.feedback-error', $container).length, 0, 'the interaction hasn\'t error');
+        assert.equal($container.children('.bulk-action-popup').length, 0, 'element is removed');
+    });
+
+    QUnit.test('requiredReasonFilled (api)', function(assert){
+
+        var theReason = 'reason';
+        var $container = $('#fixture-1');
+        var config = {
+            renderTo: $container,
+            actionName: 'Resume Test Session',
+            resourceType: 'test taker',
+            reason: true,
+            requiredReason: true,
+            allowedResources: [
+                {
+                    id : 'uri_ns#i0000001',
+                    label : 'Test Taker 1'
+                }
+            ]
+        };
+
+        var instance = bulkActionPopup(config);
+
+        QUnit.expect(6);
+
+        assert.equal($container[0], instance.getContainer()[0], 'container ok');
+        assert.equal($container.children('.bulk-action-popup').length, 1, 'element ok');
+        $container.find('textarea').text(theReason).change();
+
+        assert.equal(instance.validate(), true, 'The dialog has been validated');
         assert.equal($container[0], instance.getContainer()[0], 'container is still there');
         assert.equal($container.find('.feedback-error', $container).length, 0, 'the interaction hasn\'t error');
         assert.equal($container.children('.bulk-action-popup').length, 0, 'element is removed');

--- a/views/js/ui/bulkActionPopup.js
+++ b/views/js/ui/bulkActionPopup.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2015-2017 (original work) Open Assessment Technologies SA ;
  */
 define([
     'jquery',
@@ -21,29 +21,20 @@ define([
     'i18n',
     'tpl!ui/bulkActionPopup/tpl/layout',
     'ui/component',
+    'util/shortcut/registry',
+    'util/shortcut',
+    'util/namespace',
     'ui/modal',
     'select2'
-], function($, _, __, layoutTpl, component){
+], function($, _, __, layoutTpl, component, shortcutRegistry, globalShortcut, namespaceHelper){
     'use strict';
 
-    var _ns = '.bulk-action-popup';
-
     /**
-     * Add the form into a popup and display it
-     * @param {Object} instance
-     * @param {Object} modalConfig
-     * @returns {undefined}
+     * Namespace used in events and shortcuts
+     * @type {String}
+     * @private
      */
-    function initModal(instance, modalConfig){
-
-        instance.getElement()
-            .addClass('modal')
-            .on('closed.modal', function(){
-                //on shot only, on close, destroy the widget
-                instance.destroy();
-            })
-            .modal(modalConfig);
-    }
+    var _ns = 'bulk-action-popup';
 
     /**
      * Builds an instance of the bulkActionPopup component
@@ -52,6 +43,7 @@ define([
      * @param {jQuery} config.renderTo - the jQuery container it should be rendered to
      * @param {String} config.actionName - the action name (use in the title text)
      * @param {String} config.resourceType - the name of the resource type (use in the text)
+     * @param {Boolean} [config.allowShortcuts] - allow keyboard shortcuts (Esc to cancel, Enter or Space to validate)
      * @param {String} [config.resourceTypes] - the name of the resource type in plural (use in the text)
      * @param {Boolean} [config.reason] - defines if the reason section should be displayed or not
      * @param {Function} [config.categoriesSelector] - callback renderer for categories
@@ -67,69 +59,152 @@ define([
             comment : ''
         };
 
+        var instance = component({
+            /**
+             * Validates the dialog, and closes it (action performed when hitting the Ok button)
+             * @returns {Boolean} Returns `true` if the dialog has been successively validated (and closed)
+             */
+            validate: function validate() {
+                var $element = this.getElement();
+                var $error;
+
+                if ($element) {
+                    $('.feedback-error', $element).remove();
+                    if (!checkRequiredFields($element)) {
+                        $error = $('<div class="feedback-error small"></div>').text(__('All fields are required'));
+                        $element.find('.actions').prepend($error);
+                        return false;
+                    }
+                }
+
+                this.trigger('ok', state);
+                this.destroy();
+                return true;
+            },
+
+            /**
+             * Cancels and closes the dialog
+             */
+            cancel: function cancel() {
+                this.trigger('cancel');
+                this.destroy();
+            }
+        })
+            .setTemplate(layoutTpl)
+
+            // uninstalls the component
+            .on('destroy', function(){
+                // allows all registered shortcuts to be triggered and disables the dialog shortcuts
+                globalShortcut.enable();
+                if (this.dialogShortcut) {
+                    this.dialogShortcut.disable();
+                    this.dialogShortcut.clear();
+                    this.dialogShortcut = null;
+                }
+
+                this.getElement().removeClass('modal').modal('destroy');
+            })
+
+            // event triggered when the OK button has been clicked or the related shortcut has been used
+            .on('action-ok', function() {
+                this.validate();
+            })
+
+            // event triggered when the Cancel button has been clicked or the related shortcut has been used
+            .on('action-cancel', function() {
+                this.cancel();
+            })
+
+            // renders the component
+            .on('render', function(){
+                var self = this;
+                var $element = this.getElement();
+                var $container;
+
+                initModal({
+                    disableEscape: true,
+                    width : (this.config.single && !this.config.deniedResources.length && !this.config.reason) ? 600 : 800
+                });
+
+                if ( _.isObject(this.config.categoriesSelector)) {
+                    $container = $element.find('.reason').children('.categories');
+                    this.config.categoriesSelector.render($container);
+                }
+
+                $element
+                    .on(namespaceHelper.namespaceAll('selected.cascading-combobox', _ns), function (e, reasons) {
+                        state.reasons = reasons;
+                        self.trigger('change', state);
+                    })
+                    .on(namespaceHelper.namespaceAll('change', _ns), 'textarea', function () {
+                        state.comment = $(this).val();
+                        self.trigger('change', state);
+                    })
+                    .on(namespaceHelper.namespaceAll('click', _ns), '.actions .done', function (e) {
+                        e.preventDefault();
+                        self.trigger('action-ok');
+                    })
+                    .on(namespaceHelper.namespaceAll('click', _ns), '.actions .cancel', function (e) {
+                        e.preventDefault();
+                        self.trigger('action-cancel');
+                    });
+
+                if (this.config.allowShortcuts) {
+                    // prevents all registered shortcuts to be triggered and activate the dialog shortcuts
+                    globalShortcut.disable();
+                    this.dialogShortcut = shortcutRegistry($('body'), {
+                        propagate: false,
+                        prevent: true
+                    })
+                        // prevents the TAB key to be used to move outside the dialog box
+                        .set('Tab Shift+Tab')
+
+                        // handles the dialog's shortcuts: just fire the action using the event loop
+                        .add(namespaceHelper.namespaceAll('esc', _ns, true), function (e, shortcut) {
+                            instance.trigger('action-cancel', shortcut);
+                        })
+                        .add(namespaceHelper.namespaceAll('enter space', _ns, true), function (e, shortcut) {
+                            instance.trigger('action-ok', shortcut);
+                        });
+                }
+            });
+
+        /**
+         * Validates that all required fields have been filled
+         * @param {jQuery} $container
+         * @returns {Boolean}
+         */
+        function checkRequiredFields($container) {
+            return $("select, textarea", $container).filter(function () {
+                return $.trim($(this).val()).length === 0;
+            }).length === 0;
+        }
+
+        /**
+         * Adds the form into a popup and displays it
+         * @param {Object} modalConfig
+         */
+        function initModal(modalConfig) {
+            instance.getElement()
+                .addClass('modal')
+                .on('closed.modal', function () {
+                    // always destroy the widget when closing
+                    instance.destroy();
+                })
+                .modal(modalConfig)
+                .focus();
+        }
+
         //compute extra config data (essentially for the template)
-        config = _.defaults(config, {
+        return instance.init(_.defaults(config, {
             deniedResources : [],
             reason : false,
+            allowShortcuts: true,
             reasonRequired: false,
             resourceCount : config.allowedResources.length,
             single : (config.allowedResources.length === 1),
             singleDenied : (config.deniedResources && config.deniedResources.length === 1),
             resourceTypes : config.resourceType + 's'
-        });
-
-        var checkRequiredFields = function checkRequiredFields($container) {
-            return $("select, textarea", $container).filter(function () {
-                    return $.trim($(this).val()).length === 0;
-                }).length === 0;
-        };
-
-        return component()
-            .setTemplate(layoutTpl)
-
-            // uninstalls the component
-            .on('destroy', function(){
-                this.getElement().removeClass('modal').modal('destroy');
-            })
-
-            // renders the component
-            .on('render', function(){
-
-                var self = this;
-                var $element = this.getElement();
-
-                initModal(this, {
-                    width : (config.single && !config.deniedResources.length && !config.reason) ? 600 : 800
-                });
-
-                if ( _.isObject(config.categoriesSelector)) {
-                    var $container = $element.find('.reason').children('.categories');
-                    config.categoriesSelector.render($container);
-                }
-
-                $element.on('selected.cascading-combobox' + _ns, function(e, reasons){
-                    state.reasons = reasons;
-                    self.trigger('change', state);
-                }).on('change' + _ns, 'textarea', function(){
-                    state.comment = $(this).val();
-                    self.trigger('change', state);
-                }).on('click', '.actions .done', function(e){
-
-                    $('.feedback-error', $element).remove();
-                    if (!checkRequiredFields($element)) {
-                        var error = $('<div class="feedback-error small"></div>').text(__('All fields are required'));
-                        $element.find('.actions').prepend(error);
-                        return;
-                    }
-
-                    self.trigger('ok', state);
-                    self.destroy();
-                }).on('click', '.actions .cancel', function(e){
-                    e.preventDefault();
-                    self.trigger('cancel');
-                    self.destroy();
-                });
-            })
-            .init(config);
+        }));
     };
 });

--- a/views/js/ui/bulkActionPopup.js
+++ b/views/js/ui/bulkActionPopup.js
@@ -163,7 +163,7 @@ define([
                         .add(namespaceHelper.namespaceAll('esc', _ns, true), function (e, shortcut) {
                             instance.trigger('action-cancel', shortcut);
                         })
-                        .add(namespaceHelper.namespaceAll('enter space', _ns, true), function (e, shortcut) {
+                        .add(namespaceHelper.namespaceAll('enter', _ns, true), function (e, shortcut) {
                             instance.trigger('action-ok', shortcut);
                         });
                 }

--- a/views/js/ui/bulkActionPopup.js
+++ b/views/js/ui/bulkActionPopup.js
@@ -119,7 +119,7 @@ define([
             .on('render', function(){
                 var self = this;
                 var $element = this.getElement();
-                var $container;
+                var $reason;
 
                 initModal({
                     disableEscape: true,
@@ -127,8 +127,8 @@ define([
                 });
 
                 if ( _.isObject(this.config.categoriesSelector)) {
-                    $container = $element.find('.reason').children('.categories');
-                    this.config.categoriesSelector.render($container);
+                    $reason = $element.find('.reason').children('.categories');
+                    this.config.categoriesSelector.render($reason);
                 }
 
                 $element
@@ -153,6 +153,7 @@ define([
                     // prevents all registered shortcuts to be triggered and activate the dialog shortcuts
                     globalShortcut.disable();
                     this.dialogShortcut = shortcutRegistry($('body'), {
+                        avoidInput: true,
                         propagate: false,
                         prevent: true
                     })

--- a/views/js/ui/bulkActionPopup.js
+++ b/views/js/ui/bulkActionPopup.js
@@ -43,7 +43,7 @@ define([
      * @param {jQuery} config.renderTo - the jQuery container it should be rendered to
      * @param {String} config.actionName - the action name (use in the title text)
      * @param {String} config.resourceType - the name of the resource type (use in the text)
-     * @param {Boolean} [config.allowShortcuts] - allow keyboard shortcuts (Esc to cancel, Enter or Space to validate)
+     * @param {Boolean} [config.allowShortcuts] - allow keyboard shortcuts (Esc to cancel, Enter to validate)
      * @param {String} [config.resourceTypes] - the name of the resource type in plural (use in the text)
      * @param {Boolean} [config.reason] - defines if the reason section should be displayed or not
      * @param {Function} [config.categoriesSelector] - callback renderer for categories


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-5671

The `bulkActionPopup` was not taking care of the keyboard. The modal dialog implementation is basically supporting the Escape key, but that is not enough.

So, this fix is a refactoring of the component with support of keyboard shortcut (optional, but activated by default).

The `bulkActionPopup` component now offers an API to validate/cancel the dialog, and is listening to keyboard (Escape to cancel, Enter to validate)