### PR TITLE
Fix/tao 8180 items previously selected on brs

### DIFF
--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2017 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technologies SA;
  *
  *
  */

--- a/views/js/layout/tree/provider/resourceSelector.js
+++ b/views/js/layout/tree/provider/resourceSelector.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2017 Open Assessment Technologies SA;
+ * Copyright (c) 2014-2019 Open Assessment Technologies SA;
  */
 
 /**
@@ -187,8 +187,7 @@ define([
 
                                             if(selectedContext.type === 'class'){
                                                 actionManager.exec(options.actions.selectClass, selectedContext);
-                                            }
-                                            if(selectedContext.type === 'instance'){
+                                            } else if(selectedContext.type === 'instance'){
                                                 actionManager.exec(options.actions.selectInstance, selectedContext);
                                             }
 

--- a/views/js/ui/resource/list.js
+++ b/views/js/ui/resource/list.js
@@ -52,7 +52,7 @@ define([
      * @param {jQueryElement} $container - where to append the component
      * @param {Object} config - the component config
      * @param {String} config.classUri - the root Class URI
-     * @param {Objet[]} [config.nodes] - the nodes to preload
+     * @param {Object[]} [config.nodes] - the nodes to preload
      * @param {String} [config.icon] - the icon class to show close to the resources
      * @param {Boolean} [config.multiple = true] - multiple vs unique selection
      * @returns {resourceList} the component

--- a/views/js/ui/resource/selectable.js
+++ b/views/js/ui/resource/selectable.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -186,10 +186,11 @@ define([
              * Apply the selection to the given URIs.
              * @param {String[]} uris - the list of URIs to select
              * @param {Boolean} [only=false] - if true the selection is done "only" on the given URIs (unselect previous)
+             * @param {Boolean} [onlyVisible=true] - if true the selection was done "only" for visible nodes.
              * @returns {selectable} chains
              * @fires selectable#change
              */
-            select : function select(uris, only){
+            select : function select(uris, only, onlyVisible){
                 var $component;
                 var currentConfig  = getConfig();
 
@@ -229,9 +230,23 @@ define([
                                 selection[uri] = nodes[uri];
                             }
                         });
-                    this.trigger('change', selection);
+                    this.trigger('change', selection, onlyVisible);
                 }
                 return this;
+            },
+
+            /**
+             * Select only all visible nodes.
+             * @returns {Object[]} nodes
+             */
+            selectVisible: function selectVisible(){
+                var $component = this.getElement();
+                var $elements = $component.find('[data-uri]').filter(function () {
+                    return $(this).parents('.closed').length === 0;
+                });
+                this.select(_.map($elements, function (element) {
+                    return $(element).data('uri');
+                }), false, true);
             },
 
             /**
@@ -265,15 +280,14 @@ define([
                 }
                 return this;
             },
-
             /**
              * Select all nodes.
              * @returns {selectable} chains
              * @fires selectable#change
              */
             selectAll : function selectAll(){
-                return this.select(_.keys(nodes));
-            },
+                return this.selectVisible();
+            }
         });
     };
 });

--- a/views/js/ui/resource/selector.js
+++ b/views/js/ui/resource/selector.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -103,7 +103,7 @@ define([
         return _(resources)
             .filter({ type : nodeTypes.class })
             .map(function(resource){
-                var classNode = _.pick(resource, ['uri', 'label']);
+                var classNode = _.pick(resource, ['uri', 'label', 'signature', 'state']);
 
                 if(resource.children){
                     classNode.children = filterClasses(resource.children);
@@ -120,7 +120,7 @@ define([
      * @param {String} config.classUri - the root Class URI
      * @param {Object|[]} [config.classes] - the classes hierarchy for the class selector
      * @param {Object[]} config.formats - the definition of the supported viewer/selector component
-     * @param {Objet[]} [config.nodes] - the nodes to preload, the format is up to the formatComponent
+     * @param {Object[]} [config.nodes] - the nodes to preload, the format is up to the formatComponent
      * @param {String} [config.icon] - the icon class that represents a resource
      * @param {String} [config.type] - describes the resource type
      * @param {Boolean} [config.selectionMode] - multiple or single selection mode
@@ -377,8 +377,8 @@ define([
                             }
                             self.trigger('update');
                         })
-                        .on('change', function(selected){
-                            self.trigger('change', selected);
+                        .on('change', function(selected, onlyVisible){
+                            self.trigger('change', selected, onlyVisible);
                         })
                         .on('error', function(err){
                             self.trigger('error', err);
@@ -531,7 +531,7 @@ define([
                         $resource = this.getElement().find('.' + nodeTypes.instance);
                         if(!$resource.length){
                             $resource = this.getElement().find('.' + nodeTypes.class);
-                    }
+                        }
                         if($resource.length){
                             this.select( $resource.first().data('uri') );
                         }
@@ -729,10 +729,10 @@ define([
                     self.query();
                 });
             })
-            .on('change', function(selected){
+            .on('change', function(selected, onlyVisible){
 
-                var nodesCount = _.size(this.selectionComponent.getNodes());
                 var selectedCount = _.size(selected);
+                var nodesCount = onlyVisible ? selectedCount : _.size(this.selectionComponent.getNodes());
 
                 //the number selected at the bottom
                 $selectNum.text(selectedCount);
@@ -742,7 +742,8 @@ define([
                     $selectCtrlLabel.attr('title', __('Select loaded %s', this.config.type));
                     $selectCtrl.prop('checked', false)
                                .prop('indeterminate', false);
-                } else if (selectedCount === nodesCount) {
+                // if all of the nodes are selected (or more in the closed subclasses)
+                } else if (selectedCount >= nodesCount) {
                     $selectCtrlLabel.attr('title', __('Clear selection'));
                     $selectCtrl.prop('checked', true)
                                .prop('indeterminate', false);

--- a/views/js/ui/resource/tree.js
+++ b/views/js/ui/resource/tree.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
  */
 
 /**
@@ -117,7 +117,7 @@ define([
      * @param {jQueryElement} $container - where to append the component
      * @param {Object} config - the component config
      * @param {String} config.classUri - the root Class URI
-     * @param {Objet[]} [config.nodes] - the nodes to preload
+     * @param {Object[]} [config.nodes] - the nodes to preload
      * @param {String} [config.icon] - the icon class to show close to the resources
      * @param {Boolean} [config.multiple = true] - multiple vs unique selection
      * @returns {resourceTree} the component
@@ -183,11 +183,11 @@ define([
                         if(!node.state){
                             node.state = 'empty';
                         }
-                        self.addNode(node.uri,  _.omit(node, ['count', 'state', 'children']));
+                        self.addNode(node.uri,  _.omit(node, ['count', 'children']));
                     }
                     if(node.type === 'instance'){
                         node.selectable = true;
-                        self.addNode(node.uri,  _.omit(node, ['count', 'state', 'children']));
+                        self.addNode(node.uri,  _.omit(node, ['count', 'children']));
                         node.icon = config.icon;
                     }
                     if(node.children && node.children.length){
@@ -258,13 +258,16 @@ define([
                  * @param {jQueryElement} $class
                  */
                 var openClass = function openClass($class){
-                    if($class.hasClass('closed')){
-                        if(!$class.children('ul').children('li').length){
-                            self.query({ classUri : $class.data('uri') });
-                        }  else {
-                            $class.removeClass('closed');
-                        }
+                    var node = self.getNode($class.data('uri'));
+
+                    if(!$class.children('ul').children('li').length){
+                        self.query({ classUri : $class.data('uri') });
                     }
+                    if(node) {
+                        node.state = 'open';
+                        self.update([node]);
+                    }
+                    $class.removeClass('closed');
                 };
 
                 /**
@@ -272,6 +275,11 @@ define([
                  * @param {jQueryElement} $class
                  */
                 var closeClass = function closeClass($class){
+                    var node = self.getNode($class.data('uri'));
+                    if(node) {
+                        node.state = 'closed';
+                        self.update([node]);
+                    }
                     $class.addClass('closed');
                 };
 


### PR DESCRIPTION
Reverts oat-sa/tao-core#2103
Revert reason: merged before Bertrand's review.

Created getVisibleNodes() to get visible nodes, based on parent nodes status (more like a work around oposed by getting direct tree structured data).
Also on change nodesCount based on visible nodes, for switching the selectAll checkbox.

https://oat-sa.atlassian.net/browse/TAO-8180