### PR TITLE
TAO-7151 - Add iframe attack protection headers

### DIFF
--- a/actions/class.CommonModule.php
+++ b/actions/class.CommonModule.php
@@ -319,6 +319,6 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
     protected function setIframeHeaders()
     {
         header('X-Frame-Options: sameorigin');
-        header('Content-Security-Policy: self');
+        header("Content-Security-Policy: default-src 'self'");
     }
 }

--- a/actions/class.CommonModule.php
+++ b/actions/class.CommonModule.php
@@ -1,23 +1,23 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2002-2008 (original work) Public Research Centre Henri Tudor & University of Luxembourg (under the project TAO & TAO2);
  *               2008-2010 (update and modification) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- * 
+ *
  */
 
 use oat\tao\helpers\Template;
@@ -36,24 +36,25 @@ use oat\oatbox\service\exception\InvalidServiceManagerException;
  * @author CRP Henri Tudor - TAO Team - {@link http://www.tao.lu}
  * @license GPLv2 http://www.opensource.org/licenses/gpl-2.0.php
  * @package tao
- *         
+ *
  */
 abstract class tao_actions_CommonModule extends Module implements ServiceManagerAwareInterface
 {
     use ServiceManagerAwareTrait { getServiceManager as protected getOriginalServiceManager; }
 
     /**
-     * The Modules access the models throught the service instance
-     * 
+     * The Modules access the models through the service instance
+     *
      * @var tao_models_classes_Service
      */
     protected $service = null;
 
     /**
-     * empty constuctor
+     * tao_actions_CommonModule constructor.
      */
     public function __construct()
     {
+        $this->setIframeHeaders();
     }
 
     /**
@@ -64,6 +65,7 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
      * @param string $action
      * @param array $parameters
      * @return boolean
+     * @throws common_exception_Error
      */
     protected function hasAccess($controllerClass, $action, $parameters = [])
     {
@@ -86,37 +88,38 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
 
     /**
      * Retrieve the data from the url and make the base initialization
-     * 
+     *
      * @return void
+     * @throws common_ext_ExtensionException
      */
     protected function defaultData()
     {
         $context = Context::getInstance();
-        
+
         $this->setData('extension', context::getInstance()->getExtensionName());
         $this->setData('module', $context->getModuleName());
         $this->setData('action', $context->getActionName());
-        
+
         if ($this->hasRequestParameter('uri')) {
-            
+
             // @todo stop using session to manage uri/classUri
             $this->setSessionAttribute('uri', $this->getRequestParameter('uri'));
-            
+
             // inform the client of new classUri
             $this->setData('uri', $this->getRequestParameter('uri'));
         }
         if ($this->hasRequestParameter('classUri')) {
-            
+
             // @todo stop using session to manage uri/classUri
             $this->setSessionAttribute('classUri', $this->getRequestParameter('classUri'));
             if (! $this->hasRequestParameter('uri')) {
                 $this->removeSessionAttribute('uri');
             }
-            
+
             // inform the client of new classUri
             $this->setData('uri', $this->getRequestParameter('classUri'));
         }
-        
+
         if ($this->getRequestParameter('message')) {
             $this->setData('message', $this->getRequestParameter('message'));
         }
@@ -127,19 +130,20 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
         $this->setData('client_timeout', $this->getClientTimeout());
         $this->setData('client_config_url', $this->getClientConfigUrl());
     }
-	
+
     /**
      * Function to return an user readable error
      * Does not work with ajax Requests yet
-     * 
+     *
      * @param string $description error to show
      * @param boolean $returnLink whenever or not to add a return link
      * @param int $httpStatus
+     * @throws common_Exception
      */
     protected function returnError($description, $returnLink = true, $httpStatus = null) {
         if (tao_helpers_Request::isAjax()) {
             common_Logger::w('Called '.__FUNCTION__.' in an unsupported AJAX context');
-            throw new common_Exception($description); 
+            throw new common_Exception($description);
         } else {
             $this->setData('message', $description);
             $this->setData('returnLink', $returnLink);
@@ -154,10 +158,12 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
 
     /**
      * Returns the absolute path to the specified template
-     * 
+     *
      * @param string $identifier
      * @param string $extensionID
      * @return string
+     * @throws common_exception_Error
+     * @throws common_ext_ExtensionException
      */
     protected static function getTemplatePath($identifier, $extensionID = null)
     {
@@ -171,11 +177,10 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
     	$ext = common_ext_ExtensionsManager::singleton()->getExtensionById($extensionID);
     	return $ext->getConstant('DIR_VIEWS').'templates'.DIRECTORY_SEPARATOR.$identifier;
     }
-   
-     
+
     /**
      * Helps you to add the URL of the client side config file
-     * 
+     *
      * @param array $extraParameters additional parameters to append to the URL
      * @return string the URL
      */
@@ -183,41 +188,47 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
         return JavaScript::getClientConfigUrl($extraParameters);
     }
 
-
     /**
      * Get the client timeout value from the config.
-     * 
+     *
      * @return int the timeout value in seconds
+     * @throws common_ext_ExtensionException
      */
     protected function getClientTimeout(){
         $ext = common_ext_ExtensionsManager::singleton()->getExtensionById('tao');
         $config = $ext->getConfig('js');
         if($config != null && isset($config['timeout'])){
             return (int)$config['timeout'];
-        } 
+        }
         return 30;
     }
-    
+
+    /**
+     * Return json response.
+     *
+     * @param array $data
+     * @param int $httpStatus
+     */
     protected function returnJson($data, $httpStatus = 200) {
         header(HTTPToolkit::statusCodeHeader($httpStatus));
         Context::getInstance()->getResponse()->setContentHeader('application/json');
         echo json_encode($data);
     }
-    
+
     /**
      * Returns a report
-     * 
+     *
      * @param common_report_Report $report
      */
     protected function returnReport(common_report_Report $report) {
         $data = $report->getData();
-        $sucesses = $report->getSuccesses();
+        $successes = $report->getSuccesses();
 
         // if report has no data, try to get it from the sub report
-        while (is_null($data) && count($sucesses) > 0) {
-            $firstSubReport = current($sucesses);
+        while (is_null($data) && count($successes) > 0) {
+            $firstSubReport = current($successes);
             $data = $firstSubReport->getData();
-            $sucesses = $firstSubReport->getSuccesses();
+            $successes = $firstSubReport->getSuccesses();
         }
 
         if (!is_null($data) && $data instanceof core_kernel_classes_Resource) {
@@ -226,7 +237,6 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
         $this->setData('report', $report);
         $this->setView('report.tpl', 'tao');
     }
-
 
     /**
      * Forward using the TAO FlowController implementation
@@ -249,14 +259,16 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
     /**
      * Redirect using the TAO FlowController implementation
      * @see {@link oat\model\routing\FlowController}
+     * @param string $url
+     * @param int $statusCode
      */
-	public function redirect($url, $statusCode = 302)
+    public function redirect($url, $statusCode = 302)
     {
         $this->getFlowController()->redirect($url, $statusCode);
     }
-    
+
     /**
-     * Returns a requestparameter unencoded
+     * Returns a request parameter unencoded
      *
      * @param string $paramName
      * @throws common_exception_MissingParameter
@@ -271,10 +283,9 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
         return $raw[$paramName];
     }
 
-
     /**
      * Get the flow controller
-     * 
+     *
      * Propagate the service (logger and service manager)
      *
      * @return mixed
@@ -300,5 +311,14 @@ abstract class tao_actions_CommonModule extends Module implements ServiceManager
             $serviceManager = ServiceManager::getServiceManager();
         }
         return $serviceManager;
+    }
+
+    /**
+     * Set headers for iFrame security
+     */
+    protected function setIframeHeaders()
+    {
+        header('X-Frame-Options: sameorigin');
+        header('Content-Security-Policy: self');
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '21.9.2',
+    'version' => '21.10.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.9.6',

--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '21.8.0',
+    'version' => '21.9.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.9.6',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -855,7 +855,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->getServiceManager()->register(TaskLogInterface::SERVICE_ID, $taskLogService);
             $this->setVersion('19.20.0');
         }
-        
+
         $this->skip('19.20.0', '21.2.0');
 
         if ($this->isVersion('21.2.0')) {
@@ -874,6 +874,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('21.5.0');
         }
 
-        $this->skip('21.5.0', '21.8.0');
+        $this->skip('21.5.0', '21.9.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -874,7 +874,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('21.5.0');
         }
 
-        $this->skip('21.5.0', '21.9.2');
+        $this->skip('21.5.0', '21.10.0');
 
     }
 }


### PR DESCRIPTION
Please note that this PR is directly related to https://github.com/oat-sa/extension-tao-lti/pull/155. Please make sure these PR's get merged at the same time.

Added protected method that sets headers to protect against iframe attacks. Note that this method is protected so we can override this when needed (eg. in LTI modules)

Additionally I removed some trailing whitespaces and duplicate newlines.