### PR TITLE
Fix/ci npm git

### DIFF
--- a/.Jenkinsfile
+++ b/.Jenkinsfile
@@ -89,7 +89,7 @@ mkdir -p tao/views/locales/en-US/
                 stage('Frontend Tests') {
                     agent {
                         docker {
-                            image 'alekzonder/puppeteer'
+                            image 'btamas/puppeteer-git'
                             reuseNode true
                         }
                     }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -20,7 +20,8 @@
     },
     "@oat-sa/tao-core-sdk": {
       "version": "0.3.1",
-      "resolved": "github:oat-sa/tao-core-sdk-fe#118b37a63b31b3262b251c4f2809aca773e80bc1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-0.3.1.tgz",
+      "integrity": "sha512-YiGj9mAyTbd6xUCy849bDhbLBvQMYb/8LIOSHyue4dJRNnEfZmwH7CPGf6ueNKfQa/D479CaQ1IpY1DJ1RlbhQ==",
       "requires": {
         "idb-wrapper": "1.7.0",
         "webcrypto-shim": "0.1.4"

--- a/views/package.json
+++ b/views/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@oat-sa/tao-core-sdk": "~0.3.1",
     "@oat-sa/tao-core-libs": "~0.1.0",
+    "@oat-sa/tao-core-sdk": "~0.3.1",
     "handlebars": "1.3.0",
     "jquery": "1.9.1",
     "lodash": "2.4.1",


### PR DESCRIPTION
 1. Ensure the docker container has `git` 
 2. Update the package-lock.json to refer to the npm registry instead of github

This pull request can be tested by checking if the CI build doesn't contains the kind of error below  : 
```
+ npm install --production

npm ERR! code ENOGIT

npm ERR! No git binary found in $PATH

npm ERR! 

npm ERR! Failed using git.

npm ERR! Please check if you have git installed and in your PATH.



npm ERR! A complete log of this run can be found in:

npm ERR!     /var/lib/jenkins/workspace/ests_for_oat-sa_tao-core_PR-2178/build/tao/views/.npm/_logs/2019-06-12T14_47_38_919Z-debug.log

script returned exit code 1
```