### PR TITLE
Fix/sass compile on linux x64

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '20.2.1',
+    'version' => '20.2.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.9.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -853,6 +853,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('20.1.0');
         }
 
-        $this->skip('20.1.0', '20.2.1');
+        $this->skip('20.1.0', '20.2.2');
     }
 }

--- a/views/build/Gruntfile.js
+++ b/views/build/Gruntfile.js
@@ -59,6 +59,17 @@ module.exports = function(grunt) {
      // Load local tasks.
     grunt.loadTasks('tasks');
 
+    //instantiate sass module
+    const sass = require('node-sass');
+    //set initial config for sass to make 3.x.x branches of grunt-sass work, see https://github.com/nodejs/nan/issues/504#issuecomment-385296082, https://github.com/sourcey/spectacle/issues/156#issuecomment-401731543
+    grunt.initConfig({
+        sass: {
+                options: {
+                           implementation: sass
+                }
+        }
+    });
+
     /*
      * Load separated configs into each extension
      */

--- a/views/build/package.json
+++ b/views/build/package.json
@@ -31,7 +31,7 @@
     "grunt-notify": "^0.4.3",
     "grunt-qunit-junit": "^0.3.0",
     "grunt-replace": "^0.11.0",
-    "grunt-sass": "^2.0.0",
+    "grunt-sass": "^3.0.0",
     "load-grunt-tasks": "^3.4.0",
     "lodash": "^4.13.1",
     "time-grunt": "^1.0.0",

--- a/views/build/package.json
+++ b/views/build/package.json
@@ -34,6 +34,7 @@
     "grunt-sass": "^2.0.0",
     "load-grunt-tasks": "^3.4.0",
     "lodash": "^4.13.1",
-    "time-grunt": "^1.0.0"
+    "time-grunt": "^1.0.0",
+    "node-sass": "^4.7.2"
   }
 }


### PR DESCRIPTION
For: https://oat-sa.atlassian.net/browse/TAO-7052.
On Linux 64bits, install TAO.
Install last versions of node.js and npm.
Got to `tao/views/build` and run `npm install`

node-sass is installed you can try to run `npx grunt taosass` to compile SASS to CSS.