### PR TITLE
Fix/nex 91/grunt test config paths

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '37.3.0',
+    'version' => '37.3.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.3.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1066,6 +1066,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.8.2');
         }
 
-        $this->skip('35.8.2', '37.3.0');
+        $this->skip('35.8.2', '37.3.1');
     }
 }

--- a/views/build/grunt/test.js
+++ b/views/build/grunt/test.js
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
                     });
 
                     const extraPaths = ext.getExtensionsExtraPaths();
-                    rjsConfig.path = {...rjsConfig.path, ...extraPaths};
+                    rjsConfig.paths = {...rjsConfig.paths, ...extraPaths};
 
                     // inject a mock for the requirejs config
                     middlewares.unshift(function(req, res, next) {


### PR DESCRIPTION
During ES6 refactoring in https://github.com/oat-sa/tao-core/pull/2195/commits/83eb25dad83, `paths` became `path`. The tests won't work this way! Reverting it.

`npx grunt connect:dev taoqtiitemtest` is the way to test it.