### PR TITLE
Route resolving fails when subfolder is used in root url

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -50,7 +50,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '30.0.3',
+    'version' => '30.0.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/models/classes/routing/Resolver.php
+++ b/models/classes/routing/Resolver.php
@@ -142,6 +142,13 @@ class Resolver implements ServiceLocatorAwareInterface
     public function getControllerShortName()
     {
         $relativeUrl = $this->request->getUri()->getPath();
+
+        $rootUrl = parse_url(ROOT_URL);
+        if (isset($rootUrl['path'])) {
+            $rootUrlPath = $rootUrl['path'];
+            $relativeUrl = str_replace(rtrim($rootUrlPath, '/'), '', $relativeUrl);
+        }
+
         $parts = explode('/', trim($relativeUrl, '/'));
         if(count($parts) === 3){
             return $parts[1];

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -970,6 +970,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('30.0.2');
         }
 
-        $this->skip('30.0.2', '30.0.3');
+        $this->skip('30.0.2', '30.0.4');
     }
 }


### PR DESCRIPTION
Added a check that verifies is the `ROOT_URL` contains a path, and if so strip it form the relative uri