### PR TITLE
Fix/tao 7515/implicit dependency between d3 and c3

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '26.1.5',
+    'version' => '26.1.6',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -909,6 +909,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('22.13.1');
         }
 
-        $this->skip('22.13.1', '26.1.5');
+        $this->skip('22.13.1', '26.1.6');
     }
 }

--- a/views/build/config/requirejs.build.json
+++ b/views/build/config/requirejs.build.json
@@ -48,7 +48,7 @@
       "exports": "Class"
     },
     "c3": {
-      "deps": ["css!lib/c3js/c3.css"]
+      "deps": ["d3", "css!lib/c3js/c3.css"]
     }
   },
   "vendor" : [

--- a/views/templates/client_config.tpl
+++ b/views/templates/client_config.tpl
@@ -75,7 +75,7 @@ require.config({
         'ckeditor'              : { exports : 'CKEDITOR' },
         'ckeditor-jquery'       : ['ckeditor'],
         'class'                 : { exports : 'Class'},
-        'c3'                    : { deps : ['css!lib/c3js/c3.css']},
+        'c3'                    : { deps : ['d3', 'css!lib/c3js/c3.css']},
         'mathJax' : {
             exports : "MathJax",
             init : function(){


### PR DESCRIPTION
This Pull Request Follow Up https://github.com/oat-sa/extension-tao-proctoring/pull/669
It adds the dependency between `c3` and `d3` at the configuration level (`c3` always required `d3`). It looks like it was previously loaded by _chance_/_accident_...

This Pull Request is somehow linked to https://oat-sa.atlassian.net/browse/TAO-7515 (since the regression appeared after the update of `c3`)

How to test this pull request : 
1. Ensure the activity graph is still working on the proctoring
2. Run the tests : 
```
cd tao/views/build
npx grunt connect:test taoproctoringtest
```



