### PR TITLE
Fix/tao 7306/token error with kv storage

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '35.1.0',
+    'version' => '35.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.0.0',

--- a/models/classes/security/xsrf/Token.php
+++ b/models/classes/security/xsrf/Token.php
@@ -88,7 +88,7 @@ class Token implements JsonSerializable
     public function jsonSerialize()
     {
         return [
-            self::TOKEN_KEY     => $this->getToken(),
+            self::TOKEN_KEY     => $this->getValue(),
             self::TIMESTAMP_KEY => $this->getCreatedAt(),
         ];
     }

--- a/models/classes/security/xsrf/TokenStoreKeyValue.php
+++ b/models/classes/security/xsrf/TokenStoreKeyValue.php
@@ -46,11 +46,11 @@ class TokenStoreKeyValue extends ConfigurableService implements TokenStore
     public function getTokens()
     {
         $value = $this->getPersistence()->get($this->getKey());
-        $storedTokens = json_decode($value, true);
+        $storedTokens = json_decode($value, true) ?: [];
         $pool = [];
 
-        foreach ($storedTokens as $storedToken) {
-            $pool[] = new Token($storedToken);
+        foreach ($storedTokens as $key => $storedToken) {
+            $pool[$key] = new Token($storedToken);
         }
 
         return $pool;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1035,6 +1035,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('34.0.0');
         }
 
-        $this->skip('34.0.0', '35.1.0');
+        $this->skip('34.0.0', '35.1.1');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7306 - see comment by Ilya.

This is a correction for a few issues in the token pool backend which were causing a 500 error when key-value storage was configured for token storage.
- wrong method name in `jsonSerialize()`
- no fallback for `json_decode()`
- special form token key lost during `getTokens()`

Solution provided by @martijn-tao

To test:
```
change store in `config/tao/security-xsrf-token.conf.php` to 
'store' => new oat\tao\model\security\xsrf\TokenStoreKeyValue(array(
'persistence' => 'cache'
)),
```
and use TAO without errors.