### PR TITLE
Fix/tao 7512/tooltips on item authoring

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '28.2.0',
+    'version' => '28.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -958,6 +958,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('27.4.0');
         }
 
-        $this->skip('27.4.0', '28.2.0');
+        $this->skip('27.4.0', '28.2.1');
     }
 }

--- a/views/js/test/ui/tooltip/test.js
+++ b/views/js/test/ui/tooltip/test.js
@@ -54,12 +54,16 @@ define([
         assert.ok(instance, 'tooltip got built from given container');
     });
     QUnit.test('Tooltip: component API', function (assert) {
+        var $container = $('#' + containerName);
         var $single;
         var instance;
         var wrapperInstance;
-        QUnit.expect(14);
-        tooltip.lookup($('#' + containerName));
-        $single = $( '[data-tooltip]', '#' + containerName).first();
+        var expectedContent = $('.tooltip-content' ,$container)[0].cloneNode(true).outerHTML;
+
+        QUnit.expect(16);
+
+        tooltip.lookup($container);
+        $single = $( '[data-tooltip]', $container).first();
         wrapperInstance = $single.data('$tooltip');
         instance = tooltip.create($single, 'default text');
         assert.equal(typeof wrapperInstance.show, 'function', 'tooltipAPI: show() defined');
@@ -76,6 +80,14 @@ define([
         assert.equal(typeof instance.updateTitleContent, 'function', 'tooltipAPI: updateTitleContent() defined');
         assert.equal(typeof instance.options, 'object', 'tooltipAPI: .options defined');
         assert.equal(typeof instance._isOpen, 'boolean', 'tooltipAPI: ._isOpen defined');
+
+        assert.equal(wrapperInstance.options.title.outerHTML, expectedContent, 'tooltip can recieve DOM element as title content');
+
+        tooltip.lookup($container);
+        wrapperInstance = $single.data('$tooltip');
+        assert.equal(wrapperInstance.options.title.outerHTML, expectedContent, 'tooltip can be rewritten by the executing it several times at the same wrapper.');
+
+
     });
     QUnit.cases(themes)
         .test('Tooltip: all themes applied', function (data, assert) {

--- a/views/js/ui/tooltip.js
+++ b/views/js/ui/tooltip.js
@@ -87,12 +87,15 @@ define([
                 $('[data-tooltip]', $container).each(function(){
                     var $content = DataAttrHandler.getTarget('tooltip', $(this));
                     var opt;
+                    var predefinedOptions = _.cloneDeep(defaultOptions);
                     themeName = _.contains(themes, $(this).data('tooltip-theme')) ? $(this).data('tooltip-theme') : 'default';
                     opt = {
                         template:themesMap[themeName]
                     };
                     if($content.length){
-                        opt = _.merge(defaultOptions, opt, { title: $content[0] });
+                        opt = _.merge(predefinedOptions, opt, { title: $content[0].cloneNode(true) });
+                    }else{
+                        opt = _.merge(predefinedOptions, opt);
                     }
                     setTooltip(this, new Tooltip(this, opt));
                 });
@@ -112,8 +115,9 @@ define([
             var calculatedOptions;
             var themeName;
             var template;
+            var predefinedOptions = _.cloneDeep(defaultOptions);
 
-            calculatedOptions = options ? _.merge(defaultOptions, options) : defaultOptions;
+            calculatedOptions = options ? _.merge(predefinedOptions, options) : predefinedOptions;
             themeName = _.contains(themes, calculatedOptions.theme) ? calculatedOptions.theme : 'default';
             template = {
                 template:themesMap[themeName]


### PR DESCRIPTION
**Task** https://oat-sa.atlassian.net/browse/TAO-7512

**summary** tooltips are not shown randomly after test item being saved in back-office.

**What was fixed** Investigation took a bit longer than expected, but I found out, that the problem was in tooltip factory function, which has been taking its params in form of DOM element *by link* instead of *shallow copy* of original DOM element, so there was collision when Tooltip factory function was executed several times with same params given.

+ Proper unit test checking collision was added.
