### PR TITLE
Fix/tao 7517/fix csvexporter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "justinrainbow/json-schema": "5.2.1",
         "pimple/pimple": "^3.0",
         "imsglobal/lti": "^3.0",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/random_compat": "^2.0",
+        "league/csv": "^9.1"
     },
     "autoload": {
         "psr-4": {

--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '25.1.2',
+    'version' => '25.1.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -909,6 +909,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('22.13.1');
         }
         
-        $this->skip('22.13.1', '25.1.2');
+        $this->skip('22.13.1', '25.1.3');
     }
 }


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/TAO-7517

Issue: if there are many entries CsvExporter raised out of memory error.
Fix: Removed unnecessary file layer and now csv goes directly to stdout.

HOWTO Test: go to EventLog extension, push button "Export log entries"
