### PR TITLE
Fix/maths evaluator on chrome

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '34.2.1',
+    'version' => '34.2.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=10.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1035,6 +1035,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '34.2.1');
+        $this->skip('34.0.0', '34.2.2');
     }
 }

--- a/views/js/lib/decimal/LICENCE.md
+++ b/views/js/lib/decimal/LICENCE.md
@@ -1,6 +1,6 @@
 The MIT Licence.
 
-Copyright (c) 2018 Michael Mclaughlin
+Copyright (c) 2019 Michael Mclaughlin
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Since a few days the unit tests for the `mathsEvaluator` tool were failing. This is due to a change in the Maths engine Chrome is supplying.

The third-party lib `decimal.js` must be updated, as the issue is fixed by a workaround: https://github.com/MikeMcl/decimal.js/issues/128

To test it, with and without this PR:

```
cd tao/views/build
npx grunt connect:dev qunit:single --test=/tao/views/js/test/util/mathsEvaluator/test.html
```