### PR TITLE
Fix/tao 7313/missing lodash calculator sign

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '22.13.1',
+    'version' => '22.13.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=7.11.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -908,5 +908,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             );
             $this->setVersion('22.13.1');
         }
+
+        $this->skip('22.13.1', '22.13.2');
     }
 }

--- a/views/js/ui/maths/calculator/plugins/modifiers/sign.js
+++ b/views/js/ui/maths/calculator/plugins/modifiers/sign.js
@@ -20,11 +20,12 @@
  * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
  */
 define([
+    'lodash',
     'i18n',
     'util/namespace',
     'ui/maths/calculator/core/plugin',
     'ui/maths/calculator/core/terms'
-], function (__, nsHelper, pluginFactory, registeredTerms) {
+], function (_, __, nsHelper, pluginFactory, registeredTerms) {
     'use strict';
 
     var pluginName = 'sign';


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-7313

Fix a trivial issue in a calculator's plugin: dependency to `lodash` is missing while it is in use in the file :(