### PR TITLE
Importing .CSV file with students gives wrong interface language

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '25.1.3',
+    'version' => '25.1.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=8.2.0',

--- a/models/classes/class.LanguageService.php
+++ b/models/classes/class.LanguageService.php
@@ -316,20 +316,17 @@ class tao_models_classes_LanguageService
      */
     public static function filterLanguage($value)
     {
-        if (filter_var($value, FILTER_VALIDATE_URL) === true) {
-            $language = new core_kernel_classes_Resource($value);
-            if ($language->exists()) {
-                return $value;
-            } else {
-                $value = DEFAULT_LANG;
-            }
+        if (filter_var($value, FILTER_VALIDATE_URL) !== false) {
+            $langByUri = new \core_kernel_classes_Resource($value);
+            return $langByUri->exists()
+                ? $value
+                : null;
         }
 
-        if (is_null($langUri = \tao_models_classes_LanguageService::singleton()->getLanguageByCode($value))) {
-            $langUri = \tao_models_classes_LanguageService::singleton()->getLanguageByCode(DEFAULT_LANG);
-        }
-
-        return $langUri;
+        $langByCode = self::singleton()->getLanguageByCode($value);
+        return $langByCode !== null
+            ? $langByCode->getUri()
+            : null;
     }
 
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -909,6 +909,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('22.13.1');
         }
         
-        $this->skip('22.13.1', '25.1.3');
+        $this->skip('22.13.1', '25.1.4');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/SI-362

.csv import of test takers doesn't work properly.

v25.1.3:
You can install env with this version and try to import new test taker with language (for example nl-NL) you will see that imported language en-En

Expected
the imported language will be nl-NL after the update to v25.1.4 