### PR TITLE
Fix/theme custom texts

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '14.7.1',
+    'version' => '14.7.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=4.0.0',

--- a/models/classes/theme/ConfigurableTheme.php
+++ b/models/classes/theme/ConfigurableTheme.php
@@ -71,6 +71,64 @@ class ConfigurableTheme extends Configurable implements Theme
     const THEME_DATA_MESSAGE  = 'message';
 
     /**
+     * Defined custom texts
+     * @var array
+     */
+    private $allTexts;
+
+    /**
+     * Define all custom text
+     * return [
+     *  'myCustomTextId' => __('My custom text translation');
+     * ];
+     * @return array
+     */
+    protected function initializeTexts()
+    {
+        return [];
+    }
+
+    /**
+     * Allow to set a custom translatable string for a given key
+     * @param String $key
+     * @return string
+     */
+    public function getText($key) {
+        if (empty($this->allTexts)) {
+            $this->allTexts = $this->initializeTexts();
+        }
+        return (array_key_exists($key, $this->allTexts))
+            ? $this->allTexts[$key]
+            : '';
+    }
+
+    /**
+     * Retrieve all custom strings for the given keys
+     * @param String[] $allKeys
+     * @return array
+     */
+    public function getTextFromArray($allKeys) {
+        $allValues = [];
+        if (is_array($allKeys) && ! empty($allKeys)) {
+            forEach ($allKeys as $key) {
+                $allValues[$key] = $this->getText($key);
+            }
+        }
+        return $allValues;
+    }
+
+    /**
+     * Retrieve all existing strings
+     * @return array
+     */
+    public function getAllTexts() {
+        if (empty($this->allTexts)) {
+            $this->allTexts = $this->initializeTexts();
+        }
+        return $this->allTexts;
+    }
+
+    /**
      * Get a template associated to given $id
      *
      * @param string $id

--- a/models/classes/theme/DefaultTheme.php
+++ b/models/classes/theme/DefaultTheme.php
@@ -20,7 +20,6 @@
 namespace oat\tao\model\theme;
 
 use oat\tao\helpers\Template;
-use oat\oatbox\Configurable;
 
 /**
  * Class DefaultTheme
@@ -29,10 +28,8 @@ use oat\oatbox\Configurable;
  *
  * @package oat\tao\model\theme
  */
-class DefaultTheme extends Configurable implements Theme
+class DefaultTheme extends ConfigurableTheme
 {
-    private $allTexts;
-
     public function getId()
     {
         return 'default';
@@ -49,86 +46,11 @@ class DefaultTheme extends Configurable implements Theme
 
     /**
      * (non-PHPdoc)
-     * @see \oat\tao\model\theme\Theme::getTemplate()
-     */
-    public function getTemplate($id, $context = Theme::CONTEXT_BACKOFFICE)
-    {
-        switch ($id) {
-    		case 'header-logo' :
-    		    $template = Template::getTemplate('blocks/header-logo.tpl', 'tao');
-    		    break;
-    		case 'footer' :
-    		    $template = Template::getTemplate('blocks/footer.tpl', 'tao');
-    		    break;
-	    	case 'login-message' :
-	    	    $template = Template::getTemplate('blocks/login-message.tpl', 'tao');
-                break;
-	    	default:
-	    	    \common_Logger::w('Unkown template '.$id);
-	    	    $template = null;
-    	}
-    	return $template;
-    }
-
-    /**
-     * (non-PHPdoc)
      * @see \oat\tao\model\theme\Theme::getStylesheet()
      */
     public function getStylesheet($context = Theme::CONTEXT_BACKOFFICE)
     {
         return Template::css('tao-3.css', 'tao');
-    }
-
-    /**
-     * Define all custom text
-     * return [
-     *  'myCustomTextId' => __('My custom text translation');
-     * ];
-     * @return array
-     */
-    protected function initializeTexts()
-    {
-        return [];
-    }
-
-    /**
-     * Allow to set a custom translatable string for a given key
-     * @param String $key
-     * @return string
-     */
-    public function getText($key) {
-        if (empty($this->allTexts)) {
-            $this->allTexts = $this->initializeTexts();
-        }
-        return (array_key_exists($key, $this->allTexts))
-            ? $this->allTexts[$key]
-            : '';
-    }
-
-    /**
-     * Retrieve all custom strings for the given keys
-     * @param String[] $allKeys
-     * @return array
-     */
-    public function getTextFromArray($allKeys) {
-        $allValues = [];
-        if (is_array($allKeys) && ! empty($allKeys)) {
-            forEach ($allKeys as $key) {
-                $allValues[$key] = $this->getText($key);
-            }
-        }
-        return $allValues;
-    }
-
-    /**
-     * Retrieve all existing strings
-     * @return array
-     */
-    public function getAllTexts() {
-        if (empty($this->allTexts)) {
-            $this->allTexts = $this->initializeTexts();
-        }
-        return $this->allTexts;
     }
 
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -947,7 +947,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('14.4.1');
         }
 
-        $this->skip('14.4.1', '14.7.1');
+        $this->skip('14.4.1', '14.7.2');
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
When custom texts is accessed on theme that does not provide the expected API, an exception is thrown. This is due to the fact that only the default theme, and the `ConfigurablePlatformTheme` instances, provide the API, while others don't.

You can easily reproduce the issue by installing `taoClientDiagnostic` and trying to run a check from this page: `taoClientDiagnostic/Diagnostic/index`.

Moved the stuff that gives access to the custom texts from the default theme to the `ConfigurableTheme` class, then makes the default theme inherit this class.

Was related to https://oat-sa.atlassian.net/browse/TAO-5675