### PR TITLE
Fix / TAO-6994 Cover cases like .5 float input; 2 tests for that

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '20.2.0',
+    'version' => '20.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.9.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -853,6 +853,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('20.1.0');
         }
 
-        $this->skip('20.1.0', '20.2.0');
+        $this->skip('20.1.0', '20.2.1');
     }
 }

--- a/views/js/test/util/locale/test.js
+++ b/views/js/test/util/locale/test.js
@@ -35,6 +35,7 @@ define(['module', 'util/locale'], function(module, locale) {
         assert.equal(locale.parseFloat('6.000'), 6.0, 'the valid float value with dot as decimal separator');
         assert.equal(locale.parseFloat('6,000'), 6000.0, 'the valid float value with comma as thousands separator');
         assert.equal(locale.parseFloat('6,000.123'), 6000.123, 'the valid float value with dot as decimal separator and comma as thousands separator');
+        assert.equal(locale.parseFloat('.6'), 0.6, 'the valid float value with initial dot as decimal separator');
 
         assert.equal(locale.parseInt('6000'), 6000, 'the valid integer value without separators');
         assert.equal(locale.parseInt('6.000'), 6, 'the valid integer value with dot as decimal separator');
@@ -50,6 +51,7 @@ define(['module', 'util/locale'], function(module, locale) {
         assert.equal(locale.parseFloat('6.000'), 6.0, 'the valid float value with dot as decimal separator');
         assert.equal(locale.parseFloat('6,000'), 6.0, 'the valid float value with comma as thousands separator');
         assert.equal(locale.parseFloat('6,000.123'), 6.0, 'the valid float value with dot as decimal separator and comma as thousands separator');
+        assert.equal(locale.parseFloat(',6'), 0.6, 'the valid float value with initial comma as decimal separator');
 
         assert.equal(locale.parseInt('6000'), 6000, 'the valid integer value without separators');
         assert.equal(locale.parseInt('6.000'), 6, 'the valid integer value with dot as decimal separator');

--- a/views/js/test/util/locale/test.js
+++ b/views/js/test/util/locale/test.js
@@ -19,9 +19,10 @@
  */
 define(['module', 'util/locale'], function(module, locale) {
 
+    // All tests are grouped in one module because global state is changed during them
     QUnit.module('API');
 
-    QUnit.test('util api', function(assert) {
+    QUnit.test('util api, different locales', function(assert) {
 
         // American style
         locale.setConfig({
@@ -32,26 +33,38 @@ define(['module', 'util/locale'], function(module, locale) {
         assert.equal(locale.getDecimalSeparator(), '.', 'Default decimal separator');
         assert.equal(locale.getThousandsSeparator(), ',', 'Default thousands separator');
 
-        assert.equal(locale.parseFloat('6.000'), 6.0, 'the valid float value with dot as decimal separator');
-        assert.equal(locale.parseFloat('6,000'), 6000.0, 'the valid float value with comma as thousands separator');
+        assert.ok(isNaN(locale.parseFloat('')), 'empty input');
+        assert.equal(locale.parseFloat('6.123'), 6.123, 'the valid float value with dot as decimal separator');
+        assert.equal(locale.parseFloat('6,123'), 6123.0, 'the valid float value with comma as thousands separator');
         assert.equal(locale.parseFloat('6,000.123'), 6000.123, 'the valid float value with dot as decimal separator and comma as thousands separator');
-        assert.equal(locale.parseFloat('.6'), 0.6, 'the valid float value with initial dot as decimal separator');
+        assert.equal(locale.parseFloat('.6'), 0.6, 'the valid float value with dot as decimal separator, no leading zero');
+        assert.equal(locale.parseFloat('-6.5'), -6.5, 'negative float using decimal separator');
+        assert.equal(locale.parseFloat('-.6'), -0.6, 'negative float using decimal separator, no leading zero');
+        assert.equal(locale.parseFloat('-6,789.5'), -6789.5, 'negative float using thousands and decimal separator');
+        assert.equal(locale.parseFloat('314e-2'), 3.14, 'float with negative exponent notation');
+        assert.equal(locale.parseFloat('0.0314E+2'), 3.14, 'float with positive exponent notation');
+        assert.equal(locale.parseFloat('3.14more non-digit characters'), 3.14, 'float with invalid trailing characters');
 
+        assert.ok(isNaN(locale.parseInt('')), 'empty input');
         assert.equal(locale.parseInt('6000'), 6000, 'the valid integer value without separators');
         assert.equal(locale.parseInt('6.000'), 6, 'the valid integer value with dot as decimal separator');
         assert.equal(locale.parseInt('6,000'), 6000, 'the valid integer value with comma as thousands separator');
         assert.equal(locale.parseInt('6,000.123'), 6000, 'the valid integer value with dot as decimal separator and comma as thousands separator');
 
+                
         // Other style
         locale.setConfig({
             decimalSeparator: ',',
             thousandsSeparator: ''
         });
 
-        assert.equal(locale.parseFloat('6.000'), 6.0, 'the valid float value with dot as decimal separator');
-        assert.equal(locale.parseFloat('6,000'), 6.0, 'the valid float value with comma as thousands separator');
-        assert.equal(locale.parseFloat('6,000.123'), 6.0, 'the valid float value with dot as decimal separator and comma as thousands separator');
-        assert.equal(locale.parseFloat(',6'), 0.6, 'the valid float value with initial comma as decimal separator');
+        assert.equal(locale.parseFloat('6.123'), 6.0, 'float value with invalid decimal separator');
+        assert.equal(locale.parseFloat('6,123'), 6.123, 'the valid float value with comma as decimal separator');
+        assert.equal(locale.parseFloat('6,000.123'), 6.0, 'the valid float value with comma as decimal separator');
+        assert.equal(locale.parseFloat(',6'), 0.6, 'the valid float value with comma as decimal separator, no leading zero');
+        assert.equal(locale.parseFloat('-6,5'), -6.5, 'negative float using decimal separator');
+        assert.equal(locale.parseFloat('-,6'), -0.6, 'negative float using decimal separator, no leading zero');
+        assert.equal(locale.parseFloat('-6.789,5'), -6, 'negative float using invalid thousands separator');
 
         assert.equal(locale.parseInt('6000'), 6000, 'the valid integer value without separators');
         assert.equal(locale.parseInt('6.000'), 6, 'the valid integer value with dot as decimal separator');

--- a/views/js/util/locale.js
+++ b/views/js/util/locale.js
@@ -77,15 +77,18 @@ define(['module', 'moment'], function (module, moment) {
          * @returns {Number}
          */
         parseFloat: function (numStr) {
+            var thousandsSeparator = this.getThousandsSeparator(),
+                decimalSeparator = this.getDecimalSeparator();
+
             // discard all thousand separators:
-            if (this.getThousandsSeparator().length) {
-                numStr = numStr.replace(new RegExp('\\' + this.getThousandsSeparator(), 'g'), '');
+            if (thousandsSeparator.length) {
+                numStr = numStr.replace(new RegExp('\\' + thousandsSeparator, 'g'), '');
             }
         
             // standardise the decimal separator as '.':
-            if (this.getDecimalSeparator() !== '.') {
+            if (decimalSeparator !== '.') {
                 numStr = numStr.replace(new RegExp('\\' + '.', 'g'), '_')
-                               .replace(new RegExp('\\' + this.getDecimalSeparator(), 'g'), '.');
+                               .replace(new RegExp('\\' + decimalSeparator, 'g'), '.');
             }
         
             // now the numeric string can be correctly parsed with the native parseFloat:
@@ -99,9 +102,10 @@ define(['module', 'moment'], function (module, moment) {
          * @returns {Number}
          */
         parseInt: function (number, numericBase) {
+            var thousandsSeparator = this.getThousandsSeparator();
 
-            if (this.getThousandsSeparator().length) {
-                number = number.replace(new RegExp('\\' + this.getThousandsSeparator(), 'g'), '');
+            if (thousandsSeparator.length) {
+                number = number.replace(new RegExp('\\' + thousandsSeparator, 'g'), '');
             }
 
             return parseInt(number, numericBase);

--- a/views/js/util/locale.js
+++ b/views/js/util/locale.js
@@ -82,10 +82,10 @@ define(['module', 'moment'], function (module, moment) {
             }
 
             var parts = number.split(this.getDecimalSeparator(), 2);
-            var ones = parts[0];
+            var ones = parts[0] || '0';     // covers case where value starts with '.'
 
             if (this.getThousandsSeparator().length) {
-                ones = parts[0].replace(new RegExp('\\' + this.getThousandsSeparator(), 'g'), '');
+                ones = ones.replace(new RegExp('\\' + this.getThousandsSeparator(), 'g'), '');
             }
 
             return parseFloat(ones) + parseFloat('0.' + parts[1]);

--- a/views/js/util/locale.js
+++ b/views/js/util/locale.js
@@ -73,22 +73,23 @@ define(['module', 'moment'], function (module, moment) {
 
         /**
          * Parse float values with process locale features
-         * @param number
+         * @param numStr
          * @returns {Number}
          */
-        parseFloat: function (number) {
-            if (!number) {
-                return parseFloat(number);
-            }
-
-            var parts = number.split(this.getDecimalSeparator(), 2);
-            var ones = parts[0] || '0';     // covers case where value starts with '.'
-
+        parseFloat: function (numStr) {
+            // discard all thousand separators:
             if (this.getThousandsSeparator().length) {
-                ones = ones.replace(new RegExp('\\' + this.getThousandsSeparator(), 'g'), '');
+                numStr = numStr.replace(new RegExp('\\' + this.getThousandsSeparator(), 'g'), '');
             }
-
-            return parseFloat(ones) + parseFloat('0.' + parts[1]);
+        
+            // standardise the decimal separator as '.':
+            if (this.getDecimalSeparator() != '.') {
+                numStr = numStr.replace(new RegExp('\\' + '.', 'g'), '_')
+                               .replace(new RegExp('\\' + this.getDecimalSeparator(), 'g'), '.');
+            }
+        
+            // now the numeric string can be correctly parsed with the native parseFloat:
+            return parseFloat(numStr);
         },
 
         /**

--- a/views/js/util/locale.js
+++ b/views/js/util/locale.js
@@ -83,7 +83,7 @@ define(['module', 'moment'], function (module, moment) {
             }
         
             // standardise the decimal separator as '.':
-            if (this.getDecimalSeparator() != '.') {
+            if (this.getDecimalSeparator() !== '.') {
                 numStr = numStr.replace(new RegExp('\\' + '.', 'g'), '_')
                                .replace(new RegExp('\\' + this.getDecimalSeparator(), 'g'), '.');
             }


### PR DESCRIPTION
The bug arose because we are using our own locale-specific `parseFloat` function in `util/locale.js`. 

There was an edge case which was missed: splitting a string which begins with the decimal separator -> the part before the separator will end up empty. The first part will now become 0 in this case.