### PR TITLE
Fix/tao 6044 prevent error volume

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '17.4.0',
+    'version' => '17.4.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=6.7.0'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1084,8 +1084,8 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('17.0.0');
         }
-        
-        $this->skip('17.0.0', '17.4.0');
+
+        $this->skip('17.0.0', '17.4.1');
     }
 
     private function migrateFsAccess() {

--- a/views/js/ui/mediaplayer.js
+++ b/views/js/ui/mediaplayer.js
@@ -1725,8 +1725,10 @@ define([
                     }
 
                     //close the volume control after 15s
-                    _.delay(function(){
-                        self.$volumeControl.removeClass('up down');
+                    self.overingTimer = _.delay(function(){
+                        if(self.$volumeControl){
+                            self.$volumeControl.removeClass('up down');
+                        }
                         overing = false;
                     }, 15000);
                     self.$volumeControl.one('mouseleave' + _ns, function(){
@@ -1747,6 +1749,12 @@ define([
             this.$controls.off(_ns);
             this.$seek.off(_ns);
             this.$volume.off(_ns);
+
+            //if the volume is opened and the player destroyed,
+            //prevent the callback to run
+            if(this.overingTimer){
+                clearTimeout(this.overingTimer);
+            }
 
             $(document).off(_ns);
         },


### PR DESCRIPTION
The media player produces an error when in the following situation : 
 - open the volume control 
 - destroy the player in the following 15s

It's easy to reproduce on a test, by moving to the next item just after having opened the volume control.
