### PR TITLE
Fix/tao 7149 tmp dialog issue jquery file download

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '34.0.5',
+    'version' => '34.0.6',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1035,6 +1035,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '34.0.5');
+        $this->skip('34.0.0', '34.0.6');
     }
 }

--- a/views/js/lib/jquery.fileDownload.js
+++ b/views/js/lib/jquery.fileDownload.js
@@ -9,7 +9,7 @@
 *   http://www.opensource.org/licenses/mit-license.php
 */
 
-define(['jquery'], function($){
+define(['jquery', 'ui/feedback'], function($, feedback){
 
 $.extend({
     //
@@ -18,7 +18,7 @@ $.extend({
     fileDownload: function (fileUrl, options) {
 
         var defaultFailCallback = function (responseHtml, url) {
-            alert("A file download error has occurred, please try again.");
+            feedback().error("A file download error has occurred, please try again.");
         };
 
         //provide some reasonable defaults to any unspecified options below
@@ -135,20 +135,17 @@ $.extend({
         if (isAndroid && httpMethodUpper != "GET") {
             //the stock android browser straight up doesn't support file downloads initiated by non GET requests: http://code.google.com/p/android/issues/detail?id=1780
 
-            if ($().dialog) {
-                $("<div>").html(settings.androidPostUnsupportedMessageHtml).dialog(settings.dialogOptions);
-            } else {
-                alert(settings.androidPostUnsupportedMessageHtml);
-            }
+            feedback().error(settings.androidPostUnsupportedMessageHtml, [], { encodeHtml : false });
+
 
             return;
         }
 
         //wire up a jquery dialog to display the preparing message if specified
-        var $preparingDialog = null;
+        var preparingDialog = null;
         if (settings.preparingMessageHtml) {
 
-            $preparingDialog = $("<div>").html(settings.preparingMessageHtml).dialog(settings.dialogOptions);
+            preparingDialog = feedback().info(settings.preparingMessageHtml, [], { encodeHtml : false });
 
         }
 
@@ -157,9 +154,11 @@ $.extend({
             onSuccess: function (url) {
 
                 //remove the perparing message if it was specified
-                if ($preparingDialog) {
-                    $preparingDialog.dialog('close');
-                };
+                if (preparingDialog) {
+                    setTimeout(function(){
+                        preparingDialog.close();
+                    }, 300);
+                }
 
                 settings.successCallback(url);
 
@@ -168,14 +167,16 @@ $.extend({
             onFail: function (responseHtml, url) {
 
                 //remove the perparing message if it was specified
-                if ($preparingDialog) {
-                    $preparingDialog.dialog('close');
-                };
+                if (preparingDialog) {
+                    setTimeout(function(){
+                        preparingDialog.close();
+                    }, 300);
+                }
 
                 //wire up a jquery dialog to display the fail message if specified
                 if (settings.failMessageHtml) {
 
-                    $("<div>").html(settings.failMessageHtml).dialog(settings.dialogOptions);
+                    feedback().error(settings.failMessageHtml, [], { encodeHtml : false });
 
                     //only run the fallcallback if the developer specified something different than default
                     //otherwise we would see two messages about how the file download failed


### PR DESCRIPTION
The library `jquery.fileDownload` was using an illegal dependency to jquery-ui, based on some options.

This PR contains a quick fix, waiting to replace this library.

How to test : 
Try to download some results with or without this PR
![image](https://user-images.githubusercontent.com/468620/57359174-56092e80-7177-11e9-90a7-5768ec5f8a0f.png)
