### PR TITLE
Fix/tao 5939 fix store boolean

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '17.3.0',
+    'version' => '17.3.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=6.7.0'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1084,8 +1084,8 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('17.0.0');
         }
-        
-        $this->skip('17.0.0', '17.3.0');
+
+        $this->skip('17.0.0', '17.3.1');
     }
 
     private function migrateFsAccess() {

--- a/views/js/core/store/indexeddb.js
+++ b/views/js/core/store/indexeddb.js
@@ -115,7 +115,7 @@ define([
     var getEntry = function getEntry(store, key) {
         return new Promise(function(resolve, reject) {
             var success = function success(entry) {
-                if (!entry || !entry.value) {
+                if (!entry || typeof entry.value === 'undefined') {
                     return resolve(entry);
                 }
 

--- a/views/js/test/core/store/indexeddb/test.js
+++ b/views/js/test/core/store/indexeddb/test.js
@@ -245,6 +245,36 @@ define(['core/store/indexeddb', 'core/promise'], function(indexedDbBackend, Prom
         });
     });
 
+    QUnit.asyncTest("get/set booleans", function(assert){
+        var store;
+
+        QUnit.expect(5);
+
+        store = indexedDbBackend('foo');
+        assert.equal(typeof store, 'object', 'The store is an object');
+
+        store.setItem('true', true)
+            .then(function(added){
+                assert.ok(added, 'The item is added');
+                return store.getItem('true');
+            })
+            .then(function(result){
+                assert.equal(result, true);
+                return store.setItem('false', false);
+            })
+            .then(function(added){
+                assert.ok(added, 'The item is added');
+                return store.getItem('false');
+            })
+            .then(function(result){
+                assert.equal(result, false);
+                QUnit.start();
+            }).catch(function(err){
+                assert.ok(false, err);
+                QUnit.start();
+            });
+    });
+
     QUnit.asyncTest("getItems", function(assert){
         var store;
 


### PR DESCRIPTION
Somehow linked to TAO-5939 (where I store a boolean)

This PR fixes the following behavior  : 

`store.setItem('something', true)`
`store.getItem('something').then( console.log )` prints `true`
`store.setItem('something', false)`
`store.getItem('something').then( console.log )` prints `{ key : 'something', value : false}`

