### PR TITLE
Fix/tao 8315/disable csrf for messages

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '35.1.0',
+    'version' => '35.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1035,6 +1035,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '35.1.0');
+        $this->skip('34.0.0', '35.1.1');
     }
 }

--- a/views/js/core/communicator/poll.js
+++ b/views/js/core/communicator/poll.js
@@ -126,7 +126,7 @@ define([
                         dataType: 'json',
                         contentType: 'application/json',
                         sequential: true,
-                        noToken: true, // TODO: tokens disabled here as temporary fix for TAO-8315
+                        noToken: false,
                         timeout: config.timeout
                     })
                     .then(function(response) {

--- a/views/js/core/communicator/poll.js
+++ b/views/js/core/communicator/poll.js
@@ -25,8 +25,8 @@ define([
     'core/communicator',
     'core/polling',
     'core/promise',
-    'core/tokenHandler'
-], function ($, _, __, communicator, pollingFactory, Promise, tokenHandlerFactory) {
+    'core/request'
+], function ($, _, __, communicator, pollingFactory, Promise, coreRequest) {
     'use strict';
 
     /**
@@ -92,9 +92,6 @@ define([
         init: function init() {
             var self = this;
             var config = _.defaults(this.getConfig(), defaults);
-            var tokenHandler = tokenHandlerFactory({
-                initialToken: config.token
-            });
 
             // validate the config
             if (!config.service) {
@@ -121,90 +118,51 @@ define([
                     });
                     self.messagesQueue = [];
 
-                    tokenHandler.getToken().then(function(token) {
-                        if (token) {
-                            headers['X-CSRF-Token'] = token;
+                    coreRequest({
+                        url: config.service,
+                        method: 'POST',
+                        headers: headers,
+                        data: JSON.stringify(req),
+                        dataType: 'json',
+                        contentType: 'application/json',
+                        sequential: true,
+                        noToken: true, // TODO: tokens disabled here as temporary fix for TAO-8315
+                        timeout: config.timeout
+                    })
+                    .then(function(response) {
+                        // resolve each message promises
+                        _.forEach(promises, function (promise, idx) {
+                            promise.resolve(response.responses && response.responses[idx]);
+                        });
+
+                        if (!self.polling.is('stopped')) {
+                            // receive server messages
+                            _.forEach(response.messages, function (msg) {
+                                if (msg.channel) {
+                                    self.trigger('message', msg.channel, msg.message);
+                                } else {
+                                    self.trigger('message', 'malformed', msg);
+                                }
+                            });
                         }
 
-                        // send messages to the remote service
-                        $.ajax({
-                            url: config.service,
-                            type: 'POST',
-                            cache: false,
-                            headers: headers,
-                            data: JSON.stringify(req),
-                            async: true,
-                            dataType: 'json',
-                            contentType: 'application/json',
-                            timeout: config.timeout
-                        })
-                        // when the request succeeds...
-                        .done(function (response, status, xhr) {
-                            response = response || {};
+                        self.trigger('receive', response);
 
-                            // resolve each message promises
-                            _.forEach(promises, function (promise, idx) {
-                                promise.resolve(response.responses && response.responses[idx]);
-                            });
+                        resolve();
+                    })
+                    .catch(function(error) {
+                        error.source = 'network';
+                        error.purpose = 'communicator';
 
-                            if (!self.polling.is('stopped')) {
-                                // receive server messages
-                                _.forEach(response.messages, function (msg) {
-                                    if (msg.channel) {
-                                        self.trigger('message', msg.channel, msg.message);
-                                    } else {
-                                        self.trigger('message', 'malformed', msg);
-                                    }
-                                });
-                            }
-
-                            self.trigger('receive', response);
-
-                            // receive optional security token
-                            if (xhr && _.isFunction(xhr.getResponseHeader)) {
-                                response.token = xhr.getResponseHeader('X-CSRF-Token');
-                                if (response.token) {
-                                    tokenHandler.setToken(response.token)
-                                    .then(function() {
-                                        resolve();
-                                    });
-                                }
-                            }
-                            resolve();
-                        })
-
-                        // when the request fails...
-                        .fail(function (jqXHR, textStatus, errorThrown) {
-                            var error = {
-                                source: 'network',
-                                purpose: 'communicator',
-                                context: this,
-                                sent: jqXHR.readyState > 0,
-                                code: jqXHR.status,
-                                type: textStatus || 'error',
-                                message: errorThrown || __('An error occurred!')
-                            };
-
-                            // reject all message promises
-                            _.forEach(promises, function (promise) {
-                                promise.reject(error);
-                            });
-
-                            self.trigger('error', error);
-
-                            // the request promise must be resolved, even if failed, to continue the polling
-                            // reset the security token on error
-                            if (token) {
-                                tokenHandler.setToken(token)
-                                .then(function() {
-                                    resolve();
-                                });
-                            }
-                            resolve();
+                        // reject all message promises
+                        _.forEach(promises, function (promise) {
+                            promise.reject(error);
                         });
+
+                        self.trigger('error', error);
+
+                        resolve();
                     });
-
-
                 });
             };
 

--- a/views/js/core/request.js
+++ b/views/js/core/request.js
@@ -56,9 +56,10 @@ define([
      * @param {Object} response - the server body response as plain object
      * @param {String} fallbackMessage - the error message in case the response isn't correct
      * @param {Number} httpCode - the response HTTP code
+     * @param {Boolean} httpSent - the sent status
      * @returns {Error} the new error
      */
-    var createError = function createError(response, fallbackMessage, httpCode) {
+    var createError = function createError(response, fallbackMessage, httpCode, httpSent) {
         var err;
         if (response && response.errorCode) {
             err = new Error(response.errorCode + ' : ' + (response.errorMsg || response.errorMessage || response.error));
@@ -66,6 +67,8 @@ define([
             err = new Error(fallbackMessage);
         }
         err.response = response;
+        err.sent = httpSent;
+
         if (httpCode) {
             err.code = httpCode;
         }
@@ -161,25 +164,25 @@ define([
                             .then(function() {
                                 if (xhr.status === 204 || (response && response.errorCode === 204) || status === 'nocontent') {
                                     // no content, so resolve with empty data.
-                                    resolve();
+                                    return resolve();
                                 }
 
                                 // handle case where token expired or invalid
                                 if (xhr.status === 403 || (response && response.errorCode === 403)) {
-                                    reject(createError(response, xhr.status + ' : ' + xhr.statusText, xhr.status));
+                                    return reject(createError(response, xhr.status + ' : ' + xhr.statusText, xhr.status, xhr.readyState > 0));
                                 }
 
                                 if (response && response.success === true) {
                                     // there's some data
-                                    resolve(response);
+                                    return resolve(response);
                                 }
 
                                 //the server has handled the error
-                                reject(createError(response, __('The server has sent an empty response'), xhr.status));
+                                reject(createError(response, __('The server has sent an empty response'), xhr.status, xhr.readyState > 0));
                             })
                             .catch(function(error) {
                                 logger.error(error);
-                                reject(createError(response, error, xhr.status));
+                                reject(createError(response, error, xhr.status, xhr.readyState > 0));
                             });
                     })
                     .fail(function(xhr, textStatus, errorThrown) {
@@ -204,11 +207,11 @@ define([
 
                         setTokenFromXhr(xhr)
                             .then(function () {
-                                reject(createError(response, xhr.status + ' : ' + xhr.statusText, xhr.status));
+                                reject(createError(response, xhr.status + ' : ' + xhr.statusText, xhr.status, xhr.readyState > 0));
                             })
                             .catch(function(error) {
                                 logger.error(error);
-                                reject(createError(response, error, xhr.status));
+                                reject(createError(response, error, xhr.status, xhr.readyState > 0));
                             });
                     });
                 });

--- a/views/js/test/core/communicator/request/messages.json
+++ b/views/js/test/core/communicator/request/messages.json
@@ -1,4 +1,5 @@
 {
+  "success": true,
   "responses": [
     "ok"
   ]


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8315

The short term fix for this bug will be to disable CSRF tokens for the "messages" feature used by some customers.

I rewrote the polling request to use the new `core/request` module, so that the requests will be guaranteed sequential and it's easy to turn the tokens on/off later.

Also rewrote the unit test and made a necessary improvement to `core/request`.

Should be tested in the Test Runner on ACT and NFER envs.