### PR TITLE
Split class edition and property management

### DIFF
--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -57,7 +57,7 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
                     $this->getEventManager()->trigger(new ClassFormUpdatedEvent($clazz, $properties));
                 }
                 $this->setData('message', __('%s Class saved', $clazz->getLabel()));
-                $this->setData('reload', true);
+                $this->setData('reload', false);
             }
         }
         $this->setData('formTitle', __('Edit class %s', $clazz->getLabel()));

--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -31,6 +31,7 @@ use oat\tao\helpers\ControllerHelper;
 use oat\tao\model\security\xsrf\TokenService;
 use oat\tao\model\TaoOntology;
 use oat\tao\model\resources\ResourceService;
+use oat\generis\model\OntologyRdfs;
 
 /**
  * The TaoModule is an abstract controller,
@@ -337,6 +338,31 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule {
     }
 
     /**
+     * Common action to view and change the label of a class
+     */
+    public function editClassLabel()
+    {
+        $clazz = $this->getCurrentClass();
+
+        $editClassLabelForm = new \tao_actions_form_EditClassLabel($clazz,  $this->getRequestParameters());
+        $myForm = $editClassLabelForm->getForm();
+
+        if ($myForm->isSubmited()) {
+            if ($myForm->isValid()) {
+                $clazz->setLabel($myForm->getValue(\tao_helpers_Uri::encode(OntologyRdfs::RDFS_LABEL)));
+
+                $this->setData("selectNode", \tao_helpers_Uri::encode($clazz->getUri()));
+                $this->setData('message', __('%s Class saved', $clazz->getLabel()));
+                $this->setData('reload', true);
+            }
+        }
+
+        $this->setData('formTitle', __('Edit class %s', $clazz->getLabel()));
+        $this->setData('myForm', $myForm->render());
+        $this->setView('form.tpl', 'tao');
+    }
+
+    /**
      * Add an instance of the selected class
      * @requiresRight id WRITE
      * @return void
@@ -456,7 +482,6 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule {
         $this->setData('myForm', $myForm->render());
         $this->setView('form.tpl', 'tao');
     }
-
 
     /**
      * Duplicate the current instance

--- a/actions/form/class.EditClassLabel.php
+++ b/actions/form/class.EditClassLabel.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+use oat\generis\model\GenerisRdf;
+use oat\generis\model\OntologyRdfs;
+
+/**
+ *
+ * This form let's you edit the label of a class, only.
+ *
+ * @author Bertrand Chevrier, <bertrand@taotesting.com>
+ */
+class tao_actions_form_EditClassLabel
+    extends \tao_helpers_form_FormContainer
+{
+    /**
+     * @var core_kernel_classes_Class
+     */
+    protected $clazz;
+
+
+    /**
+     * @param core_kernel_classes_Class $clazz
+     * @param array $classData
+     * @param array $propertyData
+     * @param string $propertyMode
+     */
+    public function __construct( \core_kernel_classes_Class $clazz, $classData )
+    {
+        $this->clazz = $clazz;
+        parent::__construct($classData);
+    }
+
+    /**
+     * Class instance being authored
+     *
+     * @return core_kernel_classes_Class
+     */
+    protected function getClassInstance()
+    {
+        return $this->clazz;
+    }
+
+    /**
+     * Initialize the form
+     *
+     * @access protected
+     * @author Bertrand Chevrier, <bertrand.chevrier@tudor.lu>
+     * @return mixed
+     */
+    protected function initForm()
+    {
+        (isset($this->options['name'])) ? $name = $this->options['name'] : $name = '';
+        if (empty($name)) {
+            $name = 'form_' . (count(self::$forms) + 1);
+        }
+        unset($this->options['name']);
+
+        $this->form = \tao_helpers_form_FormFactory::getForm($name, $this->options);
+
+
+        $this->form->setActions(\tao_helpers_form_FormFactory::getCommonActions(), 'bottom');
+    }
+
+    /**
+     * Initialize the form elements
+     *
+     * @access protected
+     * @author Bertrand Chevrier, <bertrand.chevrier@tudor.lu>
+     * @return mixed
+     */
+    protected function initElements()
+    {
+        $clazz = $this->getClassInstance();
+
+        $labelProp = new \core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL);
+        //map properties widgets to form elements
+        $element = \tao_helpers_form_GenerisFormFactory::elementMap($labelProp);
+        if (!is_null($element)) {
+
+            $value = $clazz->getLabel();
+            if (!is_null($value)) {
+                $element->setValue($value);
+            }
+            //set label validator
+            $element->addValidators([
+                \tao_helpers_form_FormFactory::getValidator('NotEmpty'),
+            ]);
+            $namespace = substr($clazz->getUri(), 0, strpos($clazz->getUri(), '#'));
+            if ($namespace != LOCAL_NAMESPACE) {
+                $readonly = \tao_helpers_form_FormFactory::getElement($element->getName(), 'Readonly');
+                $readonly->setDescription($element->getDescription());
+                $readonly->setValue($element->getRawValue());
+                $element = $readonly;
+            }
+            $element->addClass('global');
+            $this->form->addElement($element);
+        }
+
+        //add an hidden elt for the class uri
+        $classUriElt = \tao_helpers_form_FormFactory::getElement('classUri', 'Hidden');
+        $classUriElt->setValue(\tao_helpers_Uri::encode($clazz->getUri()));
+        $classUriElt->addClass('global');
+        $this->form->addElement($classUriElt);
+
+        $hiddenId = tao_helpers_form_FormFactory::getElement('id', 'Hidden');
+        $hiddenId->setValue($clazz->getUri());
+        $hiddenId->addClass('global');
+        $this->form->addElement($hiddenId);
+    }
+
+}

--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '17.0.0',
+    'version' => '17.1.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=6.7.0'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1084,6 +1084,8 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('17.0.0');
         }
+
+        $this->skip('17.0.0', '17.1.0');
     }
 
     private function migrateFsAccess() {


### PR DESCRIPTION
**TRIAL VERSION - PLEASE MERGE ONLY WHEN ALL EXTENSIONS REQUESTS ARE DONE**

As seen with @ssipasseuth we will split the class edition in two actions : 
1. Edit class (by clicking a class in the tree or the action "edit class") is limited to the class label
2. "Manage class properties"  is a separate action that displays the complete form to manage the class properties
This split matches the use cases : 
  - the main use case is to update the name of the class, done very often 
  - change the metadata, less often 

Needs extensions PRs to be tested (to switch the actions)
  