### PR TITLE
[TAO-7935] WK-1281 PG - TCiaB - highlighter behavior for touchscreen

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '31.6.0',
+    'version' => '31.7.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1022,6 +1022,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('31.1.0');
         }
 
-        $this->skip('31.1.0', '31.6.0');
+        $this->skip('31.1.0', '31.7.0');
     }
 }

--- a/views/js/test/ui/highlighter/test.js
+++ b/views/js/test/ui/highlighter/test.js
@@ -873,4 +873,95 @@ define(['jquery', 'lodash', 'ui/highlighter'], function($, _, highlighterFactory
             assert.equal(fixtureContainer.innerHTML, data.output, 'highlight has been restored');
         });
 
+    QUnit.test('clearHighlights', function(assert) {
+        // Setup test
+        var highlighter = highlighterFactory({
+            className: 'hl',
+            containerSelector: '#qunit-fixture',
+            containersBlackList: [],
+        });
+        var range = document.createRange();
+
+        var fixtureContainer = document.getElementById('qunit-fixture');
+
+        assert.expect(2);
+
+        fixtureContainer.innerHTML = "<div>lorem</div>ipsum<div>dolor</div>sit<div>amet</div>";
+
+        // Create three separated higlights
+        range.setStart(fixtureContainer.childNodes[0].firstChild, 0);
+        range.setEnd(fixtureContainer.childNodes[0].firstChild, 5);
+        highlighter.highlightRanges([range]);
+
+        range.setStart(fixtureContainer.childNodes[2].firstChild, 0);
+        range.setEnd(fixtureContainer.childNodes[2].firstChild, 5);
+        highlighter.highlightRanges([range]);
+
+        range.setStart(fixtureContainer.childNodes[4].firstChild, 0);
+        range.setEnd(fixtureContainer.childNodes[4].firstChild, 4);
+        highlighter.highlightRanges([range]);
+
+        // Get higlighted node attributes
+        var highlightsAttributes = $(fixtureContainer).find('.hl')
+            .map(function (index, node) { return $(node).attr('data-hl-group'); }).toArray();
+
+        assert.deepEqual(highlightsAttributes, ["1", "2", "3"], 'Three separated higlights has been created');
+
+        // Clear all highlits
+        highlighter.clearHighlights();
+
+        assert.equal($(fixtureContainer).find('.hl').length, 0, 'All higlights has been discarded');
+    });
+
+    QUnit.test('clearSingleHighlight', function(assert) {
+        // Setup test
+        var highlighter = highlighterFactory({
+            className: 'hl',
+            containerSelector: '#qunit-fixture',
+            containersBlackList: [],
+            clearOnClick: true,
+        });
+        var range = document.createRange();
+
+        var fixtureContainer = document.getElementById('qunit-fixture');
+
+        assert.expect(4);
+
+        fixtureContainer.innerHTML = "<div>lorem</div>ipsum<div>dolor</div>sit<div>amet</div>";
+
+        // Create three separated higlights
+        range.setStart(fixtureContainer.childNodes[0].firstChild, 0);
+        range.setEnd(fixtureContainer.childNodes[0].firstChild, 5);
+        highlighter.highlightRanges([range]);
+
+        range.setStart(fixtureContainer.childNodes[2].firstChild, 0);
+        range.setEnd(fixtureContainer.childNodes[2].firstChild, 5);
+        highlighter.highlightRanges([range]);
+
+        range.setStart(fixtureContainer.childNodes[4].firstChild, 0);
+        range.setEnd(fixtureContainer.childNodes[4].firstChild, 4);
+        highlighter.highlightRanges([range]);
+
+        // Get higlighted node attributes
+        var highlightsAttributes = $(fixtureContainer).find('.hl')
+            .map(function (index, node) { return $(node).attr('data-hl-group'); }).toArray();
+
+        assert.deepEqual(highlightsAttributes, ["1", "2", "3"], 'Three separated higlights has been created');
+        var higlights = $(fixtureContainer).find('.hl');
+
+        // Clear first higlight
+        higlights[0].click();
+
+        assert.equal($(fixtureContainer).find('.hl').length, 2, 'First higlight has been discarded');
+
+        // Clear second higlight
+        higlights[1].click();
+
+        assert.equal($(fixtureContainer).find('.hl').length, 1, 'Second higlight has been discarded');
+
+        // Clear third higlight
+        higlights[2].click();
+
+        assert.equal($(fixtureContainer).find('.hl').length, 0, 'Third higlight has been discarded');
+    });
 });

--- a/views/js/ui/highlighter.js
+++ b/views/js/ui/highlighter.js
@@ -48,7 +48,7 @@ define([
      * @param {Object} options.className - name of the class that will be used by the wrappers tags to highlight text
      * @param {Object} options.containerSelector - allows to select the root Node in which highlighting is allowed
      * @param {Object} [options.containersBlackList] - additional blacklist selectors to be added to module instance's blacklist
-     * @param {Object} [options.clearOnClick] - clear single higlighted node on click
+     * @param {Object} [options.clearOnClick] - clear single highlight node on click
      * @returns {Object} - the highlighter instance
      */
     return function(options) {

--- a/views/js/ui/highlighter.js
+++ b/views/js/ui/highlighter.js
@@ -48,6 +48,7 @@ define([
      * @param {Object} options.className - name of the class that will be used by the wrappers tags to highlight text
      * @param {Object} options.containerSelector - allows to select the root Node in which highlighting is allowed
      * @param {Object} [options.containersBlackList] - additional blacklist selectors to be added to module instance's blacklist
+     * @param {Object} [options.clearOnClick] - clear single higlighted node on click
      * @returns {Object} - the highlighter instance
      */
     return function(options) {
@@ -140,6 +141,10 @@ define([
                 reindexGroups(getContainer());
                 mergeAdjacentWrappingNodes(getContainer());
             });
+
+            if (options.clearOnClick) {
+                $(containerSelector + ' .' + className).off('click').on('click', clearSingleHighlight);
+            }
         }
 
         /**
@@ -298,6 +303,15 @@ define([
             });
         }
 
+        /**
+         * Remove unwrap dom node
+         */
+        function clearSingleHighlight(e) {
+            var target = e.target;
+
+            var $wrapped = $(target);
+            $wrapped.replaceWith($wrapped.text());
+        }
 
         /**
          * Index-related functions:
@@ -552,7 +566,6 @@ define([
         function isHotNode(node) {
             return isWrappingNode(node) || isWrappable(node);
         }
-
 
         /**
          * Public API of the highlighter helper


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-7935
 
Do not discard selection on touchend during highlighting
Allow do clear highlighted node by clicking on it
Change cursor when  highlighting is activated
  
#### How to test
- Run delivery as a test taker on touchscreen device with enabled highlighting tool
- Activate highlighting tool and start selecting the text
- After triggering selection you should be allowed to resize it

- Run delivery as a test taker with enabled highlighting tool
- Highlight some text 
- After click on highlighted text it should be cleared

- Run delivery as a test taker on desktop browser with enabled highlighting tool
- After activating highlighting tool cursor above test item should be changed to marker icon

#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1264
 - [ ] https://github.com/oat-sa/extension-tao-testqti/pull/1476