### PR TITLE
Changed autoincrement primary key to uuid.

### DIFF
--- a/models/classes/notification/implementation/Notification.php
+++ b/models/classes/notification/implementation/Notification.php
@@ -58,7 +58,7 @@ class Notification implements NotificationInterface, \JsonSerializable
      */
     public function __construct($userId , $title , $message , $senderId , $senderName  , $id = null, $createdAt = null , $updatedAt = null,  $status = 0)
     {
-        $this->id         = intval($id);
+        $this->id         = $id;
         $this->status     = intval($status);
         $this->recipient  = $userId;
         $this->senderId   = $senderId;

--- a/models/classes/notification/implementation/RdsNotification.php
+++ b/models/classes/notification/implementation/RdsNotification.php
@@ -78,10 +78,11 @@ class RdsNotification
         $platform = $this->getPersistence()->getPlatForm();
 
         $sqlQuery    = 'INSERT INTO ' . self::NOTIF_TABLE .
-                        ' (' . $this->getAllFieldString() . ') 
-                            VALUES ( ? , ? , ? , ? , ? , ? , ? , ? )';
+                        ' (id, ' . $this->getAllFieldString() . ') 
+                            VALUES ( ? , ? , ? , ? , ? , ? , ? , ? , ? )';
 
         $data = [
+            $persistence->getUniquePrimaryKey(),
             $notification->getRecipient(),
             $notification->getStatus(),
             $notification->getSenderId(),

--- a/scripts/install/InstallNotificationTable.php
+++ b/scripts/install/InstallNotificationTable.php
@@ -44,7 +44,7 @@ class InstallNotificationTable extends InstallAction
             $queueTable = $schema->createtable(RdsNotification::NOTIF_TABLE);
 
             $queueTable->addOption('engine', 'MyISAM');
-            $queueTable->addColumn(RdsNotification::NOTIF_FIELD_ID           , "integer"  ,array("notnull" => true, 'autoincrement' => true));
+            $queueTable->addColumn(RdsNotification::NOTIF_FIELD_ID           , "string"   ,array("notnull" => true, 'length' => 23));
             $queueTable->addColumn(RdsNotification::NOTIF_FIELD_RECIPIENT    , "string"   ,array("notnull" => true ,"length" => 255));
             $queueTable->addColumn(RdsNotification::NOTIF_FIELD_STATUS       , "integer"  ,array("default" => 0 , "notnull" => false,"length" => 255));
             $queueTable->addColumn(RdsNotification::NOTIF_FIELD_TITLE        , "string"   ,array("length" => 255));

--- a/test/unit/models/classes/notification/implementation/RdsNotificationTest.php
+++ b/test/unit/models/classes/notification/implementation/RdsNotificationTest.php
@@ -89,13 +89,23 @@ class RdsNotificationTest extends TestCase
         $message = 'this is the message';
         $senderId = 'id of the sender';
         $senderName = 'name of the sender';
-        $id = 1;
+        $id = 'whatever';
         $createdAt = $this->persistence->getPlatform()->getNowExpression();
         $updatedAt = $this->persistence->getPlatform()->getNowExpression();
         $status = 12;
 
         $notification = new Notification($recipientId, $title , $message , $senderId , $senderName, $id, $createdAt, $updatedAt, $status);
         $this->subject->sendNotification($notification);
-        $this->assertEquals([$notification], $this->subject->getNotifications($recipientId));
+        $notifications = $this->subject->getNotifications($recipientId);
+        $storedNotification = array_pop($notifications);
+        $this->assertInstanceOf(Notification::class, $storedNotification);
+        $this->assertEquals($recipientId, $storedNotification->getRecipient());
+        $this->assertEquals($title, $storedNotification->getTitle());
+        $this->assertEquals($message, $storedNotification->getMessage());
+        $this->assertEquals($senderId, $storedNotification->getSenderId());
+        $this->assertEquals($senderName, $storedNotification->getSenderName());
+        $this->assertEquals((new \DateTime($createdAt))->getTimestamp(), $storedNotification->getCreatedAt());
+        $this->assertEquals((new \DateTime($updatedAt))->getTimestamp(), $storedNotification->getUpdatedAt());
+        $this->assertEquals($status, $storedNotification->getStatus());
     }
 }


### PR DESCRIPTION
This PR requires https://github.com/oat-sa/tao-core/pull/2206.

Not to be merged to develop until Spanner Benchmark is finished and the data migration policy is architecturally defined.

Only added uuid primary key.
