### PR TITLE
Fix interface compatibility issue

### DIFF
--- a/models/classes/api/ApiClientConnector.php
+++ b/models/classes/api/ApiClientConnector.php
@@ -68,7 +68,7 @@ class ApiClientConnector extends Configurable implements ClientInterface
      * @return ResponseInterface
      * @throws GuzzleException
      */
-    public function request($method, $uri, array $options = [])
+    public function request($method, $uri = null, array $options = [])
     {
         return $this->getClient()->request($method, $uri, $options);
     }


### PR DESCRIPTION
During `tao/scripts/taoSetup.php` using PHP 7.2 `Declaration of oat\tao\model\api\ApiClientConnector::request($method, $uri, array $options = Array) must be compatible with GuzzleHttp\ClientInterface::request($method, $uri = NULL, array $options = Array)` error occurred.