### PR TITLE
Fix/tao 7645/fix broken by dompurify datatables

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '25.1.0',
+    'version' => '25.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -909,6 +909,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('22.13.1');
         }
         
-        $this->skip('22.13.1', '25.1.0');
+        $this->skip('22.13.1', '25.1.1');
     }
 }

--- a/views/js/test/tpl/samples/dompurify_script.tpl
+++ b/views/js/test/tpl/samples/dompurify_script.tpl
@@ -1,1 +1,1 @@
-{{{dompurify dirtyHtml}}}
+<div>{{{dompurify dirtyHtml}}}</div>

--- a/views/js/test/tpl/test.js
+++ b/views/js/test/tpl/test.js
@@ -26,16 +26,32 @@ define([
 ], function (tplDomPurifyScript, tplJoinKeyValue, tplJoinArray){
     'use strict';
 
-    var fixture = '#qunit-fixture';
-
     QUnit.module('registered handlers');
 
-    QUnit.test('dompurify - script', function (assert){
-        var dirtyHtml = '<b>bold</b><script>alert("dirty!")</script><a href="#">link</a>';
+    QUnit.cases([{
+        title : 'try to inject a script',
+        html  : '<b>bold</b><script>alert("dirty!")</script><a href="#">link</a>',
+        expected : '<b>bold</b><a href="#">link</a>'
+    }, {
+        title : 'try to inject a tpl var',
+        html  : '<b>bold</b><span>{{foo}}</span>',
+        expected : '<b>bold</b><span>{{foo}}</span>'
+    }, {
+        title : 'try to inject an html var',
+        html  : '<b>bold</b><span>{{{moo}}}</span>',
+        expected : '<b>bold</b><span>{{{moo}}}</span>'
+    }, {
+        title : 'keep data-attr remove onEvent',
+        html  : '<button data-action="yolo" onclick="hijack()">Hello</button>',
+        expected : '<button data-action="yolo">Hello</button>'
+    }]).test('dompurify - script', function (data, assert) {
+
         var rendering = tplDomPurifyScript({
-            dirtyHtml : dirtyHtml
+            dirtyHtml : data.html,
+            foo : 'bar',
+            moo : '<strong>bar</strong>'
         });
-        assert.equal(rendering, '<b>bold</b><a href="#">link</a>', 'purified dom rendering ok');
+        assert.equal(rendering, '<div>' + data.expected + '</div>', 'purified dom rendering ok');
     });
 
     QUnit.test('join - key value', function (assert){

--- a/views/js/tpl.js
+++ b/views/js/tpl.js
@@ -40,6 +40,10 @@ define([
     var buildMap = {};
     var extension = '.tpl';
 
+    //to allow usage of some custom attributes with dompurify
+    //to be filled when another one missing attribute found
+    var allowedAttr = ['data-action'];
+
     //register a i18n helper
     hb.registerHelper('__', function(key){
         return __(key);
@@ -53,7 +57,9 @@ define([
      * to make output safe for template systems
      */
     hb.registerHelper('dompurify', function(context){
-        return DOMPurify.sanitize(context, {SAFE_FOR_TEMPLATES: true});
+        var params = {SAFE_FOR_TEMPLATES: true, ADD_ATTR: allowedAttr};
+
+        return DOMPurify.sanitize(context, params);
     });
 
     /**

--- a/views/js/tpl.js
+++ b/views/js/tpl.js
@@ -40,10 +40,6 @@ define([
     var buildMap = {};
     var extension = '.tpl';
 
-    //to allow usage of some custom attributes with dompurify
-    //to be filled when another one missing attribute found
-    var allowedAttr = ['data-action'];
-
     //register a i18n helper
     hb.registerHelper('__', function(key){
         return __(key);
@@ -57,9 +53,7 @@ define([
      * to make output safe for template systems
      */
     hb.registerHelper('dompurify', function(context){
-        var params = {SAFE_FOR_TEMPLATES: true, ADD_ATTR: allowedAttr};
-
-        return DOMPurify.sanitize(context, params);
+        return DOMPurify.sanitize(context);
     });
 
     /**


### PR DESCRIPTION
This changes will allow `data-action` attribute to stay on its place in datatables