### PR TITLE
Fix/tao 8631/sync csrf token config

### DIFF
--- a/actions/class.ClientConfig.php
+++ b/actions/class.ClientConfig.php
@@ -45,7 +45,7 @@ class tao_actions_ClientConfig extends tao_actions_CommonModule
 
         /** @var TokenService $tokenService */
         $tokenService = $this->getServiceLocator()->get(TokenService::SERVICE_ID);
-        $this->setData('tokens', json_encode($tokenService->getClientConfig()));
+        $this->setData(TokenService::JS_DATA_KEY, json_encode($tokenService->getClientConfig()));
 
         //get extension paths to set up aliases dynamically
         $extensionsAliases = ClientLibRegistry::getRegistry()->getLibAliasMap();

--- a/actions/class.ClientConfig.php
+++ b/actions/class.ClientConfig.php
@@ -45,15 +45,7 @@ class tao_actions_ClientConfig extends tao_actions_CommonModule
 
         /** @var TokenService $tokenService */
         $tokenService = $this->getServiceLocator()->get(TokenService::SERVICE_ID);
-        $tokenPool = $tokenService->generateTokenPool();
-        $jsTokenPool = [];
-        foreach ($tokenPool as $key => $token) {
-            if ($key !== TokenService::FORM_POOL) {
-                $jsTokenPool[] = $token->getValue();
-
-            }
-        }
-        $this->setData('tokens', json_encode([TokenService::JS_TOKEN_KEY => $jsTokenPool]));
+        $this->setData('tokens', json_encode($tokenService->getClientConfig()));
 
         //get extension paths to set up aliases dynamically
         $extensionsAliases = ClientLibRegistry::getRegistry()->getLibAliasMap();

--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '37.9.0',
+    'version' => '37.9.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.5.0',

--- a/models/classes/security/xsrf/TokenService.php
+++ b/models/classes/security/xsrf/TokenService.php
@@ -53,6 +53,7 @@ class TokenService extends ConfigurableService
 
     const CSRF_TOKEN_HEADER = 'X-CSRF-Token';
     const FORM_POOL = 'form_pool';
+    const JS_DATA_KEY = 'tokenHandler';
     const JS_TOKEN_KEY = 'tokens';
     const JS_TOKEN_POOL_SIZE_KEY = 'maxSize';
     const JS_TOKEN_TIME_LIMIT_KEY = 'tokenTimeLimit';

--- a/models/classes/security/xsrf/TokenService.php
+++ b/models/classes/security/xsrf/TokenService.php
@@ -44,7 +44,7 @@ class TokenService extends ConfigurableService
     const SERVICE_ID = 'tao/security-xsrf-token';
 
     // options keys
-    const POOL_SIZE_OPT  = 'poolSize';
+    const POOL_SIZE_OPT = 'poolSize';
     const TIME_LIMIT_OPT = 'timeLimit';
     const OPTION_STORE = 'store';
 
@@ -158,7 +158,7 @@ class TokenService extends ConfigurableService
     {
         $expired = false;
         $actualTime = microtime(true);
-        $timeLimit  = $this->getTimeLimit();
+        $timeLimit = $this->getTimeLimit();
 
         if (($timeLimit > 0) && $token->getCreatedAt() + $timeLimit < $actualTime) {
             $expired = true;
@@ -226,7 +226,7 @@ class TokenService extends ConfigurableService
     protected function invalidate($pool)
     {
         $actualTime = microtime(true);
-        $timeLimit  = $this->getTimeLimit();
+        $timeLimit = $this->getTimeLimit();
         $poolSize = $this->getPoolSize();
 
         $reduced = array_filter($pool, function ($token) use ($actualTime, $timeLimit) {
@@ -270,7 +270,7 @@ class TokenService extends ConfigurableService
             $store = $this->getStore();
             $pool = $store->getTokens();
 
-            if ($poolSize> 0 && isset($pool[self::FORM_POOL])) {
+            if ($poolSize > 0 && isset($pool[self::FORM_POOL])) {
                 $poolSize++;
             }
         }
@@ -298,7 +298,7 @@ class TokenService extends ConfigurableService
     {
         $store = $this->getOption(self::OPTION_STORE);
         if (!$store instanceof TokenStore) {
-            throw new InvalidService('Unexpected store for '.__CLASS__);
+            throw new InvalidService('Unexpected store for ' . __CLASS__);
         }
         return $this->propagate($store);
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1066,7 +1066,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('35.8.2');
         }
 
-        $this->skip('35.8.2', '37.9.0');
+        $this->skip('35.8.2', '37.9.1');
 
     }
 }

--- a/test/unit/model/security/xsrf/TokenServiceTest.php
+++ b/test/unit/model/security/xsrf/TokenServiceTest.php
@@ -44,7 +44,7 @@ class TokenServiceTest extends TestCase
     {
         $this->expectException(InvalidService::class);
         $service = new TokenService([
-            'store' =>  []
+            TokenService::OPTION_STORE =>  []
         ]);
         $service->checkToken('unusedString');
     }
@@ -53,7 +53,7 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            'store' =>  $store
+            TokenService::OPTION_STORE =>  $store
         ]);
 
         $this->assertEquals(0, count($store->getTokens()), 'The store is empty');
@@ -84,7 +84,7 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            'store' =>  $store,
+            TokenService::OPTION_STORE =>  $store,
             TokenService::POOL_SIZE_OPT => 15
         ]);
 
@@ -124,13 +124,79 @@ class TokenServiceTest extends TestCase
         $this->assertCount(13, $store->getTokens(), '2 tokens were validated, and revoked. The store contains 13 tokens');
     }
 
-    public function testPoolSize()
+    public function testGetClientConfig()
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            'store' =>  $store,
-            'poolSize' => 4
+            TokenService::OPTION_STORE => $store
         ]);
+
+        $this->assertCount(0, $store->getTokens(), 'The store is empty');
+
+        $clientConfig = $service->getClientConfig();
+
+        $tokens = $store->getTokens();
+        $this->assertCount(6, $tokens, 'The token pool contains the expected amount of tokens');
+
+        $this->assertArrayHasKey(TokenService::JS_TOKEN_KEY, $clientConfig);
+        $this->assertArrayHasKey(TokenService::JS_TOKEN_POOL_SIZE_KEY, $clientConfig);
+        $this->assertArrayHasKey(TokenService::JS_TOKEN_TIME_LIMIT_KEY, $clientConfig);
+
+        $this->assertCount(6, $clientConfig[TokenService::JS_TOKEN_KEY], 'The token pool has the expected size');
+        $this->assertEquals(6, $clientConfig[TokenService::JS_TOKEN_POOL_SIZE_KEY], 'The default pool size is set');
+        $this->assertEquals(0, $clientConfig[TokenService::JS_TOKEN_TIME_LIMIT_KEY], 'The default time limit is set');
+
+        $service->addFormToken();
+        $tokens = $store->getTokens();
+        $this->assertCount(7, $tokens, 'The token pool contains the expected amount of tokens');
+
+        $this->assertEquals(7, $service->getPoolSize(), 'The pool size is set the default value + 1');
+        $this->assertEquals(6, $clientConfig[TokenService::JS_TOKEN_POOL_SIZE_KEY], 'The default pool size is set');
+
+        $store = $this->getStoreMock();
+        $service = new TokenService([
+            TokenService::OPTION_STORE => $store,
+            TokenService::POOL_SIZE_OPT => 4,
+            TokenService::TIME_LIMIT_OPT => 3000,
+        ]);
+
+        $this->assertCount(0, $store->getTokens(), 'The store is empty');
+
+        $clientConfig = $service->getClientConfig();
+
+        $tokens = $store->getTokens();
+        $this->assertCount(4, $tokens, 'The token pool contains the expected amount of tokens');
+
+        $this->assertArrayHasKey(TokenService::JS_TOKEN_KEY, $clientConfig);
+        $this->assertArrayHasKey(TokenService::JS_TOKEN_POOL_SIZE_KEY, $clientConfig);
+        $this->assertArrayHasKey(TokenService::JS_TOKEN_TIME_LIMIT_KEY, $clientConfig);
+
+        $this->assertCount(4, $clientConfig[TokenService::JS_TOKEN_KEY], 'The token pool has the expected size');
+        $this->assertEquals(4, $clientConfig[TokenService::JS_TOKEN_POOL_SIZE_KEY], 'The configured pool size is set');
+        $this->assertEquals(3000, $clientConfig[TokenService::JS_TOKEN_TIME_LIMIT_KEY], 'The configured time limit is set');
+
+        $service->addFormToken();
+        $tokens = $store->getTokens();
+        $this->assertCount(5, $tokens, 'The token pool contains the expected amount of tokens');
+
+        $this->assertEquals(5, $service->getPoolSize(), 'The pool size is set the configured value + 1');
+        $this->assertEquals(4, $clientConfig[TokenService::JS_TOKEN_POOL_SIZE_KEY], 'The configured pool size is set');
+    }
+
+    public function testPoolSize()
+    {
+        $store = $this->getStoreMock();
+
+        $service = new TokenService([
+            TokenService::OPTION_STORE =>  $store
+        ]);
+        $this->assertEquals(6, $service->getPoolSize(), 'The pool size is set to default');
+
+        $service = new TokenService([
+            'store' =>  $store,
+            TokenService::POOL_SIZE_OPT => 4
+        ]);
+        $this->assertEquals(4, $service->getPoolSize(), 'The pool size is set the configured value');
 
         $this->assertCount(0, $store->getTokens(), 'The store is empty');
 
@@ -151,13 +217,18 @@ class TokenServiceTest extends TestCase
 
         $service->createToken();
         $this->assertCount(4, $store->getTokens(), 'The store remains at four tokens, the max pool size');
+
+        $service->addFormToken();
+        $this->assertCount(5, $store->getTokens(), 'The store remains at five tokens, the max pool size + the form pool');
+        $this->assertEquals(5, $service->getPoolSize(), 'The pool size is set the configured value + 1');
+        $this->assertEquals(4, $service->getPoolSize(false), 'The pool size is set the configured value, without the form pool');
     }
 
     public function testRevokeToken()
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            'store' =>  $store
+            TokenService::OPTION_STORE =>  $store
         ]);
 
         $this->assertCount(0, $store->getTokens(), 'The store is empty');
@@ -185,7 +256,7 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            'store' =>  $store
+            TokenService::OPTION_STORE =>  $store
         ]);
 
         $this->assertCount(0, $store->getTokens(), 'The store is empty');
@@ -209,8 +280,8 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            'store' =>  $store,
-            'timeLimit' => 1
+            TokenService::OPTION_STORE =>  $store,
+            TokenService::TIME_LIMIT_OPT => 1
         ]);
 
         $this->assertCount(0, $store->getTokens(), 'The store is empty');
@@ -240,8 +311,8 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            'store' =>  $store,
-            'timeLimit' => 2
+            TokenService::OPTION_STORE =>  $store,
+            TokenService::TIME_LIMIT_OPT => 2
         ]);
 
         $this->assertCount(0, $store->getTokens(), 'The store is empty');

--- a/test/unit/model/security/xsrf/TokenServiceTest.php
+++ b/test/unit/model/security/xsrf/TokenServiceTest.php
@@ -44,7 +44,7 @@ class TokenServiceTest extends TestCase
     {
         $this->expectException(InvalidService::class);
         $service = new TokenService([
-            TokenService::OPTION_STORE =>  []
+            TokenService::OPTION_STORE => []
         ]);
         $service->checkToken('unusedString');
     }
@@ -53,7 +53,7 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            TokenService::OPTION_STORE =>  $store
+            TokenService::OPTION_STORE => $store
         ]);
 
         $this->assertEquals(0, count($store->getTokens()), 'The store is empty');
@@ -84,7 +84,7 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            TokenService::OPTION_STORE =>  $store,
+            TokenService::OPTION_STORE => $store,
             TokenService::POOL_SIZE_OPT => 15
         ]);
 
@@ -97,7 +97,7 @@ class TokenServiceTest extends TestCase
         $this->assertCount(15, $tokens, 'The token pool contains the expected amount of tokens');
 
         /** @var Token $firstToken */
-        $firstToken  = $tokens[0];
+        $firstToken = $tokens[0];
 
         /** @var Token $secondToken */
         $secondToken = $tokens[1];
@@ -188,12 +188,12 @@ class TokenServiceTest extends TestCase
         $store = $this->getStoreMock();
 
         $service = new TokenService([
-            TokenService::OPTION_STORE =>  $store
+            TokenService::OPTION_STORE => $store
         ]);
         $this->assertEquals(6, $service->getPoolSize(), 'The pool size is set to default');
 
         $service = new TokenService([
-            'store' =>  $store,
+            'store' => $store,
             TokenService::POOL_SIZE_OPT => 4
         ]);
         $this->assertEquals(4, $service->getPoolSize(), 'The pool size is set the configured value');
@@ -228,7 +228,7 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            TokenService::OPTION_STORE =>  $store
+            TokenService::OPTION_STORE => $store
         ]);
 
         $this->assertCount(0, $store->getTokens(), 'The store is empty');
@@ -256,7 +256,7 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            TokenService::OPTION_STORE =>  $store
+            TokenService::OPTION_STORE => $store
         ]);
 
         $this->assertCount(0, $store->getTokens(), 'The store is empty');
@@ -280,7 +280,7 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            TokenService::OPTION_STORE =>  $store,
+            TokenService::OPTION_STORE => $store,
             TokenService::TIME_LIMIT_OPT => 1
         ]);
 
@@ -311,7 +311,7 @@ class TokenServiceTest extends TestCase
     {
         $store = $this->getStoreMock();
         $service = new TokenService([
-            TokenService::OPTION_STORE =>  $store,
+            TokenService::OPTION_STORE => $store,
             TokenService::TIME_LIMIT_OPT => 2
         ]);
 
@@ -347,7 +347,7 @@ class TokenServiceTest extends TestCase
         /** @var TokenStore $storeMock */
         $storeMock = $this->prophesize(TokenStore::class);
         $storeMock->getTokens()->willReturn([]);
-        $storeMock->setTokens(Argument::any())->will(function ($args) use ($storeMock){
+        $storeMock->setTokens(Argument::any())->will(function ($args) use ($storeMock) {
             $storeMock->getTokens()->willReturn($args[0]);
         });
         return $storeMock->reveal();

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -19,8 +19,8 @@
       "integrity": "sha512-NwiOQTeF87vVYt6HuluQ7uAJXDwz2868O+PTivz36uDdqZT2Bh03TE9KYamldfE4eMga0ylOjreuIE5H3eY1LQ=="
     },
     "@oat-sa/tao-core-sdk": {
-      "version": "github:oat-sa/tao-core-sdk-fe#a7bd8d238cfa263e8da0ee6873ee7594a7483f6d",
-      "from": "github:oat-sa/tao-core-sdk-fe#fix/TAO-8631/accept-token-lifetime-from-config",
+      "version": "0.5.1",
+      "resolved": "github:oat-sa/tao-core-sdk-fe#a7bd8d238cfa263e8da0ee6873ee7594a7483f6d",
       "requires": {
         "idb-wrapper": "1.7.0",
         "webcrypto-shim": "0.1.4"

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19,9 +19,8 @@
       "integrity": "sha512-NwiOQTeF87vVYt6HuluQ7uAJXDwz2868O+PTivz36uDdqZT2Bh03TE9KYamldfE4eMga0ylOjreuIE5H3eY1LQ=="
     },
     "@oat-sa/tao-core-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-0.5.0.tgz",
-      "integrity": "sha512-abBCI1vpmWhlfmvD2VgsbZSOB1VZYjFr8HAX27aSvFpAmb42bI8Hh7CqDdoZVLArfrSx7ZTZVOAQE11kCJP8Ag==",
+      "version": "github:oat-sa/tao-core-sdk-fe#a7bd8d238cfa263e8da0ee6873ee7594a7483f6d",
+      "from": "github:oat-sa/tao-core-sdk-fe#fix/TAO-8631/accept-token-lifetime-from-config",
       "requires": {
         "idb-wrapper": "1.7.0",
         "webcrypto-shim": "0.1.4"

--- a/views/package.json
+++ b/views/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
     "@oat-sa/tao-core-libs": "~0.1.0",
-    "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#fix/TAO-8631/accept-token-lifetime-from-config",
+    "@oat-sa/tao-core-sdk": "~0.5.1",
     "@oat-sa/tao-core-ui": "~0.18.0",
     "handlebars": "1.3.0",
     "jquery": "1.9.1",

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "GPL-2.0",
   "description": "tao core dependencies",
   "repository": {
@@ -10,7 +10,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
     "@oat-sa/tao-core-libs": "~0.1.0",
-    "@oat-sa/tao-core-sdk": "~0.5.0",
+    "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#fix/TAO-8631/accept-token-lifetime-from-config",
     "@oat-sa/tao-core-ui": "~0.18.0",
     "handlebars": "1.3.0",
     "jquery": "1.9.1",

--- a/views/templates/client_config.tpl
+++ b/views/templates/client_config.tpl
@@ -1,3 +1,6 @@
+<?php
+use oat\tao\model\security\xsrf\TokenService;
+?>
 require.config({
 
     baseUrl : '<?=get_data('tao_base_www')?>js',
@@ -13,7 +16,7 @@ require.config({
             useXhr: function(){ return true; },
         },
         'ui/themes' : <?= get_data('themesAvailable') ?>,
-        'core/tokenHandler' : <?=get_data('tokens')?>,
+        'core/tokenHandler' : <?=get_data(TokenService::JS_DATA_KEY)?>,
 
 //dynamic lib config
     <?php foreach (get_data('libConfigs') as $name => $config) :?>


### PR DESCRIPTION
## Context
Related to: https://oat-sa.atlassian.net/browse/TAO-8631

Requires: 
 - [x] https://github.com/oat-sa/tao-core-sdk-fe/pull/24

## Summary
During an assessment, if the test taker spends more than 24 minutes on the same item without triggering any request to the server, the following error will be raised: `No tokens available. Please refresh the page.`. This event will occur no matter the duration of the server session.

The reason why is the anti-CSRF protection hardcodes the TTL of the token to 24 minutes, on the frontend side, no matter what is set on the platform.

To fix this wrong behavior, we need to address the issue on both sides:
- the frontend should take care of the platform configuration
- the backend should provide the plartform configuration to the frontend

The companion PR aims to address the frontend issue.

This PR rework the way the config is supplied to the client. Previously, only the list of predefined tokens was given to the client. Now, the relevant token store configuration should be provided.

## Way to improve
By default, the time limit for the anti-CSRF token is set to unlimited. An improvement would be to align that with the PHP session time limit.

## Important when merging
Once the companion PR is merged, please update accordingly the file `views/package.json` to reflect the version.

## Unit Test
Unit tests have been updated.

To unit test:
```
vendor/phpunit/phpunit/phpunit tao/test/unit
```

To scope the unit test:
```
vendor/phpunit/phpunit/phpunit tao/test/unit/model/security
```

## Steps to reproduce
To reproduce the issue:
- take a test
- stay more than 24 minutes on the same item, then try to navigate

In order to reduce the time to wait, you can also change the default TTL in `tao/views/node_modules/@oat-sa/tao-core-sdk/dist/core/tokenHandler.js`, by modifying the value of `tokenTimeLimit`, at line 29:
```javascript
    var defaults = {
      maxSize: 6,
      tokenTimeLimit: 1000 * 60 * 24  // change this value to a smaller one ;-)
    };
```