### PR TITLE
FIX/TAO-8396/Secure-mode-doesn't-work

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '35.8.0',
+    'version' => '35.8.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.3.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1050,6 +1050,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.4.0');
         }
 
-        $this->skip('35.4.0', '35.8.0');
+        $this->skip('35.4.0', '35.8.1');
     }
 }

--- a/views/js/ui/dialog/alert.js
+++ b/views/js/ui/dialog/alert.js
@@ -32,12 +32,13 @@ define(['lodash', 'ui/dialog'], function (_, dialog) {
         var dlg = dialog({
             message: message,
             buttons: 'ok',
-            autoDestroy: true
+            autoDestroy: true,
+            autoRender: true
         }).on('create.dialog', function(){
             if (onCreateDialog) {
                 onCreateDialog();
             }
-        }).render();
+        });
 
         if (_.isFunction(action)) {
             dlg.on('closed.modal', action);


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8396
https://oat-sa.atlassian.net/browse/TAO-8397

**Steps to reproduce**:

Open test in secure mode
Wait for the modal window to appear.

**Expected result**: The test is launch in secure mode successfully.

**Actual result**: Error message 'Error: Cannot read property 'shortcut' of undefined' is appeared, an user is not able to proceed the test.

**reason**: change logic for tests. https://github.com/oat-sa/tao-core/pull/2134/files
