### PR TITLE
Fix/tao 7306/pool size fixes

### DIFF
--- a/actions/class.ClientConfig.php
+++ b/actions/class.ClientConfig.php
@@ -46,7 +46,13 @@ class tao_actions_ClientConfig extends tao_actions_CommonModule
         /** @var TokenService $tokenService */
         $tokenService = $this->getServiceLocator()->get(TokenService::SERVICE_ID);
         $tokenPool = $tokenService->generateTokenPool();
-        $jsTokenPool = array_map(function($token) { return $token->getValue(); }, $tokenPool);
+        $jsTokenPool = [];
+        foreach ($tokenPool as $key => $token) {
+            if ($key !== TokenService::FORM_POOL) {
+                $jsTokenPool[] = $token->getValue();
+
+            }
+        }
         $this->setData('tokens', json_encode([TokenService::JS_TOKEN_KEY => $jsTokenPool]));
 
         //get extension paths to set up aliases dynamically

--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '34.0.2',
+    'version' => '34.0.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1035,6 +1035,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '34.0.2');
+        $this->skip('34.0.0', '34.0.3');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7306

We had a bug where the token pool keys were being regenerated (by `usort`) and therefore the form token was misidentified and returned to the FE as a normal token. Which eventually caused a CSRF Exception.

This fix switches to `uasort` and also applies checks to get the correct pool size if the form token is present.

BE pool size is now 6 to match the FE (and the browser's limit on concurrent requests).

(code by @martijn-tao, commit by me)