### PR TITLE
set default header to self

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '37.1.1',
+    'version' => '37.1.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.3.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1067,5 +1067,13 @@ class Updater extends \common_ext_ExtensionUpdater {
         }
 
         $this->skip('35.8.2', '37.1.1');
+
+        if ($this->isVersion('37.1.1')) {
+            $settingsStorage = $this->getServiceManager()->get(SettingsStorage::SERVICE_ID);
+            if ($settingsStorage->exists(CspHeaderSettingsInterface::CSP_HEADER_SETTING) === false) {
+                $settingsStorage->set(CspHeaderSettingsInterface::CSP_HEADER_SETTING, 'self');
+            }
+            $this->setVersion('37.1.2');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -998,7 +998,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $settingsStorage = $this->getServiceManager()->get(SettingsStorage::SERVICE_ID);
 
             if ($settingsStorage->exists(CspHeaderSettingsInterface::CSP_HEADER_SETTING) === false) {
-                $settingsStorage->set(CspHeaderSettingsInterface::CSP_HEADER_SETTING, '*');
+                $settingsStorage->set(CspHeaderSettingsInterface::CSP_HEADER_SETTING, 'self');
             }
 
 


### PR DESCRIPTION
Looks like on some environments default value of `CSP_HEADER_SETTING` was not set.

Also `SetDefaultCSPHeader` script sets it's value to `'self'` but in the updater script (line 1001) it's set to `*` but looks like it should be `'self'`