### PR TITLE
Fix/tao 7305/poll unit test disable token

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '35.4.1',
+    'version' => '35.4.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1050,6 +1050,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.4.0');
         }
 
-        $this->skip('35.4.0', '35.4.1');
+        $this->skip('35.4.0', '35.4.2');
     }
 }

--- a/views/js/test/core/communicator/poll/test.html
+++ b/views/js/test/core/communicator/poll/test.html
@@ -21,8 +21,8 @@
                 //some mocks
                 requirejs.config({
                     "config": {
-                        "core/tokenHandler" : {
-                            tokens: ['mytoken1', 'mytoken2', 'mytoken3', 'mytoken4', 'mytoken5']
+                        "core/request" : {
+                            noToken: true
                         }
                     }
                 });


### PR DESCRIPTION
The polling unit test was using up its supply of provided tokens. I'm turning off the token requirement in that file, using the module config.

To test: `cd tao/views/build && npm i && npx grunt connect:dev taotest`