### PR TITLE
Feature/tao 5239 action service permissions

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,6 +31,7 @@ use oat\tao\scripts\install\SetupMaintenanceService;
 use oat\tao\scripts\install\AddArchiveService;
 use oat\tao\scripts\install\RegisterResourceWatcherService;
 use oat\tao\scripts\install\RegisterResourceEvents;
+use oat\tao\scripts\install\RegisterActionService;
 
 $extpath = dirname(__FILE__) . DIRECTORY_SEPARATOR;
 
@@ -39,7 +40,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '14.18.2',
+    'version' => '14.19.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=5.13.0',
@@ -102,6 +103,7 @@ return array(
             SetContainerService::class,
             RegisterResourceWatcherService::class,
             RegisterResourceEvents::class,
+            RegisterActionService::class
         )
     ),
     'update' => 'oat\\tao\\scripts\\update\\Updater',

--- a/models/classes/menu/ActionService.php
+++ b/models/classes/menu/ActionService.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\menu;
+
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\accessControl\AclProxy;
+use oat\tao\model\accessControl\ActionResolver;
+use \common_user_User;
+use oat\tao\helpers\ControllerHelper;
+use oat\taoBackOffice\model\menuStructure\Action as MenuAction; 
+/**
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class ActionService extends ConfigurableService
+{
+    const SERVICE_ID = 'tao/menuaction';
+
+    const ACCESS_DENIED    = 0;
+    const ACCESS_GRANTED   = 1;
+    const ACCESS_UNDEFINED = 2;
+
+    private $resolvedActions = [];
+
+    public function hasAccess(MenuAction $action, common_user_User $user, array $node){
+
+        $resolvedAction = $this->getResolvedAction($action);
+        if(!is_null($resolvedAction) && !is_null($user)){
+            if($node['type'] = $resolvedAction['context'] || $resolvedAction['context'] == 'resource') {
+                foreach($resolvedAction['required'] as $key){
+                    if(!array_key_exists($key, $node)){
+                        //missing required key
+                        return self::ACCESS_UNDEFINED;
+                    }
+                }
+                try {
+                    if(AclProxy::hasAccess($user, $resolvedAction['controller'], $resolvedAction['action'], $node)){
+                        return self::ACCESS_GRANTED;
+                    }
+                    return self::ACCESS_DENIED;
+                } catch(\Exception $e){
+
+                    \common_Logger::w('Unable to resolve permission for action ' . $action->getId() . ' : ' . $e->getMessage() );
+                }
+            }
+        }
+        return self::ACCESS_UNDEFINED;
+    }
+
+    public function computePermissions(array $actions, \common_user_User $user, array $node)
+    {
+        $permissions = [];
+        foreach($actions as $action){
+            $access = $this->hasAccess($action, $user, $node);
+            if($access != self::ACCESS_UNDEFINED){
+                $permissions[$action->getId()] = ($access == self::ACCESS_GRANTED);
+            }
+        }
+        return $permissions;
+    }
+
+    private function getResolvedAction(MenuAction $action)
+    {
+        $actionId = $action->getId();
+        if(!isset($this->resolvedActions[$actionId])){
+            try{
+                if($action->getContext() == '*'){
+                    //we assume the star context is not permission aware
+                    $this->resolvedActions[$actionId] = null;
+                }  else {
+
+                    $resolver = new ActionResolver($action->getUrl());
+                    $resolvedAction = [
+                        'id'         => $action->getId(),
+                        'context'    => $action->getContext(),
+                        'controller' => $resolver->getController(),
+                        'action'     => $resolver->getAction(),
+                    ];
+                    $resolvedAction['required'] = array_keys(
+                        ControllerHelper::getRequiredRights($resolvedAction['controller'], $resolvedAction['action'])
+                    );
+
+                    $this->resolvedActions[$actionId] = $resolvedAction;
+                }
+            } catch(\ResolverException $re) {
+                $this->resolvedActions[$actionId] = null;
+                \common_Logger::d('do not handle permissions for action : ' . $action->getName() . ' ' . $action->getUrl());
+            } catch(\Exception $e){
+
+                $this->resolvedActions[$actionId] = null;
+                \common_Logger::d('do not handle permissions for action : ' . $action->getName() . ' ' . $action->getUrl());
+            }
+        }
+
+        return $this->resolvedActions[$actionId];
+    }
+
+}

--- a/models/classes/menu/ActionService.php
+++ b/models/classes/menu/ActionService.php
@@ -24,8 +24,11 @@ use oat\tao\model\accessControl\AclProxy;
 use oat\tao\model\accessControl\ActionResolver;
 use \common_user_User;
 use oat\tao\helpers\ControllerHelper;
-use oat\taoBackOffice\model\menuStructure\Action as MenuAction; 
+use oat\taoBackOffice\model\menuStructure\Action as MenuAction;
+
+
 /**
+ * Manage Menu Actions
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
@@ -33,12 +36,25 @@ class ActionService extends ConfigurableService
 {
     const SERVICE_ID = 'tao/menuaction';
 
+    /**
+     * Expose the access levels
+     */
     const ACCESS_DENIED    = 0;
     const ACCESS_GRANTED   = 1;
     const ACCESS_UNDEFINED = 2;
 
+    /**
+     * Keep an index of resolved actions
+     */
     private $resolvedActions = [];
 
+    /**
+     * Has a node access to an action
+     * @param MenuAction        $action the menu action
+     * @param common_user_User  $user   the user to check
+     * @param array             $node   the node/resource to verify
+     * @return int                      the access level
+     */
     public function hasAccess(MenuAction $action, common_user_User $user, array $node){
 
         $resolvedAction = $this->getResolvedAction($action);
@@ -64,6 +80,13 @@ class ActionService extends ConfigurableService
         return self::ACCESS_UNDEFINED;
     }
 
+    /**
+     * Compute the permissions of a node against a list of actions
+     * @param MenuAction[]      $actions the menu actions
+     * @param common_user_User  $user   the user to check
+     * @param array             $node   the node/resource to verify
+     * @return array                    the computed permissions as actionId => boolean
+     */
     public function computePermissions(array $actions, \common_user_User $user, array $node)
     {
         $permissions = [];
@@ -76,6 +99,11 @@ class ActionService extends ConfigurableService
         return $permissions;
     }
 
+    /**
+     * Get the action resolved against itself in the current context
+     * @param MenuAction $action the action
+     * @return array the resolved action
+     */
     private function getResolvedAction(MenuAction $action)
     {
         $actionId = $action->getId();

--- a/scripts/install/RegisterActionService.php
+++ b/scripts/install/RegisterActionService.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\scripts\install;
+
+use common_report_Report as Report;
+use oat\oatbox\extension\AbstractAction;
+use oat\tao\model\menu\ActionService;
+
+/**
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class RegisterActionService extends AbstractAction
+{
+    public function __invoke($params)
+    {
+        $this->getServiceManager()->register(
+            ActionService::SERVICE_ID, new ActionService()
+        );
+        return new Report(Report::TYPE_SUCCESS, 'ActionService resgistered');
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -99,6 +99,7 @@ use oat\tao\model\mvc\error\ExceptionInterpreterService;
 use oat\tao\model\mvc\error\ExceptionInterpretor;
 use oat\tao\model\OperatedByService;
 use oat\tao\model\actionQueue\implementation\InstantActionQueue;
+use oat\tao\scripts\install\RegisterActionService;
 
 /**
  *
@@ -1007,6 +1008,15 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('14.16.0', '14.18.2');
+
+        if ($this->isVersion('14.18.2')) {
+
+            $action = new RegisterActionService();
+            $action->setServiceLocator($this->getServiceManager());
+            $action->__invoke([]);
+
+            $this->setVersion('14.19.0');
+        }
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
In `getOntologyData` the permission computation is done by the controller.
In order to include the Resource Selector we need also to have access to the permission computation without duplicating it, so I've moved it into a proper service `menu/ActionService` (a service to manage menu actions).
Please ensure no regressions are introduced. 