### PR TITLE
Fix version of extension installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 	"require" : {
 		"php" : ">=5.5",
 		"phpdocumentor/reflection-docblock" : "2.*",
-		"oat-sa/oatbox-extension-installer" : "dev-master",
+		"oat-sa/oatbox-extension-installer" : "~1.1||dev-master",
 		"oat-sa/extension-builder": "^0.1",
 		"phpmailer/phpmailer" : "dev-master",
 		"oat-sa/jig" : "~0.1",


### PR DESCRIPTION
In order to raise the minimum-stability of a tao install, we need to be able to install the extension installer in a released version. To this end all extensions need to move from "oat-sa/oatbox-extension-installer:dev-master" to "oat-sa/oatbox-extension-installer:~1.1||dev-master". Details: https://oat-sa.atlassian.net/browse/TAO-6542