### PR TITLE
Fix/TAO-7112/media interaction disappears after changing video size

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '34.0.0',
+    'version' => '34.0.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1035,6 +1035,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('33.6.0', '33.6.1');
+        $this->skip('34.0.0', '33.6.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1035,6 +1035,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '33.6.1');
+        $this->skip('34.0.0', '34.0.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1034,5 +1034,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $tokenStore->removeTokens();
             $this->setVersion('34.0.0');
         }
+
+        $this->skip('33.6.0', '33.6.1');
     }
 }

--- a/views/js/ui/mediasizer.js
+++ b/views/js/ui/mediasizer.js
@@ -577,7 +577,7 @@ define([
                 options.naturalWidth  = options.naturalWidth  || options.width;
                 options.naturalHeight = options.naturalHeight || options.height;
 
-                options.hasSize = options.width && options.height && _.isFinite(+options.width) && _.isFinite(options.height);
+                options.hasSize = options.width && options.height && _.isFinite(+options.width) && _.isFinite(+options.height);
 
                 // incomplete or conflicting configurations
                 // no target provided, also no width and/or no height

--- a/views/js/ui/mediasizer.js
+++ b/views/js/ui/mediasizer.js
@@ -186,7 +186,7 @@ define([
                     px: {
                         min: minWidth,
                         max: maxWidth,
-                        start: options.width
+                        start: +options.width
                     }
                 },
                 currentUnit: '%'
@@ -577,7 +577,9 @@ define([
                 options.naturalWidth  = options.naturalWidth  || options.width;
                 options.naturalHeight = options.naturalHeight || options.height;
 
-                options.hasSize = options.width && options.height && _.isNumber(options.width) && _.isNumber(options.height);
+                options.hasSize = options.width && options.height
+                    && (_.isNumber(options.width) || /^\d+$/.test(options.width))
+                    && (_.isNumber(options.height) || /^\d+$/.test(options.height));
 
                 // incomplete or conflicting configurations
                 // no target provided, also no width and/or no height

--- a/views/js/ui/mediasizer.js
+++ b/views/js/ui/mediasizer.js
@@ -577,9 +577,7 @@ define([
                 options.naturalWidth  = options.naturalWidth  || options.width;
                 options.naturalHeight = options.naturalHeight || options.height;
 
-                options.hasSize = options.width && options.height
-                    && (_.isNumber(options.width) || /^\d+$/.test(options.width))
-                    && (_.isNumber(options.height) || /^\d+$/.test(options.height));
+                options.hasSize = options.width && options.height && _.isFinite(+options.width) && _.isFinite(options.height);
 
                 // incomplete or conflicting configurations
                 // no target provided, also no width and/or no height


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-7112
 
Initial values of width and height is number, but after resizing they turned into string.
Was changed:
1. To checking `options.hasSize` added option that `options.width` and `options.height` can be string
2. Property `start` which is used  for noUiSlider was converted to number

 
#### Steps to reproduce
- Add Media interaction
- Add either uploaded video from Media or YouTube address (e.g. https://www.youtube.com/watch?v=Do3oFnaoYCM)
- Change video size
- Click "Done" button on the media interaction or click anywhere on the item authoring screen
- Click anywhere on the media interaction to activate "Interaction properties"