### PR TITLE
Fix/tao 8214/psr response exporter

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '37.1.1',
+    'version' => '37.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.3.0',

--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '37.2.1',
+    'version' => '37.2.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.3.0',

--- a/models/classes/export/PsrResponseExporter.php
+++ b/models/classes/export/PsrResponseExporter.php
@@ -30,5 +30,5 @@ interface PsrResponseExporter extends Exporter
      * @param ResponseInterface|null $originResponse base result on response
      * @return ResponseInterface
      */
-    public function exportFileResponse(ResponseInterface $originResponse = null);
+    public function getFileExportResponse(ResponseInterface $originResponse = null);
 }

--- a/models/classes/export/PsrResponseExporter.php
+++ b/models/classes/export/PsrResponseExporter.php
@@ -14,22 +14,21 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\tao\model\export;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
- * Interface Exporter
- * @package oat\tao\model\export
- * @author Aleh Hutnikau <hutnikau@1pt.com>
+ * @method string|ResponseInterface export()
  */
-interface Exporter
+interface PsrResponseExporter extends Exporter
 {
     /**
-     * Export data as string
-     * @return string
+     * @param ResponseInterface|null $originResponse base result on response
+     * @return ResponseInterface
      */
-    public function export();
+    public function exportFileResponse(ResponseInterface $originResponse = null);
 }

--- a/models/classes/export/implementation/AbstractFileExporter.php
+++ b/models/classes/export/implementation/AbstractFileExporter.php
@@ -21,10 +21,9 @@
 namespace oat\tao\model\export\implementation;
 
 use oat\tao\model\export\Exporter;
-use SplFileObject;
+use Psr\Http\Message\ResponseInterface;
 
 /**
- * Class AbstractExporter
  * @package oat\tao\model\export
  * @author Aleh Hutnikau <hutnikau@1pt.com>
  */
@@ -41,7 +40,6 @@ abstract class AbstractFileExporter implements Exporter
     protected $data;
 
     /**
-     * AbstractExporter constructor.
      * @param array $data Data to be exported
      */
     public function __construct($data)
@@ -57,24 +55,58 @@ abstract class AbstractFileExporter implements Exporter
 
     /**
      * Send exported data to end user
+     * @deprecated implement PsrResponseExporter to get Psr Response
+     * @see CsvExporter
      * @param string $data Data to be exported
      * @param string|null $fileName
-     * @return mixed
      */
     protected function download($data, $fileName = null)
     {
-        if ($fileName === null) {
-            $fileName = time();
-        }
+        $response = $this->preparePsrResponse(new \GuzzleHttp\Psr7\Response(), $data, $fileName);
+        $this->legacyEmitResponse($response);
+    }
 
+    /**
+     * Implements old logic which writes headers and data directly to output
+     * @deprecated Responses should be emitted in a centralized way using ResponseEmitter
+     * @param ResponseInterface $response
+     */
+    protected function legacyEmitResponse(ResponseInterface $response)
+    {
         while (ob_get_level() > 0) {
             ob_end_flush();
         }
 
-        header('Content-Type: ' . $this->contentType);
-        header('Content-Disposition: attachment; fileName="' . $fileName .'"');
-        header("Content-Length: " . strlen($data));
+        foreach ($response->getHeaders() as $name => $values) {
+            foreach ($values as $value) {
+                header("$name: $value");
+            }
+        }
+        $stream = $response->getBody();
+        if ($stream->isSeekable()) {
+            $stream->rewind();
+        }
+        while (!$stream->eof()) {
+            echo $stream->read(1024 * 8);
+        }
+    }
 
-        echo $data;
+    /**
+     * @param ResponseInterface $response
+     * @param string $data Data to be exported
+     * @param string|null $fileName if null timestamp will be used as file name
+     * @return ResponseInterface
+     */
+    protected function preparePsrResponse(ResponseInterface $response, $data, $fileName = null)
+    {
+        if ($fileName === null) {
+            $fileName = (string) time();
+        }
+
+        return $response
+            ->withHeader('Content-Type', $this->contentType)
+            ->withHeader('Content-Disposition', 'attachment; fileName="' . $fileName .'"')
+            ->withHeader('Content-Length', strlen($data))
+            ->withBody(\GuzzleHttp\Psr7\stream_for($data));
     }
 }

--- a/models/classes/export/implementation/CsvExporter.php
+++ b/models/classes/export/implementation/CsvExporter.php
@@ -43,7 +43,7 @@ class CsvExporter extends AbstractFileExporter implements PsrResponseExporter
 
     /**
      * @param boolean $columnNames array keys will be used in the first line of CSV data as column names.
-     * @param boolean $download Deprecated: use exportFileResponse() and setResponse() in controller
+     * @param boolean $download Deprecated: use getFileExportResponse() and setResponse() in controller
      * @param string $delimiter sets the field delimiter (one character only).
      * @param string $enclosure sets the field enclosure (one character only).
      * @return string|null
@@ -92,7 +92,7 @@ class CsvExporter extends AbstractFileExporter implements PsrResponseExporter
      * @return ResponseInterface
      * @throws \common_exception_InvalidArgumentType
      */
-    public function exportFileResponse(
+    public function getFileExportResponse(
         ResponseInterface $originResponse = null,
         $columnNames = false,
         $delimiter = ',',

--- a/models/classes/export/implementation/CsvExporter.php
+++ b/models/classes/export/implementation/CsvExporter.php
@@ -20,6 +20,9 @@
 
 namespace oat\tao\model\export\implementation;
 
+use GuzzleHttp\Psr7\Response;
+use oat\tao\model\export\PsrResponseExporter;
+use Psr\Http\Message\ResponseInterface;
 use SPLTempFileObject;
 use Traversable;
 
@@ -28,22 +31,25 @@ use Traversable;
  * @author Aleh Hutnikau <hutnikau@1pt.com>
  * @package oat\tao\model\export
  */
-class CsvExporter extends AbstractFileExporter
+class CsvExporter extends AbstractFileExporter implements PsrResponseExporter
 {
+    const FILE_NAME = 'export.csv';
+    const CSV_CONTENT_TYPE = 'text/csv; charset=UTF-8';
+
     /**
      * @var string value of `Content-Type` header
      */
-    protected $contentType = 'text/csv; charset=UTF-8';
+    protected $contentType = self::CSV_CONTENT_TYPE;
 
     /**
      * @param boolean $columnNames array keys will be used in the first line of CSV data as column names.
-     * @param boolean $download
+     * @param boolean $download Deprecated: use exportFileResponse() and setResponse() in controller
      * @param string $delimiter sets the field delimiter (one character only).
      * @param string $enclosure sets the field enclosure (one character only).
-     * @return string
+     * @return null|string|ResponseInterface
      * @throws \common_exception_InvalidArgumentType
      */
-    public function export($columnNames = false, $download = false, $delimiter = ",", $enclosure = '"')
+    public function export($columnNames = false, $download = false, $delimiter = ',', $enclosure = '"')
     {
         $data = $this->data;
 
@@ -67,9 +73,35 @@ class CsvExporter extends AbstractFileExporter
         $exportData = trim($exportData);
 
         if ($download) {
-            $this->download($exportData, 'export.csv');
-        } else {
-            return $exportData;
+            $this->download($exportData, self::FILE_NAME);
+            return null;
         }
+
+        return $exportData;
+    }
+
+    /**
+     * Returns Psr Response with exported data and proper headers for file download
+     * You can use obtained response to pass it to $this->setResponse() in controller or
+     * emit directly using ResponseEmitter (for special cases)
+     *
+     * @param ResponseInterface|null $originResponse
+     * @param boolean $columnNames array keys will be used in the first line of CSV data as column names.
+     * @param string $delimiter sets the field delimiter (one character only).
+     * @param string $enclosure sets the field enclosure (one character only).
+     * @return ResponseInterface
+     * @throws \common_exception_InvalidArgumentType
+     */
+    public function exportFileResponse(
+        ResponseInterface $originResponse = null,
+        $columnNames = false,
+        $delimiter = ',',
+        $enclosure = '"'
+    ) {
+        if ($originResponse === null) {
+            $originResponse = new Response();
+        }
+        $exportedString = $this->export($columnNames, false, $delimiter, $enclosure);
+        return $this->preparePsrResponse($originResponse, $exportedString, self::FILE_NAME);
     }
 }

--- a/models/classes/export/implementation/CsvExporter.php
+++ b/models/classes/export/implementation/CsvExporter.php
@@ -46,7 +46,7 @@ class CsvExporter extends AbstractFileExporter implements PsrResponseExporter
      * @param boolean $download Deprecated: use exportFileResponse() and setResponse() in controller
      * @param string $delimiter sets the field delimiter (one character only).
      * @param string $enclosure sets the field enclosure (one character only).
-     * @return null|string|ResponseInterface
+     * @return string|null
      * @throws \common_exception_InvalidArgumentType
      */
     public function export($columnNames = false, $download = false, $delimiter = ',', $enclosure = '"')

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1066,6 +1066,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.8.2');
         }
 
-        $this->skip('35.8.2', '37.2.1');
+        $this->skip('35.8.2', '37.2.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1066,6 +1066,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.8.2');
         }
 
-        $this->skip('35.8.2', '37.1.1');
+        $this->skip('35.8.2', '37.2.1');
     }
 }

--- a/test/integration/export/CsvExporterTest.php
+++ b/test/integration/export/CsvExporterTest.php
@@ -64,12 +64,12 @@ class CsvExporterTest extends TaoPhpUnitTestRunner
      * @param boolean $columnNames
      * @throws \common_exception_InvalidArgumentType
      */
-    public function testExportFileResponse(SplFileInfo $file, array $data, $columnNames)
+    public function testGetFileExportResponse(SplFileInfo $file, array $data, $columnNames)
     {
         $exporter = new CsvExporter($data);
         /** @var ResponseInterface $originResponse */
         $originResponse = (new Response())->withHeader('X-Old-Header', 'old_header_val');
-        $response = $exporter->exportFileResponse($originResponse, $columnNames);
+        $response = $exporter->getFileExportResponse($originResponse, $columnNames);
         $this->assertInstanceOf(ResponseInterface::class, $response);
 
         $exportedData = $this->normalizeLineEndings($response->getBody()->getContents());

--- a/test/integration/export/CsvExporterTest.php
+++ b/test/integration/export/CsvExporterTest.php
@@ -20,9 +20,11 @@
 
 namespace oat\tao\test\integration\export;
 
+use GuzzleHttp\Psr7\Response;
 use oat\tao\model\export\implementation\CsvExporter;
 use common_session_SessionManager;
 use oat\tao\test\TaoPhpUnitTestRunner;
+use Psr\Http\Message\ResponseInterface;
 use SplFileInfo;
 
 /**
@@ -45,6 +47,7 @@ class CsvExporterTest extends TaoPhpUnitTestRunner
      * @param SplFileInfo $file instance of sample file
      * @param array $data data to be exported
      * @param boolean $columnNames
+     * @throws \common_exception_InvalidArgumentType
      */
     public function testExport(SplFileInfo $file, array $data, $columnNames)
     {
@@ -52,6 +55,35 @@ class CsvExporterTest extends TaoPhpUnitTestRunner
         $exportedData = $this->normalizeLineEndings($exporter->export($columnNames));
         $sampleData = $this->normalizeLineEndings(file_get_contents($file->getPathname()));
         $this->assertEquals($exportedData, $sampleData);
+    }
+
+    /**
+     * @dataProvider dataProvider
+     * @param SplFileInfo $file instance of sample file
+     * @param array $data data to be exported
+     * @param boolean $columnNames
+     * @throws \common_exception_InvalidArgumentType
+     */
+    public function testExportFileResponse(SplFileInfo $file, array $data, $columnNames)
+    {
+        $exporter = new CsvExporter($data);
+        /** @var ResponseInterface $originResponse */
+        $originResponse = (new Response())->withHeader('X-Old-Header', 'old_header_val');
+        $response = $exporter->exportFileResponse($originResponse, $columnNames);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+
+        $exportedData = $this->normalizeLineEndings($response->getBody()->getContents());
+        $sampleData = $this->normalizeLineEndings(file_get_contents($file->getPathname()));
+        $this->assertEquals($exportedData, $sampleData);
+
+        $this->assertCount(4, $response->getHeaders());
+        $this->assertEquals('old_header_val', $response->getHeader('X-Old-Header')[0]);
+        $this->assertEquals(strlen($exportedData), $response->getHeader('Content-Length')[0]);
+        $this->assertEquals(
+            'attachment; fileName="' . CsvExporter::FILE_NAME .'"',
+            $response->getHeader('Content-Disposition')[0]
+        );
+        $this->assertEquals(CsvExporter::CSV_CONTENT_TYPE, $response->getHeader('Content-Type')[0]);
     }
 
     /**


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8214 (fix of nccer reports is in https://github.com/oat-sa/extension-tao-nccer-delivery/pull/908)

We started to use Psr Responses instead of directly writing to the output but AbstractFileExporter and CsvExporter conflict with it producing php warnings in output.

All changes don't break compatibility with old code, but the new recommended way to download file is to call `$csvExporter->exportFileResponse()` instead of `export(..., true, ...)` (which is still works for compatibility).

Interface `PsrResponseExporter` extending `Exporter` interface added with `exportFileResponse` method. `CsvExporter` implements it, but `AbstractFileExporter` doesn't, because I didn't want to add new abstract method to `AbstractFileExporter` which is extended in many extensions (it would make all extending classes broken)