### PR TITLE
Fix/tao 5988 clear test db for old impl

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '17.1.1',
+    'version' => '17.1.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=6.7.0'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1085,7 +1085,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('17.0.0');
         }
 
-        $this->skip('17.0.0', '17.1.1');
+        $this->skip('17.0.0', '17.1.2');
 
     }
 

--- a/views/js/core/store/indexeddb.js
+++ b/views/js/core/store/indexeddb.js
@@ -55,6 +55,12 @@ define([
     var idStoreName = 'id';
 
     /**
+     * Check if we're using the v2 of IndexedDB
+     * @type {Boolean}
+     */
+    var isIndexedDB2 = 'getAll' in IDBObjectStore.prototype;
+
+    /**
      * Opens a store
      * @returns {Promise} with store instance in resolve
      */
@@ -209,7 +215,13 @@ define([
                     })
                     .catch(reject);
             };
-            store.deleteDatabase(success, reject);
+            //with old implementation, deleting a store is
+            //either unsupported or buggy
+            if(isIndexedDB2){
+                store.deleteDatabase(success, reject);
+            } else {
+                store.clear(success, reject);
+            }
         });
     };
 


### PR DESCRIPTION
To prevent db requests in "blocked" state in IE (or even all other old implementations), we clear the store instead of removing it.