### PR TITLE
file_path argument in taoInstall is now required + bump version.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '27.1.2',
+    'version' => '27.1.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.2',

--- a/scripts/taoInstall.php
+++ b/scripts/taoInstall.php
@@ -57,6 +57,7 @@ $installDetails = [
 	        'name'			=> 'file_path',
 	        'type'			=> 'string',
 	        'shortcut'		=> 'f',
+	        'required'		=> true,
 	        'description'	=> 'Path to where files should be stored.'
 	    ],
 	    [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -925,6 +925,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('27.0.0');
         }
 
-        $this->skip('27.0.0', '27.1.2');
+        $this->skip('27.0.0', '27.1.3');
     }
 }


### PR DESCRIPTION
The change in this PR affects the way the install scripts checks the CLI parameters.
Now the file_path parameter has to be provided.
To test it, you can use the example from the README.md (which is also to be updated to indicate this change):
sudo -u www-data php tao/scripts/taoInstall.php --db_driver pdo_mysql --db_host localhost --db_name taoUnitTest --db_user myuser --db_pass tao \
--file_path /var/data \
--module_namespace http://sample/first.rdf --module_url http://myurl --user_login admin --user_pass admin -e taoCe
