### PR TITLE
Fix/tao 7173 calculator ans issue

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '21.17.0',
+    'version' => '21.17.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.11.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -874,6 +874,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('21.5.0');
         }
 
-        $this->skip('21.5.0', '21.17.0');
+        $this->skip('21.5.0', '21.17.1');
     }
 }

--- a/views/js/test/ui/maths/calculator/plugins/core/degrad/test.js
+++ b/views/js/test/ui/maths/calculator/plugins/core/degrad/test.js
@@ -237,7 +237,7 @@ define([
                         assert.ok(calculator.is('radian'), 'The state radian is set');
 
                         calculator.replace('cos PI');
-                        assert.equal(calculator.evaluate(), '-1', 'The expression is computed in radian mode');
+                        assert.equal(calculator.evaluate().value, '-1', 'The expression is computed in radian mode');
 
                         calculator.useCommand('degree');
 
@@ -245,7 +245,7 @@ define([
                         assert.ok(!calculator.is('radian'), 'The state radian is not set');
 
                         calculator.replace('cos 180');
-                        assert.equal(calculator.evaluate(), '-1', 'The expression is computed in degree mode');
+                        assert.equal(calculator.evaluate().value, '-1', 'The expression is computed in degree mode');
 
                         calculator.useCommand('radian');
 
@@ -253,7 +253,7 @@ define([
                         assert.ok(calculator.is('radian'), 'The state radian is set');
 
                         calculator.replace('cos PI');
-                        assert.equal(calculator.evaluate(), '-1', 'The expression is computed in radian mode');
+                        assert.equal(calculator.evaluate().value, '-1', 'The expression is computed in radian mode');
                     })
                     .catch(function (err) {
                         assert.ok(false, 'Unexpected failure : ' + err.message);

--- a/views/js/test/ui/maths/calculator/plugins/core/history/test.js
+++ b/views/js/test/ui/maths/calculator/plugins/core/history/test.js
@@ -148,7 +148,7 @@ define([
                                 assert.deepEqual(h1, [], 'history is empty');
 
                                 calculator.replace('cos PI');
-                                assert.equal(calculator.evaluate(), '-1', 'The expression is computed');
+                                assert.equal(calculator.evaluate().value, '-1', 'The expression is computed');
 
                                 calculator.on('history.read', function (h2) {
                                     calculator.off('history.read');
@@ -268,7 +268,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             calculator.replace('cos PI');
-                            assert.equal(calculator.evaluate(), '-1', 'The expression is computed');
+                            assert.equal(calculator.evaluate().value, '-1', 'The expression is computed');
 
                             calculator
                                 .on('history.read2', function (history) {
@@ -283,7 +283,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             calculator.replace('cos PI');
-                            assert.equal(calculator.evaluate(), '-1', 'The expression is computed');
+                            assert.equal(calculator.evaluate().value, '-1', 'The expression is computed');
 
                             calculator
                                 .on('history.read3', function (history) {
@@ -298,7 +298,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             calculator.replace('.1+.2');
-                            assert.equal(calculator.evaluate(), '0.3', 'The expression is computed');
+                            assert.equal(calculator.evaluate().value, '0.3', 'The expression is computed');
 
                             calculator
                                 .on('history.read4', function (history) {
@@ -394,13 +394,13 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             calculator.replace('cos PI');
-                            assert.equal(calculator.evaluate(), '-1', 'The expression "cos PI" is computed');
+                            assert.equal(calculator.evaluate().value, '-1', 'The expression "cos PI" is computed');
 
                             calculator.replace('cos PI');
-                            assert.equal(calculator.evaluate(), '-1', 'The expression "cos PI" is computed again');
+                            assert.equal(calculator.evaluate().value, '-1', 'The expression "cos PI" is computed again');
 
                             calculator.replace('.1+.2');
-                            assert.equal(calculator.evaluate(), '0.3', 'The expression ".1+.2" is computed');
+                            assert.equal(calculator.evaluate().value, '0.3', 'The expression ".1+.2" is computed');
 
                             calculator
                                 .on('history.read', function (history) {
@@ -429,7 +429,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             calculator.replace('1+2');
-                            assert.equal(calculator.evaluate(), '3', 'The expression "1+2" is computed');
+                            assert.equal(calculator.evaluate().value, '3', 'The expression "1+2" is computed');
 
                             calculator
                                 .on('history.read', function (history) {
@@ -444,7 +444,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             calculator.replace('3*4');
-                            assert.equal(calculator.evaluate(), '12', 'The expression "3*4" is computed');
+                            assert.equal(calculator.evaluate().value, '12', 'The expression "3*4" is computed');
 
                             calculator
                                 .on('history.read', function (history) {
@@ -663,13 +663,13 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             calculator.replace('cos PI');
-                            assert.equal(calculator.evaluate(), '-1', 'The expression "cos PI" is computed');
+                            assert.equal(calculator.evaluate().value, '-1', 'The expression "cos PI" is computed');
 
                             calculator.replace('cos PI');
-                            assert.equal(calculator.evaluate(), '-1', 'The expression "cos PI" is computed again');
+                            assert.equal(calculator.evaluate().value, '-1', 'The expression "cos PI" is computed again');
 
                             calculator.replace('.1+.2');
-                            assert.equal(calculator.evaluate(), '0.3', 'The expression ".1+.2" is computed');
+                            assert.equal(calculator.evaluate().value, '0.3', 'The expression ".1+.2" is computed');
 
                             calculator
                                 .on('history.read', function (history) {
@@ -698,7 +698,7 @@ define([
                     .then(function () {
                         return new Promise(function (resolve) {
                             calculator.replace('1+2');
-                            assert.equal(calculator.evaluate(), '3', 'The expression "1+2" is computed');
+                            assert.equal(calculator.evaluate().value, '3', 'The expression "1+2" is computed');
 
                             calculator
                                 .on('history.read', function (history) {
@@ -777,7 +777,7 @@ define([
                             calculator
                                 .on('evaluate.set', function (result) {
                                     calculator.off('evaluate.set');
-                                    assert.equal(result, '0.6', 'The expression is computed');
+                                    assert.equal(result.value, '0.6', 'The expression is computed');
 
                                     resolve();
                                 })
@@ -861,7 +861,7 @@ define([
                             calculator
                                 .on('evaluate.set', function (result) {
                                     calculator.off('evaluate.set');
-                                    assert.equal(result, '2', 'The expression is computed');
+                                    assert.equal(result.value, '2', 'The expression is computed');
 
                                     resolve();
                                 })

--- a/views/js/test/ui/maths/calculator/plugins/core/remind/test.js
+++ b/views/js/test/ui/maths/calculator/plugins/core/remind/test.js
@@ -155,8 +155,8 @@ define([
 
                                     assert.ok(!calculator.hasVariable('mem'), 'The remind variable still does not exist');
                                     assert.ok(calculator.hasVariable('last'), 'The remind last variable should now exist');
-                                    assert.equal(calculator.getVariable('last'), r1, 'The remind last variable is equal to the last result');
-                                    assert.equal(r1, '7', 'The result is correct');
+                                    assert.deepEqual(calculator.getVariable('last'), r1, 'The remind last variable is equal to the last result');
+                                    assert.equal(r1.value, '7', 'The result is correct');
 
                                     resolve();
                                 })
@@ -275,8 +275,8 @@ define([
 
                                     assert.ok(!calculator.hasVariable('mem'), 'The remind variable still does not exist');
                                     assert.ok(calculator.hasVariable('last'), 'The remind last variable should now exist');
-                                    assert.equal(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
-                                    assert.equal(result, '7', 'The result is correct');
+                                    assert.deepEqual(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
+                                    assert.equal(result.value, '7', 'The result is correct');
 
                                     resolve();
                                 })
@@ -292,8 +292,8 @@ define([
 
                                     assert.ok(!calculator.hasVariable('mem'), 'The remind variable still does not exist');
                                     assert.ok(calculator.hasVariable('last'), 'The remind last variable should now exist');
-                                    assert.equal(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
-                                    assert.equal(result, '20', 'The result is correct');
+                                    assert.deepEqual(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
+                                    assert.equal(result.value, '20', 'The result is correct');
 
                                     resolve();
                                 })
@@ -309,8 +309,8 @@ define([
 
                                     assert.ok(calculator.hasVariable('mem'), 'The remind variable should now exist');
                                     assert.ok(calculator.hasVariable('last'), 'The remind last variable should now exist');
-                                    assert.equal(calculator.getVariable('mem'), calculator.getVariable('last'), 'The remind last variable is equal to the last result');
-                                    assert.equal(calculator.getVariable('mem'), '20', 'The variable contains the correct value');
+                                    assert.deepEqual(calculator.getVariable('mem'), calculator.getVariable('last'), 'The remind last variable is equal to the last result');
+                                    assert.equal(calculator.getVariable('mem').value, '20', 'The variable contains the correct value');
 
                                     resolve();
                                 })
@@ -339,9 +339,9 @@ define([
 
                                     assert.ok(calculator.hasVariable('mem'), 'The remind variable still exist');
                                     assert.ok(calculator.hasVariable('last'), 'The remind last variable still exist');
-                                    assert.equal(calculator.getVariable('mem'), '20', 'The remind variable contains the correct value');
-                                    assert.equal(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
-                                    assert.equal(result, '30', 'The result is correct');
+                                    assert.equal(calculator.getVariable('mem').value, '20', 'The remind variable contains the correct value');
+                                    assert.deepEqual(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
+                                    assert.equal(result.value, '30', 'The result is correct');
 
                                     resolve();
                                 })
@@ -357,9 +357,9 @@ define([
                                     assert.equal(calculator.getExpression(), 'last+mem', 'The expression has been properly updated');
                                     assert.ok(calculator.hasVariable('mem'), 'The remind variable still exist');
                                     assert.ok(calculator.hasVariable('last'), 'The remind last variable still exist');
-                                    assert.equal(calculator.getVariable('mem'), '20', 'The remind variable contains the correct value');
-                                    assert.equal(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
-                                    assert.equal(result, '50', 'The result is correct');
+                                    assert.equal(calculator.getVariable('mem').value, '20', 'The remind variable contains the correct value');
+                                    assert.deepEqual(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
+                                    assert.equal(result.value, '50', 'The result is correct');
 
                                     resolve(result);
                                 })
@@ -378,7 +378,7 @@ define([
 
                                     assert.ok(!calculator.hasVariable('mem'), 'The remind variable has been destroyed');
                                     assert.ok(calculator.hasVariable('last'), 'The remind last variable still exist');
-                                    assert.equal(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
+                                    assert.deepEqual(calculator.getVariable('last'), result, 'The remind last variable is equal to the last result');
 
                                     resolve();
                                 })

--- a/views/js/test/ui/maths/calculator/plugins/keyboard/templateKeyboard/test.js
+++ b/views/js/test/ui/maths/calculator/plugins/keyboard/templateKeyboard/test.js
@@ -386,7 +386,7 @@ define([
                                 .after('evaluate.test', function (result) {
                                     calculator.off('evaluate.test');
 
-                                    assert.equal(result, '45', 'The expression has been computed and the result is 45');
+                                    assert.equal(result.value, '45', 'The expression has been computed and the result is 45');
                                     assert.equal(calculator.getExpression(), '42+3', 'The expression still contains 42+3');
 
                                     resolve();
@@ -451,7 +451,7 @@ define([
                 $input.setCursorPosition(this.getPosition());
             })
             .on('evaluate', function (result) {
-                $output.val(result);
+                $output.val(result.value);
             })
             .on('syntaxerror', function (err) {
                 $output.val(err);

--- a/views/js/test/ui/maths/calculator/plugins/screen/simpleScreen/test.js
+++ b/views/js/test/ui/maths/calculator/plugins/screen/simpleScreen/test.js
@@ -530,7 +530,7 @@ define([
                         assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
 
                         assert.ok(calculator.hasVariable('ans'), 'A variable exists to store the last result');
-                        assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
                     })
                     .then(function () {
                         var $screen = $container.find('.calculator-screen');
@@ -573,7 +573,7 @@ define([
                                     assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
                                     assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    assert.equal(calculator.getVariable('ans'), '5', 'The last result is 5');
+                                    assert.equal(calculator.getVariable('ans').value, '5', 'The last result is 5');
 
                                     assert.equal($screen.find('.expression .term').length, 1, 'The expected number of terms has been transformed in the expression');
 
@@ -683,7 +683,7 @@ define([
                                     assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
                                     assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    assert.equal(calculator.getVariable('ans'), '8', 'The last result is 8');
+                                    assert.equal(calculator.getVariable('ans').value, '8', 'The last result is 8');
 
                                     assert.equal($screen.find('.expression .term').length, 1, 'The expected number of terms has been transformed in the expression');
 
@@ -732,7 +732,7 @@ define([
 
                                     assert.equal(calculator.getExpression(), '0', 'The expression should be reset to 0');
                                     assert.equal(calculator.getPosition(), 1, 'The position should be reset to 1');
-                                    assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
                                     assert.equal($screen.find('.expression .term').length, 1, 'The expected number of terms has been transformed in the expression');
 
@@ -794,7 +794,7 @@ define([
                         assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
 
                         assert.ok(calculator.hasVariable('ans'), 'A variable exists to store the last result');
-                        assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
                     })
                     .then(function () {
                         var $screen = $container.find('.calculator-screen');
@@ -837,7 +837,7 @@ define([
                                     assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
                                     assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
                                     assert.equal($screen.find('.expression .term').length, 1, 'The expected number of terms has been transformed in the expression');
 
@@ -913,7 +913,7 @@ define([
 
                                     assert.equal(calculator.getExpression(), '0', 'The expression should be reset to 0');
                                     assert.equal(calculator.getPosition(), 1, 'The position should be reset to 1');
-                                    assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
                                     assert.equal($screen.find('.expression .term').length, 1, 'The expected number of terms has been transformed in the expression');
 
@@ -975,7 +975,7 @@ define([
                         assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
 
                         assert.ok(calculator.hasVariable('ans'), 'A variable exists to store the last result');
-                        assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
                     })
                     .then(function () {
                         var $screen = $container.find('.calculator-screen');
@@ -1018,7 +1018,7 @@ define([
                                     assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
                                     assert.equal(calculator.is('error'), false, 'There is no error');
 
-                                    assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
                                     assert.equal($screen.find('.expression .term').length, 1, 'The expected number of terms has been transformed in the expression');
 
@@ -1094,7 +1094,7 @@ define([
 
                                     assert.equal(calculator.getExpression(), '0', 'The expression should be reset to 0');
                                     assert.equal(calculator.getPosition(), 1, 'The position should be reset to 1');
-                                    assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
                                     assert.equal($screen.find('.expression .term').length, 1, 'The expected number of terms has been transformed in the expression');
 
@@ -1156,7 +1156,7 @@ define([
                         assert.equal(calculator.getPosition(), 1, 'The position should be set to 1');
 
                         assert.ok(calculator.hasVariable('ans'), 'A variable exists to store the last result');
-                        assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                        assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
                     })
                     .then(function () {
                         var $screen = $container.find('.calculator-screen');
@@ -1198,7 +1198,7 @@ define([
                                     assert.equal(calculator.getPosition(), 2, 'The position should be set to 2');
                                     assert.equal(calculator.is('error'), true, 'There is an error');
 
-                                    assert.equal(calculator.getVariable('ans'), '0', 'The last result is 0');
+                                    assert.equal(calculator.getVariable('ans').value, '0', 'The last result is 0');
 
                                     assert.equal($screen.find('.expression .term').length, 3, 'The expected number of terms has been transformed');
 
@@ -1266,7 +1266,7 @@ define([
                                     assert.equal(calculator.getExpression(), 'ans', 'The expression should be set with the last result variable');
                                     assert.equal(calculator.getPosition(), 3, 'The position should be set to 3');
 
-                                    assert.equal(calculator.getVariable('ans'), '5', 'The last result is 5');
+                                    assert.equal(calculator.getVariable('ans').value, '5', 'The last result is 5');
 
                                     assert.equal($screen.find('.expression .term').length, 1, 'The expected number of terms has been transformed in the expression');
 

--- a/views/js/test/util/mathsEvaluator/test.js
+++ b/views/js/test/util/mathsEvaluator/test.js
@@ -154,9 +154,17 @@ define([
             expected: '1'
         }])
         .test('arithmetic expression', function (data, assert) {
-            var evaluate = mathsEvaluatorFactory();
-            QUnit.expect(1);
-            assert.equal(evaluate(data.expression), data.expected, "The expression " + data.expression + " is correctly computed");
+            var evaluate = mathsEvaluatorFactory(data.config);
+            var output = evaluate(data.expression, data.variables);
+
+            QUnit.expect(4);
+            if (!_.isBoolean(output.value)) {
+                output.value = String(output.value);
+            }
+            assert.equal(output.value, data.expected, "The expression " + data.expression + " is correctly computed to " + data.expected);
+            assert.equal(output.expression, data.expression, "The expression is provided in the output");
+            assert.equal(output.variables, data.variables, "The variables are provided in the output");
+            assert.notEqual(typeof output.result, 'undefined', "The internal result is provided in the output");
         });
 
     QUnit
@@ -262,9 +270,17 @@ define([
             expected: '42'
         }])
         .test('logical expression', function (data, assert) {
-            var evaluate = mathsEvaluatorFactory();
-            QUnit.expect(1);
-            assert.equal(evaluate(data.expression), data.expected, "The expression " + data.expression + " is correctly computed");
+            var evaluate = mathsEvaluatorFactory(data.config);
+            var output = evaluate(data.expression, data.variables);
+
+            QUnit.expect(4);
+            if (!_.isBoolean(output.value)) {
+                output.value = String(output.value);
+            }
+            assert.equal(output.value, data.expected, "The expression " + data.expression + " is correctly computed to " + data.expected);
+            assert.equal(output.expression, data.expression, "The expression is provided in the output");
+            assert.equal(output.variables, data.variables, "The variables are provided in the output");
+            assert.notEqual(typeof output.result, 'undefined', "The internal result is provided in the output");
         });
 
     QUnit
@@ -275,9 +291,17 @@ define([
             expected: '45'
         }])
         .test('parametric expression', function (data, assert) {
-            var evaluate = mathsEvaluatorFactory();
-            QUnit.expect(1);
-            assert.equal(evaluate(data.expression, data.variables), data.expected, "The expression " + data.expression + " is correctly computed");
+            var evaluate = mathsEvaluatorFactory(data.config);
+            var output = evaluate(data.expression, data.variables);
+
+            QUnit.expect(4);
+            if (!_.isBoolean(output.value)) {
+                output.value = String(output.value);
+            }
+            assert.equal(output.value, data.expected, "The expression " + data.expression + " is correctly computed to " + data.expected);
+            assert.equal(output.expression, data.expression, "The expression is provided in the output");
+            assert.equal(output.variables, data.variables, "The variables are provided in the output");
+            assert.notEqual(typeof output.result, 'undefined', "The internal result is provided in the output");
         });
 
     QUnit
@@ -509,8 +533,16 @@ define([
         }])
         .test('trigo - radian', function (data, assert) {
             var evaluate = mathsEvaluatorFactory(data.config);
-            QUnit.expect(1);
-            assert.equal(evaluate(data.expression, data.variables), data.expected, "The expression " + data.expression + " is correctly computed");
+            var output = evaluate(data.expression, data.variables);
+
+            QUnit.expect(4);
+            if (!_.isBoolean(output.value)) {
+                output.value = String(output.value);
+            }
+            assert.equal(output.value, data.expected, "The expression " + data.expression + " is correctly computed to " + data.expected);
+            assert.equal(output.expression, data.expression, "The expression is provided in the output");
+            assert.equal(output.variables, data.variables, "The variables are provided in the output");
+            assert.notEqual(typeof output.result, 'undefined', "The internal result is provided in the output");
         });
 
     QUnit
@@ -762,9 +794,47 @@ define([
         }])
         .test('trigo - degree', function (data, assert) {
             var evaluate = mathsEvaluatorFactory(data.config);
-            QUnit.expect(1);
-            assert.equal(evaluate(data.expression, data.variables), data.expected, "The expression " + data.expression + " is correctly computed");
+            var output = evaluate(data.expression, data.variables);
+
+            QUnit.expect(4);
+            if (!_.isBoolean(output.value)) {
+                output.value = String(output.value);
+            }
+            assert.equal(output.value, data.expected, "The expression " + data.expression + " is correctly computed to " + data.expected);
+            assert.equal(output.expression, data.expression, "The expression is provided in the output");
+            assert.equal(output.variables, data.variables, "The variables are provided in the output");
+            assert.notEqual(typeof output.result, 'undefined', "The internal result is provided in the output");
         });
+
+    QUnit.test('expression as object', function (assert) {
+        var evaluate = mathsEvaluatorFactory();
+        var mathsExpression = {
+            expression: '3*x + 1',
+            variables: {
+                x: 2
+            }
+        };
+        var variables = {
+            x: 3
+        };
+
+        var output = evaluate(mathsExpression);
+
+        QUnit.expect(8);
+
+        assert.equal(output.value, '7', "The expression " + mathsExpression.expression + " is correctly computed to 7");
+        assert.equal(output.expression, mathsExpression.expression, "The expression is provided in the output");
+        assert.equal(output.variables, mathsExpression.variables, "The variables are provided in the output");
+        assert.notEqual(typeof output.result, 'undefined', "The internal result is provided in the output");
+
+
+        output = evaluate(mathsExpression, variables);
+
+        assert.equal(output.value, '10', "The expression " + mathsExpression.expression + " is correctly computed to 10");
+        assert.equal(output.expression, mathsExpression.expression, "The expression is provided in the output");
+        assert.equal(output.variables, variables, "The variables are provided in the output");
+        assert.notEqual(typeof output.result, 'undefined', "The internal result is provided in the output");
+    });
 
     /** Visual Test **/
 
@@ -818,7 +888,7 @@ define([
 
         function processExpression(expr, variables) {
             try {
-                return evaluate(expr, variables);
+                return evaluate(expr, variables).value;
             } catch (err) {
                 console.log(err);
                 return 'Syntax error!';

--- a/views/js/ui/maths/calculator/core/board.js
+++ b/views/js/ui/maths/calculator/core/board.js
@@ -226,7 +226,7 @@ define([
             /**
              * Gets a variable defined for the expression.
              * @param {String} name - The variable name
-             * @returns {String} The value. Can be another expression.
+             * @returns {mathsExpression} The value. Can be another expression.
              */
             getVariable: function getVariable(name) {
                 return variables.get(name);
@@ -244,11 +244,19 @@ define([
             /**
              * Sets a variable that can be used by the expression.
              * @param {String} name - The variable name
-             * @param {String} value - The value. Can be another expression.
+             * @param {String|mathsExpression} value - The value. Can be another expression.
              * @returns {calculator}
              * @fires variableadd after the variable has been set
              */
             setVariable: function setVariable(name, value) {
+                var errValue;
+                try {
+                    value = mathsEvaluator(value);
+                } catch(err) {
+                    errValue = value && value.expression || value;
+                    value = mathsEvaluator('0');
+                    value.expression = errValue;
+                }
                 variables.set(name, value);
                 /**
                  * @event variableadd
@@ -282,7 +290,7 @@ define([
             getVariables: function getVariables() {
                 var defs = {};
                 variables.forEach(function (value, name) {
-                    defs[name] = value;
+                    defs[name] = value.result;
                 });
                 return defs;
             },
@@ -585,7 +593,7 @@ define([
 
             /**
              * Evaluates the current expression
-             * @returns {String|null}
+             * @returns {mathsExpression|null}
              * @fires evaluate when the expression has been evaluated
              * @fires syntaxerror when the expression contains an error
              */
@@ -595,12 +603,12 @@ define([
                     if (expression.trim()) {
                         result = mathsEvaluator(expression, this.getVariables());
                     } else {
-                        result = '0';
+                        result = mathsEvaluator('0');
                     }
 
                     /**
                      * @event evaluate
-                     * @param {String} result
+                     * @param {mathsExpression} result
                      */
                     this.trigger('evaluate', result);
                 } catch (e) {

--- a/views/js/util/mathsEvaluator.js
+++ b/views/js/util/mathsEvaluator.js
@@ -582,18 +582,35 @@ define([
         /**
          * The exposed parser
          *
-         * @param {String} expression - The expression to evaluate
+         * @param {String|mathsExpression} expression - The expression to evaluate
          * @param {Object} [variables] - Optional variables to use from the expression
-         * @returns {String}
+         * @returns {mathsExpression}
          */
         function evaluate(expression, variables) {
-            var expr = parser.parse(expression);
-            var result = expr.evaluate(variables);
-            var value = native(result);
-            if (typeof value === "boolean") {
-                return value;
+            var parsedExpression, result, value;
+
+            if (_.isPlainObject(expression)) {
+                variables = variables || expression.variables;
+                expression = expression.expression;
             }
-            return String(value);
+
+            parsedExpression = parser.parse(expression);
+            result = parsedExpression.evaluate(variables);
+            value = native(result);
+
+            /**
+             * @typedef {Object} mathsExpression
+             * @property {String} expression - The evaluated expression
+             * @property {Object} variables - Optional variables used from the expression
+             * @property {Decimal|Number|Boolean|String} result - The result of the expression, as returned by the evaluator
+             * @property {Boolean|String} value - The result of the expression, as a native value
+             */
+            return {
+                expression: expression,
+                variables: variables,
+                result: result,
+                value: value
+            };
         }
 
         // replace built-in operators and functions in expr-eval by those from decimal.js


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-7173

Fix an issue occurring when the last result is used in an expression, and this last result contains an irrational value.

For instance, compute the result of `1/3`, then multiply the result by `3`. The calculator will display `0.99999999`. With the fix it will display `1`.

To fix the issue, instead of simply use the last result casted to a native type, the calculator now always deal with the full data (all variables are now stored with full precision).