### PR TITLE
Fix/tao 7149 remove jqueryui in vendor config

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '33.4.1',
+    'version' => '33.4.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1022,6 +1022,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('31.1.0');
         }
 
-        $this->skip('31.1.0', '33.4.1');
+        $this->skip('31.1.0', '33.4.2');
     }
 }

--- a/views/build/config/requirejs.build.json
+++ b/views/build/config/requirejs.build.json
@@ -60,7 +60,6 @@
     "tpl",
     "jquery",
     "jquery.cookie",
-    "jqueryui",
     "select2",
     "nouislider",
     "lodash",


### PR DESCRIPTION
Remove `jqueryui` from the "vendor" bundle configuration, otherwise the bundling of the extension tao-core will fail.
Without this fix the command
```
cd views/build
npx grunt taobundle
```
fails