### PR TITLE
Fix/tao 8312/add British english language label

### DIFF
--- a/locales/en-GB/lang.rdf
+++ b/locales/en-GB/lang.rdf
@@ -2,7 +2,7 @@
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xml:base="http://www.tao.lu/Ontologies/TAO.rdf#">
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAO.rdf#Langen-GB">
     <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#Languages"/>
-    <rdfs:label xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xml:lang="en-US"><![CDATA[]]></rdfs:label>
+    <rdfs:label xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xml:lang="en-US"><![CDATA[British English]]></rdfs:label>
     <rdf:value><![CDATA[en-GB]]></rdf:value>
     <tao:LanguageUsages xmlns:tao="http://www.tao.lu/Ontologies/TAO.rdf#" rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#LanguageUsageGUI"/>
     <tao:LanguageUsages xmlns:tao="http://www.tao.lu/Ontologies/TAO.rdf#" rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#LanguageUsageData"/>

--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '35.8.1',
+    'version' => '35.8.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.3.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1051,5 +1051,19 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('35.4.0', '35.8.1');
+
+        if ($this->isVersion('35.8.1')) {
+            OntologyUpdater::syncModels();
+
+            $iterator = new FileIterator(__DIR__ . '/../../locales/en-GB/lang.rdf');
+            $rdf = ModelManager::getModel()->getRdfInterface();
+
+            /* @var \core_kernel_classes_Triple $triple */
+            foreach ($iterator as $triple) {
+                $rdf->remove($triple);
+                $rdf->add($triple);
+            }
+            $this->setVersion('35.8.2');
+        }
     }
 }


### PR DESCRIPTION
Add British english language label value
Steps to reproduce:
1 Go to backend office -> user settings (/tao/Main/indexstructure=user_settings&ext=tao&section=settings_my_settings) 
2 look into Interface language list.
Expected result: in this list exist option value->en-GB, label->English British
Actual result: in this list exist option value->en-GB, but with an empty label

