### PR TITLE
Handling headers for RestNotFound exception

### DIFF
--- a/helpers/RestExceptionHandler.php
+++ b/helpers/RestExceptionHandler.php
@@ -47,6 +47,7 @@ class RestExceptionHandler
 				break;
 
 			case \common_exception_NotFound::class:
+			case \common_exception_RestNotFound::class:
 				header("HTTP/1.0 404 Not Found");
 				break;
 

--- a/manifest.php
+++ b/manifest.php
@@ -53,10 +53,10 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '34.0.3',
+    'version' => '34.1.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
-        'generis' => '>=9.0.0',
+        'generis' => '>=10.1.0',
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAO.rdf',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1035,6 +1035,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '34.0.3');
+        $this->skip('34.0.0', '34.1.0');
     }
 }


### PR DESCRIPTION
Depends on https://github.com/oat-sa/generis/pull/611

Related to https://oat-sa.atlassian.net/browse/TAO-7607

Updated `RestExceptionHandler` with a case for `\common_exception_RestNotFound`