### PR TITLE
core/eventifier.spread

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '15.2.2',
+    'version' => '15.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=6.2.0'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1048,7 +1048,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('15.0.0');
         }
 
-        $this->skip('15.0.0', '15.2.2');
+        $this->skip('15.0.0', '15.3.0');
     }
 
     private function migrateFsAccess() {

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -454,7 +454,7 @@ define([
             },
 
             /**
-             * Forward events to another eventifier object.
+             * Spread events to another eventifier object.
              * So when an event is triggered on the current target,
              * it get's triggered on the destination too.
              *
@@ -465,7 +465,7 @@ define([
              * @param {String|String[]} eventNames - the list of events to forward
              * @returns {Object} target - chains
              */
-            forward : function forward(destination, eventNames){
+            spread : function spread(destination, eventNames){
                 var self = this;
                 if(destination && _.isFunction(destination.trigger)){
                     if(_.isString(eventNames)){
@@ -492,6 +492,9 @@ define([
         logger = eventifierLogger.child({ target : targetName });
 
         _(eventApi).functions().forEach(function(method){
+            if(_.isFunction(target[method])){
+                eventifierLogger.warn('The target object has already a method named ' + method, target);
+            }
             target[method] = function delegate(){
                 var args =  [].slice.call(arguments);
                 return eventApi[method].apply(target, args);

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -171,7 +171,6 @@ define([
         //it stores all the handlers under ns/name/[handlers]
         var eventHandlers  = {};
 
-
         /**
          * Get the handlers for an event type
          * @param {String} eventName - the event name, namespace included
@@ -452,6 +451,35 @@ define([
                 if (_.isString(name) && ! _.isEmpty(name.trim())) {
                     stoppedEvents[name.trim()] = true;
                 }
+            },
+
+            /**
+             * Forward events to another eventifier object.
+             * So when an event is triggered on the current target,
+             * it get's triggered on the destination too.
+             *
+             * Be careful, the forward will be triggered only if the event reach the `on` steps
+             * (it can be canceled by a before).
+             *
+             * @param {eventifier} destination - the destination emitter
+             * @param {String|String[]} eventNames - the list of events to forward
+             * @returns {Object} target - chains
+             */
+            forward : function forward(destination, eventNames){
+                var self = this;
+                if(destination && _.isFunction(destination.trigger)){
+                    if(_.isString(eventNames)){
+                        eventNames = getEventNames(eventNames);
+                    }
+                    _.forEach(eventNames, function(eventName) {
+                        self.on(eventName, function forwardEventTo(){
+                            var args = [eventName].concat([].slice.call(arguments));
+
+                            destination.trigger.apply(destination, args);
+                        });
+                    });
+                }
+                return this;
             }
         };
 

--- a/views/js/test/core/eventifier/test.js
+++ b/views/js/test/core/eventifier/test.js
@@ -34,7 +34,12 @@ define([
     });
 
 
-    QUnit.module('eventification');
+    QUnit.module('eventification', {
+        setup : function setup(){
+            testLogger.reset();
+        }
+    });
+
 
     QUnit.test("delegates", function(assert){
 
@@ -49,7 +54,36 @@ define([
         assert.ok(typeof emitter.off === 'function', "the emitter defintion holds the method off");
         assert.ok(typeof emitter.removeAllListeners === 'function', "the emitter defintion holds the method removeAllListeners");
         assert.ok(typeof emitter.trigger === 'function', "the emitter defintion holds the method trigger");
-        assert.ok(typeof emitter.forward === 'function', "the emitter defintion holds the method forward");
+        assert.ok(typeof emitter.spread === 'function', "the emitter defintion holds the method spread");
+    });
+
+    QUnit.test('warn when overriting', function(assert){
+
+        QUnit.expect(4);
+
+        assert.equal(testLogger.getMessages().warn.length, 0, 'No warning');
+
+        eventifier();
+        assert.equal(testLogger.getMessages().warn.length, 0, 'No overwrite no warning');
+        testLogger.reset();
+
+        eventifier({
+            spread: function(){}
+        });
+
+        assert.equal(testLogger.getMessages().warn.length, 1, 'A warning is created because the spread method exists');
+        testLogger.reset();
+
+        eventifier({
+            spread: function(){},
+            trigger: function(){},
+            on: function(){},
+            foo : function(){}
+        });
+
+        assert.equal(testLogger.getMessages().warn.length, 3, 'Warnings are created because 3 methods exist');
+        testLogger.reset();
+
     });
 
     QUnit.asyncTest("listen and trigger with params", function(assert){
@@ -181,7 +215,12 @@ define([
         emitter.trigger('foo');
     });
 
-    QUnit.module('namespaces');
+
+    QUnit.module('namespaces', {
+        setup : function setup(){
+            testLogger.reset();
+        }
+    });
 
     QUnit.asyncTest("listen namespace, trigger without namespace", function(assert){
         var emitter = eventifier();
@@ -321,7 +360,11 @@ define([
         emitter.trigger('foo').trigger('norz');
     });
 
-    QUnit.module('before');
+    QUnit.module('before', {
+        setup : function setup(){
+            testLogger.reset();
+        }
+    });
 
     QUnit.asyncTest("sync", function(assert){
 
@@ -413,8 +456,6 @@ define([
 
         QUnit.expect(11);
 
-        testLogger.reset();
-
         itemEditor.on('save', function(){
             assert.ok(false, "The listener should not be executed : e.g. do save item");
         });
@@ -454,8 +495,6 @@ define([
         var itemEditor = eventifier();
 
         QUnit.expect(11);
-
-        testLogger.reset();
 
         itemEditor.on('save', function(){
             assert.ok(false, "The listener should not be executed : e.g. do save item");
@@ -728,7 +767,12 @@ define([
         emitter.trigger('ev4.ns4 ev2');
     });
 
-    QUnit.module('on/between');
+    QUnit.module('on/between', {
+        setup : function setup(){
+            testLogger.reset();
+        }
+    });
+
 
     QUnit.asyncTest('async promise, resolved', function (assert) {
         var emitter = eventifier(),
@@ -760,8 +804,6 @@ define([
         var emitter = eventifier();
 
         QUnit.expect(4);
-
-        testLogger.reset();
 
         emitter
             .on('foo', function(){
@@ -832,8 +874,6 @@ define([
 
         QUnit.expect(5);
 
-        testLogger.reset();
-
         emitter
             .on('foo', function(){
                 return new Promise(function (resolve) {
@@ -869,7 +909,12 @@ define([
         }, 30);
     });
 
-    QUnit.module('after');
+    QUnit.module('after', {
+        setup : function setup(){
+            testLogger.reset();
+        }
+    });
+
 
     QUnit.asyncTest("trigger", function(assert){
 
@@ -1012,14 +1057,17 @@ define([
         emitter.trigger('foo bar.moo bar');
     });
 
-    QUnit.module('stopEvent');
+
+    QUnit.module('stopEvent', {
+        setup : function setup(){
+            testLogger.reset();
+        }
+    });
 
     QUnit.asyncTest("stop in sync .before() handlers", function(assert){
         var emitter = eventifier();
 
         QUnit.expect(4);
-
-        testLogger.reset();
 
         emitter
             .before('save', function(){
@@ -1055,8 +1103,6 @@ define([
 
         QUnit.expect(5);
 
-        testLogger.reset();
-
         emitter
             .before('save', function(){
                 assert.ok(true, 'The .before() handler has been called');
@@ -1091,8 +1137,6 @@ define([
 
         QUnit.expect(6);
 
-        testLogger.reset();
-
         emitter
             .before('save', function(){
                 assert.ok(true, 'The .before() handler has been called');
@@ -1126,8 +1170,6 @@ define([
         var emitter = eventifier();
 
         QUnit.expect(6);
-
-        testLogger.reset();
 
         emitter
             .before('save', function(){
@@ -1170,8 +1212,6 @@ define([
         var emitter = eventifier();
 
         QUnit.expect(7);
-
-        testLogger.reset();
 
         emitter
             .before('save', function(){
@@ -1216,8 +1256,6 @@ define([
 
         QUnit.expect(8);
 
-        testLogger.reset();
-
         emitter
             .before('save', function(){
                 assert.ok(true, 'The .before() handler has been called');
@@ -1261,8 +1299,6 @@ define([
 
         QUnit.expect(6);
 
-        testLogger.reset();
-
         emitter
             .on('save', function(){
                 assert.ok(true, 'The .on(save) handler has been called');
@@ -1296,8 +1332,6 @@ define([
         var emitter = eventifier();
 
         QUnit.expect(7);
-
-        testLogger.reset();
 
         emitter
             .on('save', function(){
@@ -1348,8 +1382,6 @@ define([
 
         QUnit.expect(4);
 
-        testLogger.reset();
-
         emitter
             .before('save.ns1', function(){
                 assert.ok(true, 'The .before() handler has been called');
@@ -1379,7 +1411,12 @@ define([
         }, 10);
     });
 
-    QUnit.module('forward');
+
+    QUnit.module('spread', {
+        setup : function setup(){
+            testLogger.reset();
+        }
+    });
 
     QUnit.asyncTest('simple event', function(assert){
         var emitter = eventifier();
@@ -1387,7 +1424,7 @@ define([
 
         QUnit.expect(3);
 
-        emitter.forward(destination, 'foo');
+        emitter.spread(destination, 'foo');
 
         emitter.on('foo', function(){
             assert.ok(true, 'The emitter handler is called');
@@ -1398,7 +1435,7 @@ define([
         });
 
         destination.on('foo', function(){
-            assert.ok(true, 'The event is forwarded');
+            assert.ok(true, 'The event is spread');
         });
         destination.on('bar', function(){
             assert.ok(false, 'The event must not be fowarded');
@@ -1416,7 +1453,7 @@ define([
 
         QUnit.expect(6);
 
-        emitter.forward(destination, 'foo');
+        emitter.spread(destination, 'foo');
 
         emitter.on('foo', function(received1, received2){
             assert.ok(true, 'The emitter handler is called');
@@ -1425,7 +1462,7 @@ define([
         });
 
         destination.on('foo', function(received1, received2){
-            assert.ok(true, 'The event is forwarded');
+            assert.ok(true, 'The event is spread');
             assert.deepEqual(received1, param1);
             assert.deepEqual(received2, param2);
             QUnit.start();
@@ -1442,7 +1479,7 @@ define([
 
         QUnit.expect(14);
 
-        emitter.forward(destination, 'foo bar noz');
+        emitter.spread(destination, 'foo bar noz');
 
         emitter.on('foo bar', function(received1, received2){
             assert.ok(true, 'The emitter handler is called');
@@ -1454,17 +1491,17 @@ define([
         });
 
         destination.on('foo', function(received1, received2){
-            assert.ok(true, 'The event is forwarded');
+            assert.ok(true, 'The event is spread');
             assert.deepEqual(received1, param1);
             assert.deepEqual(received2, param2);
         });
         destination.on('bar', function(received1, received2){
-            assert.ok(true, 'The event is forwarded');
+            assert.ok(true, 'The event is spread');
             assert.deepEqual(received1, param1);
             assert.deepEqual(received2, param2);
         });
         emitter.on('noz', function(){
-            assert.ok(true, 'The event is forwarded');
+            assert.ok(true, 'The event is spread');
             QUnit.start();
         });
 
@@ -1478,7 +1515,7 @@ define([
 
         QUnit.expect(3);
 
-        emitter.forward(destination, 'foo.bar');
+        emitter.spread(destination, 'foo.bar');
 
         emitter.on('foo.noz', function(){
             assert.ok(true, 'The emitter handler is called');
@@ -1488,10 +1525,10 @@ define([
         });
 
         destination.on('foo.noz', function(){
-            assert.ok(false, 'The event should not be forwarded');
+            assert.ok(false, 'The event should not be spread');
         });
         destination.on('foo.bar', function(){
-            assert.ok(true, 'The event is forwarded');
+            assert.ok(true, 'The event is spread');
             QUnit.start();
         });
 
@@ -1505,7 +1542,7 @@ define([
 
         QUnit.expect(4);
 
-        emitter.forward(destination, 'foo bar');
+        emitter.spread(destination, 'foo bar');
 
         emitter.before('foo', function(){
             assert.ok(true, 'The emitter before phase is called');
@@ -1516,7 +1553,7 @@ define([
         });
 
         destination.on('foo', function(){
-            assert.ok(false, 'The event should not be forwarded');
+            assert.ok(false, 'The event should not be spread');
         });
 
 
@@ -1529,7 +1566,7 @@ define([
         });
 
         destination.on('bar', function(){
-            assert.ok(true, 'The event is forwarded');
+            assert.ok(true, 'The event is spread');
             QUnit.start();
         });
 

--- a/views/js/test/core/eventifier/test.js
+++ b/views/js/test/core/eventifier/test.js
@@ -57,7 +57,7 @@ define([
         assert.ok(typeof emitter.spread === 'function', "the emitter defintion holds the method spread");
     });
 
-    QUnit.test('warn when overriting', function(assert){
+    QUnit.test('warn when overwriting', function(assert){
 
         QUnit.expect(4);
 


### PR DESCRIPTION
Adds a `forward|` method on `core/eventifier` in order to forward events, this will be useful in components (like the mediaSelector) to forward events between components. 
The PR needs to be validated through the unit test