### PR TITLE
file_path is now optional in web installer.

### DIFF
--- a/install/js/step_server_setup.js
+++ b/install/js/step_server_setup.js
@@ -69,6 +69,11 @@ require(['config'], function() {
 
             setTimeout(function() { // Fake additional delay for user - 500ms.
                 var file_path = install.getData('file_path');
+                // Fixing file_path default value.
+                if (file_path === null) {
+                    file_path = '/var/data/';
+                    $('#file_path').val(file_path);
+                }
                 var file_path_overwrite = install.getData('file_path_overwrite');
 
                 var check = {

--- a/install/js/step_server_setup.js
+++ b/install/js/step_server_setup.js
@@ -71,7 +71,7 @@ require(['config'], function() {
                 var file_path = install.getData('file_path');
                 // Fixing file_path default value.
                 if (file_path === null) {
-                    file_path = '/var/data/';
+                    file_path = 'data';
                     $('#file_path').val(file_path);
                 }
                 var file_path_overwrite = install.getData('file_path_overwrite');

--- a/install/js/step_server_setup.js
+++ b/install/js/step_server_setup.js
@@ -186,6 +186,14 @@ require(['config'], function() {
                     validifyNotMandatory(this);
                     break;
 
+                case 'file_path':
+                    install.getValidator(this, {
+                        dataType: 'string',
+                        mandatory: false
+                    });
+                    validifyNotMandatory(this);
+                    break;
+
                 default:
                     install.getValidator(this);
                     break;

--- a/install/services/class.CheckFileSystemComponentService.php
+++ b/install/services/class.CheckFileSystemComponentService.php
@@ -23,19 +23,19 @@
 /**
  * A Service implementation aiming at checking the existence and the validity of rights
  * of file system components, in other words files and directorties.
- * 
+ *
  * Please refer to tao/install/api.php for more information about how to call this service.
  *
  * @access public
  * @author Jerome Bogaerts, <jerome@taotesting.com>
  * @package tao
- 
+
  */
-class tao_install_services_CheckFileSystemComponentService 
+class tao_install_services_CheckFileSystemComponentService
 	extends tao_install_services_Service
 	implements tao_install_services_CheckService
 	{
-    
+
     /**
      * Creates a new instance of the service.
      * @param tao_install_services_Data $data The input data to be handled by the service.
@@ -44,18 +44,18 @@ class tao_install_services_CheckFileSystemComponentService
     public function __construct(tao_install_services_Data $data){
         parent::__construct($data);
     }
-    
+
     /**
      * Executes the main logic of the service.
      * @return tao_install_services_Data The result of the service execution.
      */
     public function execute(){
-    	
+
         $fsc = self::buildComponent($this->getData());
-        $report = $fsc->check();                       
+        $report = $fsc->check();
         $this->setResult(self::buildResult($this->getData(), $report, $fsc));
     }
-    
+
     protected function checkData(){
     	$content = json_decode($this->getData()->getContent(), true);
         if (!isset($content['type']) || empty($content['type'])){
@@ -77,10 +77,21 @@ class tao_install_services_CheckFileSystemComponentService
             throw new InvalidArgumentException("Missing data: 'location' must be provided.");
         }
     }
-    
+
     public static function buildComponent(tao_install_services_Data $data){
     	$content = json_decode($data->getContent(), true);
         $location = $content['value']['location'];
+
+        if ($content['value']['id'] === 'fs_data') {
+            if ($location === '') {
+                $location = 'data';
+            }
+            if (substr($location, 0, 1) !== '/') {
+                $location = __DIR__ . '/../../../' . $location;
+            }
+            $location = realpath($location);
+        }
+
         $rights = $content['value']['rights'];
         $recursive = isset($content['value']['recursive']) && (bool) $content['value']['recursive'];
     	if (isset($content['value']['optional'])) {
@@ -95,10 +106,10 @@ class tao_install_services_CheckFileSystemComponentService
         } else {
             $mustCheckIfEmpty = false;
         }
-        
+
         return common_configuration_ComponentFactory::buildFileSystemComponent($location, $rights, $optional, $recursive, $mustCheckIfEmpty);
     }
-    
+
     public static function buildResult(
         tao_install_services_Data $data,
         common_configuration_Report $report,
@@ -107,7 +118,7 @@ class tao_install_services_CheckFileSystemComponentService
 		$content = json_decode($data->getContent(), true);
         $rights = $content['value']['rights'];
         $id = $content['value']['id'];
-        
+
         $data = array('type' => 'FileSystemComponentReport',
                       'value' => array(
                            'status' => $report->getStatusAsString(),
@@ -124,8 +135,8 @@ class tao_install_services_CheckFileSystemComponentService
                            'location' => $component->getLocation()
                       )
         );
-        
-        return new tao_install_services_Data(json_encode($data));						   	
+
+        return new tao_install_services_Data(json_encode($data));
 	}
 }
 ?>

--- a/install/services/class.CheckFileSystemComponentService.php
+++ b/install/services/class.CheckFileSystemComponentService.php
@@ -87,9 +87,8 @@ class tao_install_services_CheckFileSystemComponentService
                 $location = 'data';
             }
             if (substr($location, 0, 1) !== '/') {
-                $location = __DIR__ . '/../../../' . $location;
+                $location = dirname(dirname(dirname(__DIR__))) . '/' . $location;
             }
-            $location = realpath($location);
         }
 
         $rights = $content['value']['rights'];

--- a/install/tpl_step_server_setup.html
+++ b/install/tpl_step_server_setup.html
@@ -70,7 +70,7 @@
                     <li>
                         <label for="file_path">Enter the path to the directory where TAO will store files.</label><br />
                         <input type="text" id="file_path" name="file_path" class="tao-input" title="e.g. /var/data/"/>
-                        <div title="learn more on this topic" class="icons ui-state-default ui-corner-all"><a id="hlp_file_path" class="ui-icon ui-icon-help"></a></div><span class="formMandatory">*</span>
+                        <div title="learn more on this topic" class="icons ui-state-default ui-corner-all"><a id="hlp_file_path" class="ui-icon ui-icon-help"></a></div>
                     </li>
                     <li>
                         <label for="file_path_overwrite">Overwrite TAO installation data folder if already exists?</label><br/>

--- a/install/tpl_step_server_setup.html
+++ b/install/tpl_step_server_setup.html
@@ -69,7 +69,7 @@
                     </li>
                     <li>
                         <label for="file_path">Enter the path to the directory where TAO will store files.</label><br />
-                        <input type="text" id="file_path" name="file_path" class="tao-input" title="e.g. /var/data/"/>
+                        <input type="text" id="file_path" name="file_path" class="tao-input" title="Defaults to /var/data/"/>
                         <div title="learn more on this topic" class="icons ui-state-default ui-corner-all"><a id="hlp_file_path" class="ui-icon ui-icon-help"></a></div>
                     </li>
                     <li>

--- a/install/tpl_step_server_setup.html
+++ b/install/tpl_step_server_setup.html
@@ -69,7 +69,7 @@
                     </li>
                     <li>
                         <label for="file_path">Enter the path to the directory where TAO will store files.</label><br />
-                        <input type="text" id="file_path" name="file_path" class="tao-input" title="Defaults to /var/data/"/>
+                        <input type="text" id="file_path" name="file_path" class="tao-input" title="Defaults to {ROOT_PATH}/data"/>
                         <div title="learn more on this topic" class="icons ui-state-default ui-corner-all"><a id="hlp_file_path" class="ui-icon ui-icon-help"></a></div>
                     </li>
                     <li>

--- a/manifest.php
+++ b/manifest.php
@@ -49,7 +49,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '27.1.2',
+    'version' => '27.1.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -925,6 +925,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('27.0.0');
         }
 
-        $this->skip('27.0.0', '27.1.2');
+        $this->skip('27.0.0', '27.1.3');
     }
 }


### PR DESCRIPTION
We move the other way around: make the "file_path" parameter optional in both CLI and web installer.
To test it, try to install without specifying a path in the last left box on the second screnn of installer (see attachment in https://oat-sa.atlassian.net/browse/TAO-8162).