### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"issues" : "http://forge.taotesting.com"
 	},
 	"homepage" : "http://www.taotesting.com",
-	"license" : "GPL-2.0",
+	"license" : "GPL-2.0-only",
 	"keywords" : [
 		"tao",
 		"oat",


### PR DESCRIPTION
License "GPL-2.0" is a deprecated SPDX license identifier, use "GPL-2.0-only" instead