### PR TITLE
Fix/tao 6322 fix failing tests

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,7 +43,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '19.2.0',
+    'version' => '19.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -772,7 +772,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('18.8.0');
         }
 
-        $this->skip('18.8.0', '19.2.0');
+        $this->skip('18.8.0', '19.2.1');
     }
 
 }

--- a/views/js/test/core/dataProvider/request/test.js
+++ b/views/js/test/core/dataProvider/request/test.js
@@ -144,7 +144,7 @@ define([
         title : '200 error fallback',
         url : '//200/error/fallback',
         reject : true,
-        err : new Error('No response')
+        err : new Error('The server has sent an empty response')
     }];
 
     QUnit

--- a/views/js/test/ui/resource/selectable/test.js
+++ b/views/js/test/ui/resource/selectable/test.js
@@ -38,6 +38,9 @@ define([
         trigger: noop,
         getElement : function(){
             return $('#qunit-fixture .component');
+        },
+        getConfig : function(){
+            return {};
         }
     };
     var nodesMock = [

--- a/views/js/test/ui/tableModel/test.html
+++ b/views/js/test/ui/tableModel/test.html
@@ -12,7 +12,7 @@
     <script type="text/javascript">
         QUnit.config.autostart = false;
         require(['/tao/ClientConfig/config'], function () {
-            require(['tao/test/ui/TableModel/test'], function () {
+            require(['tao/test/ui/tableModel/test'], function () {
                 QUnit.start();
             });
         });


### PR DESCRIPTION
 Fix the failing unit test. 
We had a case issue in the module to load, a mock to update to comply with the mocked API, and an updated error message not changed in the test ( see https://github.com/oat-sa/tao-core/commit/78ca3f1bea8f7ea6f17e00cc627856a69d555f97#diff-55663eacffddd3217253f3da541a3dabR96) 