### PR TITLE
FIX/TAO-7845/browser zoom behavior for touchscreen

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '31.1.0',
+    'version' => '31.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1019,7 +1019,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $ext = $this->getServiceManager()->get(\common_ext_ExtensionsManager::SERVICE_ID)->getExtensionById('tao');
             $ext->setConfig(\tao_helpers_Date::CONFIG_KEY, new EuropeanFormatter());
 
-            $this->setVersion('31.1.0');
+            $this->setVersion('31.1.1');
         }
     }
 }

--- a/views/js/lib/calculator/index.js
+++ b/views/js/lib/calculator/index.js
@@ -67,7 +67,11 @@ define(['jquery', 'lodash', 'tpl!lib/calculator/template', 'i18n', 'lib/gamp/gam
          * Gives the focus to the input
          */
         function setFocus() {
-            display.focus();
+            var isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+
+            if (!isMobile) {
+                display.focus();
+            }
         }
 
         /**


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7845

This is a fix for the Calculator zoom behavior.

**Steps to reproduce:**
Invoke calculator > Zoom in > after typing in each number, control goes to the part where the result is displayed.

**How to test on touch devices:**

- open https://act-test.taocloud.org
- find delivery http://localhost/tao.rdf#i1503426381071581600217278 (just type this in the search box in the delivery) or anyone else with Calculator.
- open delivery via lti (http://ltiapps.net/test/tc.php)
- Invoke calculator > Zoom in > after typing in each number, control goes to the part where the result is displayed.

**cause of the problem:**
When you click on the numbers, the autofocus on the textarea is triggered and because of this, the screen takes the user to this textarea.

solution to the problem:
autofocus is disabled for mobile devices because it is not needed there.