### PR TITLE
Feature/tao 5833 inverted permission model unified

### DIFF
--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -399,6 +399,7 @@ class tao_actions_Main extends tao_actions_CommonModule
                 if (FuncProxy::accessPossible($user, $resolver->getController(), $resolver->getAction())) {
 
                     foreach($section->getActions() as $action){
+                        $this->getServiceManager()->propagate($action);
                         $resolver = new ActionResolver($action->getUrl());
                         if(!FuncProxy::accessPossible($user, $resolver->getController(), $resolver->getAction())){
                             $section->removeAction($action); 

--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -30,6 +30,7 @@ use oat\tao\model\lock\LockManager;
 use oat\tao\helpers\ControllerHelper;
 use oat\tao\model\security\xsrf\TokenService;
 use oat\tao\model\TaoOntology;
+use oat\tao\model\resources\ResourceService;
 
 /**
  * The TaoModule is an abstract controller, 
@@ -180,37 +181,44 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule {
 		*/
 		$this->setView('index.tpl');
 	}
-	
-	/**
-	 * Renders json data from the current ontology root class.
-	 * 
-	 * The possible request parameters are the following:
-	 * 
-	 * * uniqueNode: A URI indicating the returned hiearchy will be a single class, with a single children corresponding to the URI.
-	 * * browse:
-	 * * hideInstances:
-	 * * chunk:
-	 * * offset:
-	 * * limit:
-	 * * subclasses:
-	 * * classUri:
-	 * 
-	 * @return void
-	 * @requiresRight classUri READ
-	 */
-	public function getOntologyData()
-	{
-		if (!tao_helpers_Request::isAjax()) {
-            throw new common_exception_IsAjaxAction(__FUNCTION__); 
-		}
+
+     /**
+      * Renders json data from the current ontology root class.
+      *
+      * The possible request parameters are the following:
+      *
+      * * uniqueNode: A URI indicating the returned hiearchy will be a single class, with a single children corresponding to the URI.
+      * * browse:
+      * * hideInstances:
+      * * chunk:
+      * * offset:
+      * * limit:
+      * * subclasses:
+      * * classUri:
+      *
+      * @return void
+      * @requiresRight classUri READ
+      */
+    public function getOntologyData()
+    {
+        if (!tao_helpers_Request::isAjax()) {
+            throw new common_exception_IsAjaxAction(__FUNCTION__);
+        }
         $options = $this->getTreeOptionsFromRequest([]);
+
         //generate the tree from the given parameters
         $tree = $this->getClassService()->toTree($options['class'], $options);
-        $tree = $this->addPermissions($tree);
+
+        //retrieve resources permissions
+        $user = \common_Session_SessionManager::getSession()->getUser();
+        $permissions = $this->getResourceService()->getResourcesPermissions($user, $tree);
 
         //expose the tree
-        $this->returnJson($tree);
-	}
+        $this->returnJson([
+            'tree' => $tree,
+            'permissions' => $permissions
+        ]);
+    }
 
     /**
      * Get options to generate tree
@@ -267,7 +275,9 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule {
     }
 
 	/**
-	 * Add permission information to the tree structure
+         * Add permission information to the tree structure
+         *
+         * @deprecated
 	 * 
 	 * @param array $tree
 	 * @return array
@@ -299,6 +309,9 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule {
 
     /**
      * compulte permissions for a node against actions
+     *
+     * @deprecated
+     *
      * @param array[] $actions the actions data with context, name and the resolver
      * @param User $user the user 
      * @param array $node a tree node
@@ -755,4 +768,12 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule {
         return $this->getServiceManager()->get(ActionService::SERVICE_ID);
     }
 
+    /**
+     * Get the resource service
+     * @return ResourceService
+     */
+    protected function getResourceService()
+    {
+        return $this->getServiceManager()->get(ResourceService::SERVICE_ID);
+    }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '15.8.0',
+    'version' => '15.9.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=6.7.0'

--- a/models/classes/menu/ActionService.php
+++ b/models/classes/menu/ActionService.php
@@ -100,6 +100,30 @@ class ActionService extends ConfigurableService
     }
 
     /**
+     * Get the rights required for the given action
+     * @param MenuAction $action
+     * @return array the required rights
+     */
+    public function getRequiredRights(MenuAction $action)
+    {
+        $rights = [];
+        $resolvedAction = $this->getResolvedAction($action);
+        if(!is_null($resolvedAction)){
+            try {
+                $rights  = ControllerHelper::getRequiredRights(
+                    $resolvedAction['controller'],
+                    $resolvedAction['action']
+                );
+            } catch(\Exception $e){
+                \common_Logger::d('do not handle permissions for action : ' . $action->getName() . ' ' . $action->getUrl());
+            }
+        }
+
+        return $rights;
+    }
+
+
+    /**
      * Get the action resolved against itself in the current context
      * @param MenuAction $action the action
      * @return array the resolved action

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1059,7 +1059,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('15.5.0');
         }
 
-        $this->skip('15.5.0', '15.8.0');
+        $this->skip('15.5.0', '15.9.0');
     }
 
     private function migrateFsAccess() {

--- a/views/js/layout/permissions.js
+++ b/views/js/layout/permissions.js
@@ -1,0 +1,178 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 Open Assessment Technologies SA;
+ */
+
+/**
+ * Manage resources and actions permissions.
+ * The model is based on actions expecting some permissions (requiredRights) for a given parameter.
+ * Then each resource has it's own permissions (READ, WRITE, GRANT) that we store.
+ *
+ * We can check if a resource has a given permission (can read for example)
+ * or to validate a context that must contains all required parameters.
+ *
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'lodash',
+    'uri',
+], function(_, uriUtil){
+    'use strict';
+
+    /**
+     * store permissions per resource
+     * @type {Object}
+     */
+    var permissionStore = {};
+
+    /**
+     * The list of supported rights
+     * @type {String[]}
+     */
+    var supportedRights = [];
+
+    /**
+     * The permissions manager
+     * @typedef {Object} permissionsManager
+     */
+    var permissionsManager = {
+
+        /**
+         * set the rights, none by defaults
+         * @param {String[]} rights
+         * @returns {permissionsManager} chains
+         */
+        setSupportedRights : function setSupportedRights(rights){
+            if (_.isArray(rights)) {
+                supportedRights = _.filter(rights, _.isString);
+            }
+        },
+
+        /**
+         * Get the current rights
+         * @returns {String[]} the rights
+         */
+        getRights : function getRights(){
+            return supportedRights;
+        },
+
+        /**
+         * Check if the given right is supported
+         * @param {String} right - the right to check
+         * @returns {Boolean}
+         */
+        isSupported : function isSupported(right){
+            return _.contains(supportedRights, right);
+        },
+
+        /**
+         * Add permissions to the store.
+         *
+         * Polymorphic.
+         * @example permissionsManager.addPermissions('http://uri.foo/a', ['READ', 'WRITE']);
+         * @example permissionsManager.addPermissions({
+         *      'http://uri.foo/a' : ['READ', 'WRITE'],
+         *      'http://uri.foo/b' : ['READ']
+         *  });
+         *
+         *
+         * @param {String} [uri] - the resource URI
+         * @param {Array|Object} permissions - either an object where the keys are the URIs or directly the permissions
+         * @returns {permissionsManager} chains
+         */
+        addPermissions : function addPermissions(uri, permissions){
+            if(_.isString(uri) && _.isArray(permissions)){
+                permissionStore[uri] = _.intersection(permissions, _.values(this.getRights()));
+            }
+
+            if(_.isUndefined(permissions) && _.isPlainObject(uri)){
+                permissions = uri;
+                _.forEach(permissions, function(value, key){
+                    this.addPermissions(key, value);
+                }, this);
+            }
+
+            return this;
+        },
+
+        /**
+         * Retrieve the permissions for the given resource
+         * @param {String} uri - the resource URI
+         * @returns {Array} the permissions
+         */
+        getPermissions : function getPermissions(uri){
+            return permissionStore[uri];
+        },
+
+        /**
+         * Check if the given resource has the permission
+         * @param {String} uri - the resource URI
+         * @param {String} permission - the permission to check
+         * @returns {Boolean}
+         */
+        hasPermission : function hasPermission(uri, permission){
+
+            //if no right is defined, it's open bar
+            if( supportedRights.length === 0 ) {
+                return true;
+            }
+            if(typeof permissionStore[uri] !== 'undefined'){
+                return _.contains(permissionStore[uri], permission);
+            }
+            return false;
+        },
+
+        /**
+         * Clear all permissions
+         * @returns {permissionsManager} chains
+         */
+        clear : function clear(){
+            permissionStore = {};
+            return this;
+        },
+
+        /**
+         * Check if the given context is allowed to execute an action with required rights.
+         * @param {Object} requiredRights - the action required rights (parameterName : permission)
+         * @param {Object} resourceContext - the context to verify
+         * @returns {Boolean}
+         */
+        isContextAllowed : function isContextAllowed(requiredRights, resourceContext){
+            var self    = this;
+            if(! requiredRights || _.size(requiredRights) === 0 || supportedRights.length === 0){
+                return true;
+            }
+            if(!_.isPlainObject(resourceContext)){
+                return false;
+            }
+            return _.all(requiredRights, function(right, requiredParameter){
+                var parameterValue;
+
+                if(typeof resourceContext[requiredParameter] === 'undefined' || !self.isSupported(right)){
+                    return false;
+                }
+
+                //some values in the context are still URI encoded
+                parameterValue = uriUtil.decode(resourceContext[requiredParameter]);
+
+                return self.hasPermission(parameterValue, right);
+            });
+        },
+    };
+
+    return permissionsManager;
+});

--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -32,11 +32,12 @@ define([
     'layout/generisRouter',
     'layout/actions',
     'layout/section',
+    'layout/permissions',
     'ui/feedback',
     'uri',
     'jquery.tree',
     'lib/jsTree/plugins/jquery.tree.contextmenu'
-], function($, _, __, context, store, Promise, urlUtil, generisRouter, actionManager, sectionManager, feedback, uri){
+], function($, _, __, context, store, Promise, urlUtil, generisRouter, actionManager, sectionManager, permissionsManager, feedback, uri){
     'use strict';
 
     var pageRange = 30;
@@ -70,8 +71,6 @@ define([
         init : function init($container, options){
             var lastOpened;
             var lastSelected;
-            var permissionErrorMessage;
-            var permissions = {};
 
             var moreNode = {
                 data : __('More'),
@@ -170,7 +169,6 @@ define([
                  * @param {String} data.cssClass - the css class for the new node (node-instance or node-class at least).
                  */
                 addnode : function addnode(data) {
-
                     var tree =  $.tree.reference($container);
                     var parentNode = tree.get_node($('#' + uri.encode(data.parent), $container).get(0));
 
@@ -189,7 +187,8 @@ define([
                         async       : tree.settings.data.async,
                         data        : params,
                         success     : function (response) {
-                            var items = response.children ? response.children : response;
+                            var treeData = getTreeData(response);
+                            var items = treeData.children || treeData;
                             var node = _.filter(items, function (child) {
                                 return child.attributes && child.attributes['data-uri'] === data.uri;
                             });
@@ -336,25 +335,26 @@ define([
                      */
                     ondata: function ondata(data) {
 
+                        var treeData;
                         if(data.error){
                             feedback().error(data.error);
                             return [];
                         }
 
+                        treeData = getTreeData(data);
+
                         //automatically open the children of the received node
-                        if (data.children) {
-                            data.state = 'open';
+                        if (treeData.children) {
+                            treeData.state = 'open';
                         }
 
-                        computeSelectionAccess(data);
+                        computeSelectionAccess(treeData);
 
-                        flattenPermissions(data);
+                        needMore(treeData);
 
-                        needMore(data);
+                        addTitle(treeData);
 
-                        addTitle(data);
-
-                        return data;
+                        return treeData;
                     },
 
                     /**
@@ -390,7 +390,7 @@ define([
                             if(lastSelected){
                                 $lastSelected = $('#' +  lastSelected, $container);
                                 if($lastSelected.length && !$lastSelected.hasClass('private')){
-                                    lastSelected = undefined;
+                                    lastSelected = null;
                                     return tree.select_branch($lastSelected);
                                 }
                             }
@@ -453,10 +453,9 @@ define([
                         var $node           = $(node);
                         var classActions = [];
                         var nodeId          = $node.attr('id');
+                        var nodeUri         = $node.data('uri');
                         var $parentNode     = tree.parent($node);
-                        var nodeContext     = permissions[nodeId] ? {
-                            permissions : permissions[nodeId]
-                        } : {};
+                        var nodeContext     =  { };
 
                         //mark all unselected
                         $('a.clicked', $container)
@@ -476,8 +475,7 @@ define([
                                 tree.open_branch($node);
                             }
                             nodeContext.classUri = nodeId;
-                            nodeContext.permissions = permissions[nodeId];
-                            nodeContext.id = $node.data('uri');
+                            nodeContext.id = nodeUri;
                             nodeContext.context = ['class', 'resource'];
 
                             //Check if any class-level action is defined in the structures.xml file
@@ -492,7 +490,7 @@ define([
                         if ($node.hasClass('node-instance')){
                             nodeContext.uri = nodeId;
                             nodeContext.classUri = $parentNode.attr('id');
-                            nodeContext.id = $node.data('uri');
+                            nodeContext.id = nodeUri;
                             nodeContext.context = ['instance', 'resource'];
 
                             //the last selected node is stored
@@ -620,8 +618,12 @@ define([
              */
             function hasAccessTo(actionType, node){
                 var action = options.actions[actionType];
-                if(node && action && node.permissions && typeof node.permissions[action.id] !== 'undefined'){
-                    return !!node.permissions[action.id];
+                if(node && action && node.permissions && action.rights){
+                    return permissionsManager.isContextAllowed(action.rights, {
+                        uri : node.attributes['data-uri'],
+                        classUri : node.attributes['data-classUri'],
+                        id : node.attributes.id
+                    });
                 }
                 return true;
             }
@@ -637,10 +639,8 @@ define([
                     _.forEach(node, computeSelectionAccess);
                     return;
                 }
-                if(node.type && node.permissions){
-                    addClassToNode(node, getPermissionClass(node));
-                }
                 if(node.type){
+                    addClassToNode(node, getPermissionClass(node));
                     if (!hasAccessTo('moveInstance', node)) {
                         addClassToNode(node, 'node-undraggable');
                     }
@@ -657,22 +657,24 @@ define([
              * @returns {String} the CSS class
              */
             function getPermissionClass(node){
-                var actions = _.pluck(_.filter(options.actions, function (val) {
-                    return val.context === node.type || val.context === 'resource';
-                }), 'id');
-                var keys = _.intersection(_.keys(node.permissions), actions);
-                var values = _.filter(node.permissions, function (val, key) {
-                    return _.contains(keys, key);
-                });
-                var containsTrue = _.contains(values, true),
-                    containsFalse = _.contains(values, false);
+                var nodeId = node.attributes['data-uri'];
 
-                if (containsTrue && !containsFalse) {
+                var rights = permissionsManager.getRights();
+                var count    = _.reduce(rights, function(acc, right){
+                    if(permissionsManager.hasPermission(nodeId, right)){
+                        acc++;
+                    }
+                    return acc;
+                }, 0);
+
+                if (rights.length === 0 || count === rights.length) {
                     return 'permissions-full';
-                } else if (containsTrue && containsFalse) {
-                    return 'permissions-partial';
                 }
-                return 'permissions-none';
+                if(count === 0){
+                    return 'permissions-none';
+                }
+
+                return 'permissions-partial';
             }
 
             /**
@@ -690,24 +692,6 @@ define([
                 }
                 if(node.children){
                     _.forEach(node.children, addTitle);
-                }
-            }
-
-            /**
-             * Reads the permissions from tree data to put them into a flat Map as <pre>nodeId : nodePermissions</pre>
-             * @private
-             * @param {Object} node - the tree node as recevied from the server
-             */
-            function flattenPermissions(node){
-                if(_.isArray(node)){
-                    _.forEach(node, flattenPermissions);
-                    return;
-                }
-                if(node.attributes && node.attributes.id){
-                    permissions[node.attributes.id] = node.permissions;
-                }
-                if(node.children){
-                    _.forEach(node.children, flattenPermissions);
                 }
             }
 
@@ -748,11 +732,12 @@ define([
                     async       : tree.settings.data.async,
                     data        : params
                 }).done(function(response){
-                    if(response && _.isArray(response.children)){
-                        response = response.children;
+                    var treeData = getTreeData(response);
+                    if(treeData && _.isArray(treeData.children)){
+                        treeData = treeData.children;
                     }
-                    if(_.isArray(response)){
-                        _.forEach(response, function(newNode){
+                    if(_.isArray(treeData)){
+                        _.forEach(treeData, function(newNode){
                             if(newNode.type === 'instance'){   //yes the server send also the class, even though I ask him gently...
                                 tree.create(newNode, $parentNode);
                             }
@@ -781,23 +766,14 @@ define([
                 if (!_.isArray(exclude)) {
                     exclude = [];
                 }
+
                 possibleActions = _.filter(actions, function (action, name) {
                     var possible = _.contains(nodeContext.context, action.context);
-                    if (context.permissions) {
-                        possible = possible && nodeContext.permissions[action.id];
-                    }
-                    possible = possible && !_.contains(exclude, name);
-                    return possible;
+                    return possible && !_.contains(exclude, name);
                 });
                 //execute the first allowed action
                 if(possibleActions.length > 0){
-                    //hide shown earlier message
-                    if (permissionErrorMessage) {
-                        permissionErrorMessage.close();
-                    }
                     actionManager.exec(possibleActions[0], nodeContext);
-                } else {
-                    permissionErrorMessage = feedback().error(__("You don't have sufficient permissions to access"));
                 }
             }
 
@@ -812,6 +788,33 @@ define([
                         node.attributes['class'] = clazz;
                     }
                 }
+            }
+
+            /**
+             * Parse a response from a request to get the tree data
+             * and extract the permissions if given
+             * @param {Object} response - from a request
+             * @returns {Object} the tree data
+             */
+            function getTreeData(response){
+                var treeData = response.tree || response;
+                var currentRights;
+
+                if(response.permissions){
+                    currentRights = permissionsManager.getRights();
+
+                    if(response.permissions.supportedRights &&
+                        response.permissions.supportedRights.length &&
+                        currentRights.length === 0) {
+
+                        permissionsManager.setSupportedRights(response.permissions.supportedRights);
+
+                    }
+                    if(response.permissions.data){
+                        permissionsManager.addPermissions(response.permissions.data);
+                    }
+                }
+                return treeData;
             }
 
             return setUpTree();

--- a/views/js/test/layout/permissions/test.html
+++ b/views/js/test/layout/permissions/test.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Permission Manager Test</title>
+    <link rel="stylesheet" type="text/css" href="/tao/views/js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="/tao/views/js/lib/require.js"></script>
+    <script type="text/javascript" src="/tao/views/js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="/tao/views/js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="/tao/views/js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="layout/permissions.js"></script>
+    <script type="text/javascript">
+        QUnit.config.autostart = false;
+        require(['/tao/ClientConfig/config'], function () {
+            require(['test/layout/permissions/test'], function () {
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+</body>
+</html>

--- a/views/js/test/layout/permissions/test.js
+++ b/views/js/test/layout/permissions/test.js
@@ -1,0 +1,283 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ */
+/**
+ * Test the module {@link layout/permissions}
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([
+    'layout/permissions'
+], function (permissionsManager) {
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('module export', function (assert) {
+        QUnit.expect(1);
+
+        assert.ok(typeof permissionsManager === 'object', 'The module exports an object');
+    });
+
+    QUnit.cases([
+        {title: 'setSupportedRights'},
+        {title: 'getRights'},
+        {title: 'isSupported'},
+        {title: 'getPermissions'},
+        {title: 'hasPermission'},
+        {title: 'clear'},
+        {title: 'isContextAllowed'},
+    ])
+    .test('Instance API', function (data, assert) {
+        QUnit.expect(1);
+        assert.ok(typeof permissionsManager[data.title] === 'function', 'The permissionsManager exposes the method ' + data.title);
+    });
+
+
+    QUnit.module('rights');
+
+    QUnit.test('supported', function(assert){
+
+        QUnit.expect(10);
+
+        assert.deepEqual(permissionsManager.getRights(), [], 'No supported rights by default');
+        assert.ok( ! permissionsManager.isSupported('r'));
+        assert.ok( ! permissionsManager.isSupported('w'));
+        assert.ok( ! permissionsManager.isSupported('x'));
+        assert.ok( ! permissionsManager.isSupported('y'));
+
+        permissionsManager.setSupportedRights(['r', 'w', 'x']);
+
+        assert.deepEqual(permissionsManager.getRights(), ['r', 'w', 'x'], 'New supported rights');
+        assert.ok(permissionsManager.isSupported('r'));
+        assert.ok(permissionsManager.isSupported('w'));
+        assert.ok(permissionsManager.isSupported('x'));
+        assert.ok( ! permissionsManager.isSupported('y'));
+    });
+
+
+    QUnit.module('Permissions', {
+        setup: function setup(){
+            permissionsManager.setSupportedRights(['READ', 'WRITE', 'GRANT']);
+        },
+        teardown : function teardown(){
+            permissionsManager.setSupportedRights([]);
+        }
+    });
+
+    QUnit.test('add and get one resource permissions', function(assert){
+        var uri = 'http://foo.bar/a';
+
+        QUnit.expect(4);
+
+        assert.equal(typeof permissionsManager.getPermissions(uri), 'undefined', 'No permissions set for the resource');
+
+        permissionsManager.addPermissions(uri, ['READ', 'WRITE']);
+
+        assert.deepEqual(permissionsManager.getPermissions(uri), ['READ', 'WRITE'], 'Permissions are set for the resource');
+
+        permissionsManager.addPermissions(uri, []);
+
+        assert.deepEqual(permissionsManager.getPermissions(uri), [], 'No permissions set for the resource anymore');
+
+        permissionsManager.addPermissions(uri, ['GRANT', 'FOO']);
+
+        assert.deepEqual(permissionsManager.getPermissions(uri), ['GRANT'], 'Valid permissions only are kept');
+    });
+
+    QUnit.test('add and get multiple permissions', function(assert){
+        var permissions = {
+            'http://foo.bar/b' : ['READ', 'WRITE', 'GRANT'],
+            'http://foo.bar/c' : ['READ'],
+            'http://foo.bar/d' : ['FOO', 'BAR', 'WRITE'],
+            'http://foo.bar/e' : []
+        };
+
+        QUnit.expect(8);
+
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/b'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/c'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/d'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/e'), 'undefined', 'No permissions set for the resource');
+
+        permissionsManager.addPermissions(permissions);
+
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/b'), ['READ', 'WRITE', 'GRANT'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/c'), ['READ'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/d'), ['WRITE'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/e'), [], 'Permissions set for the resource');
+    });
+
+    QUnit.test('clear permissions', function(assert){
+        var permissions = {
+            'http://foo.bar/f' : ['READ', 'WRITE', 'GRANT'],
+            'http://foo.bar/g' : ['READ'],
+        };
+
+        QUnit.expect(6);
+
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/f'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/g'), 'undefined', 'No permissions set for the resource');
+
+        permissionsManager.addPermissions(permissions);
+
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/f'), ['READ', 'WRITE', 'GRANT'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/g'), ['READ'], 'Permissions set for the resource');
+
+        permissionsManager.clear();
+
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/f'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/g'), 'undefined', 'No permissions set for the resource');
+    });
+
+    QUnit.test('has permissions', function(assert){
+        var permissions = {
+            'http://foo.bar/i' : ['READ', 'WRITE', 'GRANT'],
+            'http://foo.bar/j' : ['READ', 'WRITE'],
+            'http://foo.bar/k' : ['READ'],
+            'http://foo.bar/l' : [],
+        };
+
+        QUnit.expect(23);
+
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/i'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/j'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/k'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/l'), 'undefined', 'No permissions set for the resource');
+
+        permissionsManager.addPermissions(permissions);
+
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/i'), ['READ', 'WRITE', 'GRANT'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/j'), ['READ', 'WRITE'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/k'), ['READ'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/l'), [], 'Permissions set for the resource');
+
+
+        assert.ok(permissionsManager.hasPermission('http://foo.bar/i', 'READ'));
+        assert.ok(permissionsManager.hasPermission('http://foo.bar/i', 'WRITE'));
+        assert.ok(permissionsManager.hasPermission('http://foo.bar/i', 'GRANT'));
+
+        assert.ok(permissionsManager.hasPermission('http://foo.bar/j', 'READ'));
+        assert.ok(permissionsManager.hasPermission('http://foo.bar/j', 'WRITE'));
+        assert.ok( ! permissionsManager.hasPermission('http://foo.bar/j', 'GRANT'));
+
+        assert.ok(permissionsManager.hasPermission('http://foo.bar/k', 'READ'));
+        assert.ok( ! permissionsManager.hasPermission('http://foo.bar/k', 'WRITE'));
+        assert.ok( ! permissionsManager.hasPermission('http://foo.bar/k', 'GRANT'));
+
+        assert.ok( ! permissionsManager.hasPermission('http://foo.bar/l', 'READ'));
+        assert.ok( ! permissionsManager.hasPermission('http://foo.bar/l', 'WRITE'));
+        assert.ok( ! permissionsManager.hasPermission('http://foo.bar/l', 'GRANT'));
+
+        assert.ok( ! permissionsManager.hasPermission('http://foo.bar/z', 'READ'));
+        assert.ok( ! permissionsManager.hasPermission('http://foo.bar/z', 'WRITE'));
+        assert.ok( ! permissionsManager.hasPermission('http://foo.bar/z', 'GRANT'));
+    });
+
+    QUnit.module('Action and context', {
+        setup: function setup(){
+            permissionsManager.setSupportedRights(['READ', 'WRITE', 'GRANT']);
+        },
+        teardown : function teardown(){
+            permissionsManager.setSupportedRights([]);
+        }
+    });
+
+
+    QUnit.cases([{
+        title : 'allowed for a read action',
+        requiredRights : { id : 'READ'},
+        context : {
+            id : 'http://foo.bar/o'
+        },
+        allowed : true
+    }, {
+        title : 'denied for a read action',
+        requiredRights : { id : 'READ'},
+        context : {
+            id : 'http://foo.bar/p'
+        },
+        allowed : false
+    }, {
+        title : 'denied for a missing parameter',
+        requiredRights : { id : 'READ'},
+        context : {
+            uri : 'http://foo.bar/p'
+        },
+        allowed : false
+    }, {
+        title : 'denied for a wrong parameter',
+        requiredRights : { id : 'READ'},
+        context : {
+            uri : 'http://foo.bar/z'
+        },
+        allowed : false
+    }, {
+        title : 'denied for an empty context',
+        requiredRights : { id : 'READ'},
+        context : null,
+        allowed : false
+    }, {
+        title : 'allowed for a READ/WRITE action',
+        requiredRights : { id : 'READ', classUri: 'WRITE'},
+        context : {
+            id : 'http://foo.bar/m',
+            classUri: 'http://foo.bar/n',
+        },
+        allowed : true
+    }, {
+        title : 'denied for a READ/WRITE action',
+        requiredRights : { id : 'READ', classUri: 'WRITE'},
+        context : {
+            id : 'http://foo.bar/m',
+            classUri: 'http://foo.bar/o',
+        },
+        allowed : false
+    }, {
+        title : 'allowed for empty rights',
+        requiredRights : { },
+        context : {
+            id : 'http://foo.bar/m',
+            classUri: 'http://foo.bar/n',
+        },
+        allowed : true
+    }]).test('is context ', function(data, assert){
+        var permissions = {
+            'http://foo.bar/m' : ['READ', 'WRITE', 'GRANT'],
+            'http://foo.bar/n' : ['READ', 'WRITE'],
+            'http://foo.bar/o' : ['READ'],
+            'http://foo.bar/p' : [],
+        };
+
+        QUnit.expect(9);
+
+        permissionsManager.clear();
+
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/m'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/n'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/o'), 'undefined', 'No permissions set for the resource');
+        assert.equal(typeof permissionsManager.getPermissions('http://foo.bar/p'), 'undefined', 'No permissions set for the resource');
+
+        permissionsManager.addPermissions(permissions);
+
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/m'), ['READ', 'WRITE', 'GRANT'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/n'), ['READ', 'WRITE'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/o'), ['READ'], 'Permissions set for the resource');
+        assert.deepEqual(permissionsManager.getPermissions('http://foo.bar/p'), [], 'Permissions set for the resource');
+
+        assert.equal( permissionsManager.isContextAllowed(data.requiredRights, data.context), data.allowed);
+    });
+});

--- a/views/templates/blocks/actions.tpl
+++ b/views/templates/blocks/actions.tpl
@@ -8,7 +8,8 @@ use oat\tao\helpers\Layout;
         title="<?= __($action->getName()) ?>"
         data-context="<?= $action->getContext() ?>"
         data-action="<?= $action->getBinding() ?>"
-        data-multiple="<?= $action->isMultiple() ? 'true' : 'false' ?>">
+        data-multiple="<?= $action->isMultiple() ? 'true' : 'false' ?>"
+        data-rights='<?= json_encode($action->getRequiredRights()) ?>' >
         <a class="li-inner" href="<?= $action->getUrl(); ?>">
             <?= Layout::renderIcon( $action->getIcon(), ' icon-magicwand'); ?> <?= __($action->getName()) ?>
         </a>


### PR DESCRIPTION
### In order to manage permissions on the client side with more diligence I've inverted the model.

The current implementation for each resource loads the access for each action (does a resource can access to move, duplicate, etc.). This could be good but doesn't offer enough granularity on permission (you know you can't select a resource but you don't know why) and it requires to query ACLs each actions for each resources. 

#### Here's what I propose : 

 1. Each action comes with it's requirement (the _requiredRights_). For example the _delete_ action comes with the required rights `WRITE` on the resource `id`. So we load  then _requiredRights_ once per action. 
 2. When retrieving the resources, we load the permissions of the resources (for example, this resource has the 'WRITE' permission, that one has `READ`, etc.)
3. For performance reasons, we query the permissions engine only once per HTTP request, with the list of URIs to get the permissions. It's the reason why the request to `getOntologyData` returns now 2 sub entries : 
    - `tree` which contains the tree data
    - `permissions` which contains the permissions data. 
Please note the new format is optional so you can still use the old one.
 4. A _permission manager_  (module `layout/permissions`) does the matching client side to know who can access what.
 5. The list of supported rights is dynamic. 
    - By default, if the permission implementation doesn't provide supported rights, it's then free access to everybody (this is the case for a vanilla TAO). So no permission check nor permissions data in that situation. 
    - If supported rights are defined (this is the case when installing `taoDacSimple`) we load the permissions and check them. 


#### Code considerations : 

Only the jstree benefits for now of this change, the resource selector will be modified in a further PR.

There's also a weird dependency between tao, taoBackOffice and taoDacSimple to have the `MenuAction` modified (the interface belongs to taoBackOffice). 

#### Companion PRs

 - [ ] https://github.com/oat-sa/extension-tao-backoffice/pull/39
 - [ ] https://github.com/oat-sa/extension-tao-dac-simple/pull/59