### PR TITLE
Fix/ncsup 182/wrong parameter order in route parameter serialization

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '25.0.3',
+    'version' => '25.0.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.0',

--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '25.0.2',
+    'version' => '25.0.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -909,6 +909,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('22.13.1');
         }
       
-        $this->skip('22.13.1', '25.0.2');
+        $this->skip('22.13.1', '25.0.3');
     }
 }

--- a/views/js/test/util/url/test.js
+++ b/views/js/test/util/url/test.js
@@ -239,7 +239,7 @@ define(['util/url', 'context'], function(urlUtil, context){
         title    : 'path with object params to encode',
         path      : 'http://tao.localdomain:8080/test/test.html',
         params      : { foo : {bar: 'f o oBAR! +/ 1', foo2: 23}},
-        expected : 'http://tao.localdomain:8080/test/test.html?foo[f%20o%20oBAR!%20%2B%2F%201]=bar&foo[23]=foo2&'
+        expected : 'http://tao.localdomain:8080/test/test.html?foo[bar]=f%20o%20oBAR!%20%2B%2F%201&foo[foo2]=23&'
     }];
 
     QUnit

--- a/views/js/util/url.js
+++ b/views/js/util/url.js
@@ -177,7 +177,7 @@ define([
                             acc += '&';
                         }
                         if (typeof value === "object") {
-                            _.forOwn(value, function(parameterName, parameterValue) {
+                            _.forOwn(value, function(parameterValue, parameterName) {
                                 acc += encodeURIComponent(key) + "[" + encodeURIComponent(parameterName) + "]=" + encodeURIComponent(parameterValue) + "&";
                             });
                         } else {


### PR DESCRIPTION
Amend for https://github.com/oat-sa/tao-core/pull/1967/files.

Parameter order for _.forOwn function has been confused before it was merged.

https://oat-sa.atlassian.net/browse/NCSUP-182