### PR TITLE
Fix/tao 6308 fix tree more button

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '19.0.1',
+    'version' => '19.0.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -773,7 +773,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('18.8.0');
         }
 
-        $this->skip('18.8.0', '19.0.1');
+        $this->skip('18.8.0', '19.0.2');
     }
 
 }

--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -755,7 +755,7 @@ define([
                         });
                         tree.deselect_branch($node);
                         tree.remove($node);
-                        if(left - response.length > 0){
+                        if(left - treeData.length > 0){
                             tree.create(moreNode, $parentNode);
                         }
                     }


### PR DESCRIPTION
### Environment 

Any TAO instance, develop.

### How to reproduce the bug 

 - On any extension that have a tree (items for example),
 - Create a Class
 - Create/Import at least 61 resources under that class
 - Select a resource outside that class 
 - Refresh your browser
 - Open the class
 - click the _More_ button

:arrow_right: The _More_ button doesn't appear anymore even if all resources aren't yet displayed
