### PR TITLE
Fix/nex 81 update tao core sdk

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '36.1.0',
+    'version' => '36.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.3.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1066,6 +1066,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.8.2');
         }
 
-        $this->skip('35.8.2', '36.1.0');
+        $this->skip('35.8.2', '36.1.1');
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/oat-sa/tao-core.git"
   },
   "dependencies": {
-    "@oat-sa/tao-core-sdk": "^0.1.3",
+    "@oat-sa/tao-core-sdk": "~0.2.0",
     "@babel/polyfill": "^7.4.4"
   }
 }


### PR DESCRIPTION
Update tao-core-sdk to 0.2.0
This deprecate the usage of `core/promise` and `core/collections` since they will be polyfilled in the bundles using core-js/babel-polyfill