### PR TITLE
Fix/tao 6385 cancel promises in action manager

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '19.11.2',
+    'version' => '19.11.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -822,7 +822,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('19.10.0');
         }
 
-        $this->skip('19.10.0', '19.11.2');
+        $this->skip('19.10.0', '19.11.3');
 
     }
 

--- a/views/js/layout/actions.js
+++ b/views/js/layout/actions.js
@@ -262,6 +262,9 @@ define([
                         self.trigger(events.join(' '), context || resourceContext, actionData);
                     })
                     .catch( function actionError(err){
+                        if(err && err.cancel){
+                            return self.trigger('cancel', action.id);
+                        }
                         self.trigger('error', err);
                     });
             }

--- a/views/js/layout/actions/common.js
+++ b/views/js/layout/actions/common.js
@@ -270,7 +270,9 @@ define([
                             reject(httpErrorParser.parse(xhr, options, err));
                         }
                     });
-                }, reject);
+                }, function cancel(){
+                    reject({ cancel : true });
+                });
             });
         });
 
@@ -342,7 +344,9 @@ define([
                             reject(httpErrorParser.parse(xhr, options, err));
                         }
                     });
-                }, reject);
+                }, function cancel(){
+                    reject({ cancel : true });
+                });
             });
         });
 

--- a/views/js/test/layout/actions/manager/commonActionsMock.js
+++ b/views/js/test/layout/actions/manager/commonActionsMock.js
@@ -1,0 +1,28 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 Open Assessment Technologies SA;
+ */
+
+/**
+ * Mock of {@link layout/actions/common}
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define([], function() {
+    'use strict';
+
+    return  function(){};
+});

--- a/views/js/test/layout/actions/manager/test.html
+++ b/views/js/test/layout/actions/manager/test.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Layout Test - Action Manager</title>
+    <base href="../../../../../" />
+    <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+    <script type="text/javascript" src="js/lib/require.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+    <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
+    <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="layout/actions.js"></script>
+    <script type="text/javascript">
+        //don't start the test now
+        QUnit.config.autostart = false;
+
+        //load the config
+        require(['/tao/ClientConfig/config'], function(){
+
+            //inject mocks
+            require.config({
+                paths: {
+                    'layout/actions/common': 'test/layout/actions/manager/commonActionsMock'
+                }
+            });
+
+            //load the test
+            require(['test/layout/actions/manager/test'], function() {
+                //Tests loaded, run tests
+                QUnit.start();
+            });
+        });
+    </script>
+</head>
+
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+        <ul class="action-bar">
+            <li class="action" id="foo-new" title="New Foo" data-context="resource" data-action="addFoo" data-multiple="false" data-rights='{"id":"WRITE"}'>
+                <a href="https://foo.org/taoFoo/Foo/new">New Foo</a>
+            </li>
+            <li class="action hidden" id="foo-delete" title="Delete" data-context="instance" data-action="removeFoo" data-multiple="false" data-rights='{"id":"WRITE"}'>
+                <a href="https://foo.org/taoFoo/Foo/delete">Delete</a>
+            </li>
+            <li class="action disabled" id="foo-special" title="Special" data-context="class" data-action="special" data-multiple="false" data-rights='{}'>
+                <a href="https://foo.org/taoFoo/Foo/special">Special</a>
+            </li>
+        </ul>
+    </div>
+</body>
+
+</html>

--- a/views/js/test/layout/actions/manager/test.html
+++ b/views/js/test/layout/actions/manager/test.html
@@ -40,7 +40,7 @@
             <li class="action" id="foo-new" title="New Foo" data-context="resource" data-action="addFoo" data-multiple="false" data-rights='{"id":"WRITE"}'>
                 <a href="https://foo.org/taoFoo/Foo/new">New Foo</a>
             </li>
-            <li class="action hidden" id="foo-delete" title="Delete" data-context="instance" data-action="removeFoo" data-multiple="false" data-rights='{"id":"WRITE"}'>
+            <li class="action hidden" id="foo-delete" title="Delete" data-context="instance" data-action="deleteFoo" data-multiple="false" data-rights='{"id":"WRITE"}'>
                 <a href="https://foo.org/taoFoo/Foo/delete">Delete</a>
             </li>
             <li class="action disabled" id="foo-special" title="Special" data-context="class" data-action="special" data-multiple="false" data-rights='{}'>

--- a/views/js/test/layout/actions/manager/test.js
+++ b/views/js/test/layout/actions/manager/test.js
@@ -1,0 +1,163 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technlogies SA
+ *
+ */
+
+/**
+ * Test the module {@link layout/actions}
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+define(['jquery', 'layout/actions', 'layout/actions/binder'], function($, actionsManager, binder){
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('module', function(assert){
+        assert.ok(typeof actionsManager === 'object', 'The module expose a plain object');
+    });
+
+    QUnit.cases([
+        { title : 'on' },
+        { title : 'off' },
+        { title : 'trigger' },
+        { title : 'before' },
+        { title : 'after' },
+    ]).test('Eventifier API ', function(data, assert) {
+        assert.equal(typeof actionsManager[data.title], 'function', 'The module exposes the eventifier method "' + data.title);
+    });
+
+    QUnit.cases([
+        { title : 'init' },
+        { title : 'updateState' },
+        { title : 'updateContext' },
+        { title : 'exec' },
+        { title : 'getBy' },
+    ]).test('Instance API ', function(data, assert) {
+        assert.equal(typeof actionsManager[data.title], 'function', 'The module exposes the method "' + data.title + '"');
+    });
+
+    QUnit.module('Behavior');
+
+    QUnit.test('Load actions and update context', function(assert){
+
+        QUnit.expect(10);
+
+        assert.equal(actionsManager.getBy('foo-new'), null, 'The foo-new action is not bound');
+        assert.equal(actionsManager.getBy('foo-delete'), null, 'The foo-delete action is not bound');
+        assert.equal(actionsManager.getBy('foo-special'), null, 'The foo-special action is not bound');
+
+        actionsManager.init($('#qunit-fixture'));
+
+        assert.deepEqual(actionsManager.getBy('foo-new'), {
+            id      : 'foo-new',
+            name    : 'New Foo',
+            binding : 'addFoo',
+            url     : 'https://foo.org/taoFoo/Foo/new',
+            context : 'resource',
+            multiple : false,
+            rights  : { id : 'WRITE'},
+            state : {
+                disabled    : false,
+                hidden      : true,
+                active      : false
+            }
+        }, 'The foo-new action is now bound');
+        assert.deepEqual(actionsManager.getBy('foo-delete'), {
+            id      : 'foo-delete',
+            name    : 'Delete',
+            binding : 'removeFoo',
+            url     : 'https://foo.org/taoFoo/Foo/delete',
+            context : 'instance',
+            multiple : false,
+            rights  : { id : 'WRITE'},
+            state : {
+                disabled    : false,
+                hidden      : true,
+                active      : false
+            }
+        }, 'The foo-delete action is now bound');
+        assert.deepEqual(actionsManager.getBy('foo-special'), {
+            id      : 'foo-special',
+            name    : 'Special',
+            binding : 'special',
+            url     : 'https://foo.org/taoFoo/Foo/special',
+            context : 'class',
+            multiple : false,
+            rights  : { },
+            state : {
+                disabled    : true,
+                hidden      : true,
+                active      : false
+            }
+        }, 'The foo-special action is now bound');
+
+        actionsManager.updateContext({
+            type : 'instance',
+            uri  : 'https://foo.org/Foo#123'
+        });
+
+        assert.equal(actionsManager.getBy('foo-new').state.hidden, false, 'The new action is now visible');
+        assert.equal(actionsManager.getBy('foo-delete').state.hidden, false, 'The delete action is now visible');
+        assert.equal(actionsManager.getBy('foo-special').state.hidden, true, 'The special action is not visible');
+        assert.equal(actionsManager.getBy('foo-special').state.disabled, true, 'The special action remains disabled');
+    });
+
+    QUnit.asyncTest('execute an action', function(assert){
+        var context = {
+            type : 'instance',
+            uri  : 'https://foo.org/Foo#123'
+        };
+
+        QUnit.expect(3);
+
+        binder.register('addFoo', function(receivedContext){
+
+            assert.deepEqual(this, {
+                id      : 'foo-new',
+                name    : 'New Foo',
+                binding : 'addFoo',
+                url     : 'https://foo.org/taoFoo/Foo/new',
+                context : 'resource',
+                multiple : false,
+                rights  : { id : 'WRITE'},
+                state : {
+                    disabled    : false,
+                    hidden      : false,
+                    active      : true
+                }
+            }, 'The executed action has the actionContext as lexical scope');
+            assert.deepEqual(context, receivedContext, 'The received context matches the current');
+            return new Promise( function(resolve){
+                setTimeout(resolve, 10);
+            });
+        });
+
+        actionsManager.init($('#qunit-fixture'));
+        actionsManager.updateContext(context);
+
+        actionsManager.exec('foo-new')
+            .then(function(){
+                assert.ok(true, 'exec resolves once the action is done');
+                QUnit.start();
+            })
+            .catch(function(err){
+                assert.ok(false, err.message);
+                QUnit.start();
+            });
+    });
+});


### PR DESCRIPTION
**Context :** 
Some actions where rejecting their promise on "cancel", but when the error displaying has been added from the `catch` clause, the canceling was caught  as an error.

**How to test :** 
 - Backoffice
 - Call the "delete" action from a class or a resource
 - Cancel when the confirmation popup opens

**Fix content**
 - use the agreed cancellation format : `Promise.reject({cancel : true });`
 - Added the unit test for the action manager with minimal feature tests (`init` and `updateContext`) even if out of scope
 - Added unit tests for actions executions (ok, cancel and fail)
 - Added the `cancel` event since it could be useful
