### PR TITLE
Fix/i18n parametric text not translated

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '22.10.0',
+    'version' => '22.10.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.11.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -889,5 +889,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('22.10.0');
         }
+
+        $this->skip('22.10.0', '22.10.1');
     }
 }

--- a/views/js/i18n.js
+++ b/views/js/i18n.js
@@ -1,26 +1,22 @@
-define(['lodash', 'json!i18ntr/messages.json', 'context', 'core/format'], function(_, i18nTr, context, format){
-    'use strict';   
- 
+define(['json!i18ntr/messages.json', 'core/format'], function(i18nTr, format){
+    'use strict';
+
     var translations = i18nTr.translations;
-    
+
     /**
      * Common translation method.
      * @see /locales/#lang#/messages_po.js
-     * 
-     * @param {String} message should be the string in the default language (usually english) used as the key in the gettext translations  
-     * @returns {String} translated message 
+     *
+     * @param {String} message should be the string in the default language (usually english) used as the key in the gettext translations
+     * @returns {String} translated message
      */
-    var __ = function __(message){
-        var localized =  !translations[message] ? message :  translations[message];
+    return function __(message){
+        var localized =  translations[message] || message;
 
         if(arguments.length > 1){
-            arguments[0] = localized;
-            localized = format.apply(null, arguments); 
+            localized = format.apply(null, [localized].concat([].slice.call(arguments, 1)));
         }
 
         return localized;
     };
-
-    //expose the translation function
-    return __ ;
 });


### PR DESCRIPTION
Fix issue occurring when a parametric translation is applied. The issue is only visible in production mode, as the transpiler is simplifying the code, removing some parts.

On `i18n`, the source code:
```javascript
    var translations = i18nTr.translations;
    var __ = function __(message){
        var localized =  !translations[message] ? message :  translations[message];
        if(arguments.length > 1){
            arguments[0] = localized;
            localized = format.apply(null, arguments); 
        }
        return localized;
    };
    return __ ;
```

is rewritten to:
```javascript
var translations = i18nTr.translations;
    return function (message) {
        var localized = translations[message] ? translations[message] : message;
        return 1 < arguments.length && (message = localized, localized = format.apply(null, arguments)), localized
    }
```

Note the removing of `arguments[0] = localized;`, which was an arguable fix brought by https://github.com/oat-sa/tao-core/pull/478

The purpose here is to provide a cleaner solution, that pass better through transpilation process.