### PR TITLE
Fix/TAO-8318/Proctor terminated session

### DIFF
--- a/views/js/core/request.js
+++ b/views/js/core/request.js
@@ -172,7 +172,7 @@ define([
                                     return reject(createError(response, xhr.status + ' : ' + xhr.statusText, xhr.status, xhr.readyState > 0));
                                 }
 
-                                if (xhr.status === 200 || response && response.success === true) {
+                                if (xhr.status === 200 || ( response && response.success === true)) {
                                     // there's some data
                                     return resolve(response);
                                 }

--- a/views/js/core/request.js
+++ b/views/js/core/request.js
@@ -172,7 +172,7 @@ define([
                                     return reject(createError(response, xhr.status + ' : ' + xhr.statusText, xhr.status, xhr.readyState > 0));
                                 }
 
-                                if (response && response.success === true) {
+                                if (xhr.status === 200 || response && response.success === true) {
                                     // there's some data
                                     return resolve(response);
                                 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-8318

Bug related to these changes in request.js https://github.com/oat-sa/tao-core/commit/260e99238934420d583953d4e5fb1e7f2176e970#diff-2e6dd4d72bb11ed226ad289bbade954cR164

Request URL: https://nccersso.taocloud.org/taoQtiTest/Runner/move
Status Code: **200 OK**
Response in this case: 
```js
{**"success":false**,"type":"TestState","code":4,"message":"The assessment has been terminated. You cannot interact with it anymore.","messages":[{"channel":"teststate","message":{"type":"close","code":4,"message":"The assessment has been terminated. You cannot interact with it anymore. Please contact your proctor if required."}}]}
```

In case xhr.status 200 and `response.success === false` response will be put in new Error by function `createError`
https://github.com/oat-sa/tao-core/blob/a8dcde9b87d14e89a2f8db2422d907cbb31d6ec4/views/js/core/request.js#L181
https://github.com/oat-sa/tao-core/blob/a8dcde9b87d14e89a2f8db2422d907cbb31d6ec4/views/js/core/request.js#L62-L76

**and then in proxy message will not be send to channel teststate**
because of condition if (response.data && response.data.messages)
https://github.com/oat-sa/extension-tao-test/blob/06d14c4083fa9594d6dfa718ab80e4ff804a38c2/views/js/runner/proxy.js#L599-L611

on this step, we have such response:
![image](https://user-images.githubusercontent.com/25976342/58258466-76420b80-7d7b-11e9-8032-bb84b42b6139.png)

and in testState plugin test will not be closed
https://github.com/oat-sa/extension-tao-testqti/blob/7a2fc0e7fd5f398249164b8a55e27d23b05ec318/views/js/runner/plugins/controls/testState/testState.js#L75-L84

**Solution 1**
**Case with code 200 and response.success === false is considered as a correct response** and promise will be resolved (like it was previously)
Revert changes done by https://github.com/oat-sa/tao-core/commit/260e99238934420d583953d4e5fb1e7f2176e970#diff-2e6dd4d72bb11ed226ad289bbade954cR164

Another fact for this solution: this case ( response.success=false ) will be handled in qtiServiceProxy https://github.com/oat-sa/extension-tao-testqti/blob/7a2fc0e7fd5f398249164b8a55e27d23b05ec318/views/js/runner/proxy/qtiServiceProxy.js#L98-L102

**Solution 2**
**Case with code 200 and response.success === false is considered as an error** and promise will be rejected (like it was now)
To change condition in proxy.js to process case with error, for example:
```
var messages = response.data && (response.data.messages || response.data.response && response.data.response.messages);
```

#### Steps to reproduce
1. Start a test and authorize by proctor
2. Pass some items and terminate session by proctor
3. Click next as TT