### PR TITLE
Feature/act 322 raise log messages level in worker

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '33.5.0',
+    'version' => '33.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/models/classes/taskQueue/Queue.php
+++ b/models/classes/taskQueue/Queue.php
@@ -180,6 +180,7 @@ class Queue implements QueueInterface, TaskLogAwareInterface
         if ($task = $this->getBroker()->pop()) {
             if ($this->canDequeueTask($task)) {
                 $this->getTaskLog()->setStatus($task->getId(), TaskLogInterface::STATUS_DEQUEUED);
+                $this->logInfo('Task ' . $task->getId() . ' has been dequeued', $this->getLogContext());
             }
 
             return $task;
@@ -229,5 +230,18 @@ class Queue implements QueueInterface, TaskLogAwareInterface
     protected function canDequeueTask(TaskInterface $task)
     {
         return $this->getTaskLog()->getStatus($task->getId()) != TaskLogInterface::STATUS_CANCELLED;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getLogContext()
+    {
+        $rs = [
+            'PID' => getmypid(),
+            'QueueName' => $this->getName()
+        ];
+
+        return $rs;
     }
 }

--- a/models/classes/taskQueue/Worker/AbstractWorker.php
+++ b/models/classes/taskQueue/Worker/AbstractWorker.php
@@ -79,7 +79,7 @@ abstract class AbstractWorker implements WorkerInterface
                 // execute the task
                 $taskReport = $task();
 
-                $this->logWarning('Task ' . $task->getId() . ' has been processed.', $this->getLogContext());
+                $this->logInfo('Task ' . $task->getId() . ' has been processed.', $this->getLogContext());
 
                 if (!$taskReport instanceof Report) {
                     $this->logWarning('Task ' . $task->getId() . ' should return a report object.', $this->getLogContext());
@@ -89,11 +89,11 @@ abstract class AbstractWorker implements WorkerInterface
                 $report->add($taskReport);
 
                 unset($taskReport, $rowsTouched);
-            } catch (\Exception $e) {
-                $this->logError('Executing task ' . $task->getId() . ' failed with MSG: ' . $e->getMessage(), $this->getLogContext());
-                $report = Report::createFailure(__('Executing task %s failed', $task->getId()));
             } catch (\Error $e) {
                 $this->logCritical('Executing task ' . $task->getId() . ' failed with MSG: ' . $e->getMessage(), $this->getLogContext());
+                $report = Report::createFailure(__('Executing task %s failed', $task->getId()));
+            } catch (\Exception $e) {
+                $this->logError('Executing task ' . $task->getId() . ' failed with MSG: ' . $e->getMessage(), $this->getLogContext());
                 $report = Report::createFailure(__('Executing task %s failed', $task->getId()));
             }
 

--- a/models/classes/taskQueue/Worker/AbstractWorker.php
+++ b/models/classes/taskQueue/Worker/AbstractWorker.php
@@ -63,13 +63,13 @@ abstract class AbstractWorker implements WorkerInterface
             $report = Report::createInfo(__('Running task %s', $task->getId()));
 
             try {
-                $this->logDebug('Processing task ' . $task->getId(), $this->getLogContext());
+                $this->logInfo('Processing task ' . $task->getId(), $this->getLogContext());
 
                 $rowsTouched = $this->taskLog->setStatus($task->getId(), TaskLogInterface::STATUS_RUNNING, TaskLogInterface::STATUS_DEQUEUED);
 
                 // if the task is being executed by another worker, just return, no report needs to be saved
                 if (!$rowsTouched) {
-                    $this->logDebug('Task ' . $task->getId() . ' seems to be processed by another worker.', $this->getLogContext());
+                    $this->logInfo('Task ' . $task->getId() . ' seems to be processed by another worker.', $this->getLogContext());
                     return TaskLogInterface::STATUS_UNKNOWN;
                 }
 
@@ -78,6 +78,8 @@ abstract class AbstractWorker implements WorkerInterface
 
                 // execute the task
                 $taskReport = $task();
+
+                $this->logWarning('Task ' . $task->getId() . ' has been processed.', $this->getLogContext());
 
                 if (!$taskReport instanceof Report) {
                     $this->logWarning('Task ' . $task->getId() . ' should return a report object.', $this->getLogContext());
@@ -89,6 +91,9 @@ abstract class AbstractWorker implements WorkerInterface
                 unset($taskReport, $rowsTouched);
             } catch (\Exception $e) {
                 $this->logError('Executing task ' . $task->getId() . ' failed with MSG: ' . $e->getMessage(), $this->getLogContext());
+                $report = Report::createFailure(__('Executing task %s failed', $task->getId()));
+            } catch (\Error $e) {
+                $this->logCritical('Executing task ' . $task->getId() . ' failed with MSG: ' . $e->getMessage(), $this->getLogContext());
                 $report = Report::createFailure(__('Executing task %s failed', $task->getId()));
             }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1022,6 +1022,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('31.1.0');
         }
 
-        $this->skip('31.1.0', '33.5.0');
+        $this->skip('31.1.0', '33.6.0');
     }
 }


### PR DESCRIPTION
Some of tasks stuck on production workers and never gets executed.
To improve stability of task queue and to facilitate investigation of support issues I added a few log messages and catching `Error`.