### PR TITLE
Fix/hidden errors

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'label' => 'Tao base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '17.4.0',
+    'version' => '17.4.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=6.7.0'

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1085,7 +1085,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('17.0.0');
         }
         
-        $this->skip('17.0.0', '17.4.0');
+        $this->skip('17.0.0', '17.4.1');
     }
 
     private function migrateFsAccess() {

--- a/views/js/core/eventifier.js
+++ b/views/js/core/eventifier.js
@@ -390,6 +390,9 @@ define([
                 }
 
                 function logHandlerStop(stoppedIn, event, err) {
+                    if(err instanceof Error){
+                        logger.error(err);
+                    }
                     logger.trace({ err: err, event: event.name, stoppedIn: stoppedIn }, event.name + ' handlers stopped');
                 }
 


### PR DESCRIPTION
This PR logs error that can be hidden when using the rejection on events.

For example, we use `Promise.reject` to interrupt an event : 

```js
emitter
.before('foo', function(){
    return Promise.reject();
})
.on('foo', function(){
    //won't be called
})
.trigger('foo');
```

Then if a runtime error is raised inside the promise chains, the promise rejects. The event is interupted but the error is never shown. 
This PR logs the error when the rejection contains an `Error`  : 

#### Nothing logged, interruption normal case

```js
emitter
.before('foo', function(){
    return Promise.reject();
})
.on('foo', function(){
    //won't be called
})
.trigger('foo');
```

#### An error is thrown by the developers, the error is logged

```js
emitter
.before('foo', function(){
    return Promise.reject(new TypeError('Something wen wrong');
})
.on('foo', function(){
    //won't be called
})
.trigger('foo');
```

#### A runtime error occurs, the error is logged

 ```js
var runtimeError = function(){
      return new Promise(function(resolve){
           foo.bar = baz;   //throw a TypeError  
           resolve(foo);
     });
}

emitter
.before('foo', function(){
    return runtimeError();
})
.on('foo', function(){
    //won't be called
})
.trigger('foo');
```