### PR TITLE
Fix/tao 7305/module config override for noToken

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '34.1.0',
+    'version' => '34.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=9.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1035,6 +1035,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '34.1.0');
+        $this->skip('34.0.0', '34.1.1');
     }
 }

--- a/views/js/core/request.js
+++ b/views/js/core/request.js
@@ -34,12 +34,13 @@ define([
     'jquery',
     'lodash',
     'i18n',
+    'module',
     'context',
     'core/promise',
     'core/promiseQueue',
     'core/tokenHandler',
     'core/logger'
-], function($, _, __, context, Promise, promiseQueue, tokenHandlerFactory, loggerFactory) {
+], function($, _, __, module, context, Promise, promiseQueue, tokenHandlerFactory, loggerFactory) {
     'use strict';
 
     var tokenHeaderName = 'X-CSRF-Token';
@@ -87,6 +88,10 @@ define([
      * @returns {Promise} resolves with response, or reject if something went wrong
      */
     return function request(options) {
+        // Allow external config to override user option
+        if (module.config().noToken) {
+            options.noToken = true;
+        }
 
         if (_.isEmpty(options.url)) {
             throw new TypeError('At least give a URL...');


### PR DESCRIPTION
We will allow a value `noToken` to be set in the client config for the module `core/request`. This will override whatever value the module's `request()` function is called with.

The purpose is to allow tokenisation to be turned off for testing purposes.