### PR TITLE
Turn off google page translation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '27.2.2',
+    'version' => '27.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.2',

--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '27.2.1',
+    'version' => '27.2.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -950,6 +950,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('27.2.0');
         }
 
-        $this->skip('27.2.0', '27.2.2');
+        $this->skip('27.2.0', '27.3.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -950,6 +950,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('27.2.0');
         }
 
-        $this->skip('27.2.0', '27.2.1');
+        $this->skip('27.2.0', '27.2.2');
     }
 }

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -19,6 +19,7 @@ $hasVersionWarning = empty($_COOKIE['versionWarning'])
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="google" content="notranslate" />
     <title><?= Layout::getTitle() ?></title>
 
     <link rel="shortcut icon" href="<?= Template::img('favicon.ico', 'tao') ?>"/>


### PR DESCRIPTION
When TAO uses another language than set in the system google chrome suggest translation the page that if applied can raise unexpected errors or understanding from users. As we have own rules about the language of the interface it makes sense to turn off this feature for the application.

Google Help says that it can be done by adding special meta tag
https://support.google.com/webmasters/answer/79812?hl=en