### PR TITLE
Replace jqueryui dialog by ui/modal in extension manager

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '33.4.0',
+    'version' => '33.4.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1022,6 +1022,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('31.1.0');
         }
 
-        $this->skip('31.1.0', '33.4.0');
+        $this->skip('31.1.0', '33.4.1');
     }
 }

--- a/views/js/controller/settings/extensionManager.js
+++ b/views/js/controller/settings/extensionManager.js
@@ -22,11 +22,10 @@
 define([
     'jquery',
     'i18n',
-    'context',
-    'helpers',
+    'util/url',
     'ui/feedback',
     'ui/modal'
-], function($, __, context, helpers, feedback){
+], function($, __, urlUtil, feedback){
     'use strict';
 
     var ext_installed = [];
@@ -67,11 +66,11 @@ define([
         progressConsole(__('Installing extension %s...').replace('%s', ext));
         $.ajax({
             type: "POST",
-            url: helpers._url('install', 'ExtensionsManager', 'tao'),
+            url: urlUtil.route('install', 'ExtensionsManager', 'tao'),
             data: 'id='+ext,
             dataType: 'json',
-            success: function(data) {
-                helpers.loaded();
+            success: function success(data) {
+
                 if (data.success) {
                     progressConsole(__('> Extension %s succesfully installed.').replace('%s', ext));
 
@@ -120,7 +119,7 @@ define([
         progressConsole(__('Post install processing'));
         return $.ajax({
             type: "GET",
-            url: helpers._url('postInstall', 'ExtensionsManager', 'tao')
+            url: urlUtil.route('postInstall', 'ExtensionsManager', 'tao')
         });
     }
 
@@ -130,7 +129,7 @@ define([
             $('#installProgress .bar').animate({backgroundColor:'#bb6',width:'100%'}, 1000);
 
             postInstall().done(function() {
-                helpers.loaded();
+
                 $('#installProgress .bar').animate({backgroundColor:'#6b6'}, 1000);
                 $('#installProgress p.status').text(__('Installation done.'));
                 progressConsole(__('> Installation done.'));

--- a/views/js/controller/settings/extensionManager.js
+++ b/views/js/controller/settings/extensionManager.js
@@ -239,7 +239,7 @@ define([
                 $modalContainer.modal({
                     width : 400,
                     height : 300,
-                    top: 300,
+                    top : 150,
                     disableEscape : true,
                     disableClosing : true
                 });

--- a/views/js/controller/settings/extensionManager.js
+++ b/views/js/controller/settings/extensionManager.js
@@ -1,4 +1,33 @@
-define(['jquery', 'i18n', 'context', 'helpers', 'ui/feedback'], function($, __, context, helpers, feedback){
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2019 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * Extension manager controller
+ */
+define([
+    'jquery',
+    'i18n',
+    'context',
+    'helpers',
+    'ui/feedback',
+    'ui/modal'
+], function($, __, context, helpers, feedback){
+    'use strict';
 
     var ext_installed = [];
     var toInstall = [];
@@ -20,7 +49,8 @@ define(['jquery', 'i18n', 'context', 'helpers', 'ui/feedback'], function($, __, 
     //Give an array with unique values
     function getUnique(orig){
         var a = [];
-        for (var i = 0; i < orig.length; i++) {
+        var i;
+        for (i = 0; i < orig.length; i++) {
             if ($.inArray(orig[i], a) < 0) a.push(orig[i]);
         }
         return a;
@@ -62,7 +92,7 @@ define(['jquery', 'i18n', 'context', 'helpers', 'ui/feedback'], function($, __, 
 
                             // If the available extensions table is empty,
                             // just inform the user.
-                            if ($('#available-extensions-container table tbody tr').length == 0){
+                            if ($('#available-extensions-container table tbody tr').length === 0){
                                 noAvailableExtensions();
                             }
 
@@ -99,7 +129,7 @@ define(['jquery', 'i18n', 'context', 'helpers', 'ui/feedback'], function($, __, 
             toInstall = [];
             $('#installProgress .bar').animate({backgroundColor:'#bb6',width:'100%'}, 1000);
 
-            postInstall().done(function(data) {
+            postInstall().done(function() {
                 helpers.loaded();
                 $('#installProgress .bar').animate({backgroundColor:'#6b6'}, 1000);
                 $('#installProgress p.status').text(__('Installation done.'));
@@ -135,7 +165,7 @@ define(['jquery', 'i18n', 'context', 'helpers', 'ui/feedback'], function($, __, 
     }
 
     return {
-        start : function(){
+        start : function start(){
 
             // Table styling.
             styleTables();
@@ -164,6 +194,10 @@ define(['jquery', 'i18n', 'context', 'helpers', 'ui/feedback'], function($, __, 
             });
 
             $('#available-extensions-container #installButton').click(function(event) {
+                var $modalContainer = $('#installProgress');
+
+                event.preventDefault();
+
                 //Prepare the list of extension to install in the order of dependency
                 toInstall = [];
                 $('#available-extensions-container input:checked').each(function() {
@@ -183,36 +217,33 @@ define(['jquery', 'i18n', 'context', 'helpers', 'ui/feedback'], function($, __, 
                 percentByExt = 100 / toInstall.length;
 
                 //Show the dialog with the result
-                $('#installProgress p.status').text(__('%s extension(s) to install.').replace('%s', toInstall.length));
-                $('#installProgress .bar').width(0);
-                $('#installProgress .console').empty();
+                $('.status', $modalContainer).text(__('%s extension(s) to install.').replace('%s', toInstall.length));
+                $('.bar', $modalContainer).width(0);
+                $('.console', $modalContainer).empty();
+
                 progressConsole(__('Do you wish to install the following extension(s):\n%s?').replace('%s', toInstall.join(', ')));
-                $('#installProgress').dialog({
-                    modal: true,
-                    width: 400,
-                    height: 300,
-                    buttons: [{
-                        text: __('No'),
-                        click: function() {
-                            $(this).dialog('close');
-                        }
-                    },{
-                        text: __('Yes'),
-                        click: function() {
-                            //Run the install one by one
-                            progressConsole(__('Preparing installation...'));
-                            $('.ui-widget-overlay').css({"height":"100%","width":"100%", "position":"fixed"});
-                            $('.ui-dialog-buttonpane').remove();
-                            installError = 0;
-                            indexCurrentToInstall = 0;
-                            installNextExtension();
-                        }
-                    }]
+
+                $('[data-control=cancel]', $modalContainer).on('click', function(e){
+                    e.preventDefault();
+                    $modalContainer.modal('close');
                 });
-                $('.ui-dialog').css({"position":"fixed","top":"33%"});
-                event.preventDefault();
+                $('[data-control=confirm]', $modalContainer).on('click', function(e){
+                    e.preventDefault();
+                    progressConsole(__('Preparing installation...'));
+                    $('.buttons', $modalContainer).remove();
+                    installError = 0;
+                    indexCurrentToInstall = 0;
+                    installNextExtension();
+                });
+
+                $modalContainer.modal({
+                    width : 400,
+                    height : 300,
+                    top: 300,
+                    disableEscape : true,
+                    disableClosing : true
+                });
             });
         }
     };
-
 });

--- a/views/templates/extensionManager/view.tpl
+++ b/views/templates/extensionManager/view.tpl
@@ -86,8 +86,18 @@ use oat\tao\helpers\Template;
     </div>
 
 </div>
-<div id="installProgress" title="<?= __('Installation...') ?>">
-    <div class="progress"><div class="bar"></div></div>
-    <p class="status">...</p>
-    <div class="console"></div>
+<div id="installProgress" class="modal" title="<?= __('Installation...') ?>">
+    <div class="modal-body">
+        <div class="progress"><div class="bar"></div></div>
+        <p class="status">...</p>
+        <div class="console"></div>
+        <div class="buttons rgt">
+            <button class="btn-info small key-navigation-highlight" data-control="cancel" type="button">
+                <span class="label"><?= __('No') ?></span>
+            </button>
+            <button class="btn-info small key-navigation-highlight" data-control="confirm" type="button">
+                <span class="label"><?= __('Yes') ?></span>
+            </button>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
Regression found in https://oat-sa.atlassian.net/browse/TAO-7149
 
 - The dependency to `jqueryui` wasn't declared by the module itself. It was working by chance (another module had to import it previously)
 - This PR brings a quick fix to use `ui/modal` instead of jqueryui's `dialog` 

How to reproduce : 
 - Ensure your instance is in `DEBUG_MODE` (in `config/generis.conf.php`)
 - Open the `Extension Manager` from `Settings`
 - Select extensions and click the `Install` button

What's expected : 
 - A modal popup is displayed, you can confirm or cancel the installation, follow up the installation progress  