### PR TITLE
Read variables from .env file in project dir if it is provided.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "imsglobal/lti": "^3.0",
         "paragonie/random_compat": "^2.0",
         "oat-sa/composer-npm-bridge": "^0.3.0",
-        "symfony/dotenv": "^4.0"
+        "symfony/dotenv": "~4.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "pimple/pimple": "^3.0",
         "imsglobal/lti": "^3.0",
         "paragonie/random_compat": "^2.0",
-        "oat-sa/composer-npm-bridge": "^0.3.0"
+        "oat-sa/composer-npm-bridge": "^0.3.0",
+        "symfony/dotenv": "^5.0@dev"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "imsglobal/lti": "^3.0",
         "paragonie/random_compat": "^2.0",
         "oat-sa/composer-npm-bridge": "^0.3.0",
-        "symfony/dotenv": "^5.0@dev"
+        "symfony/dotenv": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '38.1.1',
+    'version' => '38.2.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return array(
     'version' => '38.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
-        'generis' => '>=11.5.0',
+        'generis' => '>=12.1.0',
     ),
     'models' => array(
         'http://www.tao.lu/Ontologies/TAO.rdf',

--- a/models/classes/mvc/Bootstrap.php
+++ b/models/classes/mvc/Bootstrap.php
@@ -41,6 +41,7 @@ use tao_helpers_Request;
 use tao_helpers_Uri;
 use Exception;
 use oat\tao\model\mvc\error\ExceptionInterpreterService;
+use Symfony\Component\Dotenv\Dotenv;
 
 /**
  * The Bootstrap Class enables you to drive the application flow for a given extenstion.
@@ -89,6 +90,13 @@ class Bootstrap implements ServiceManagerAwareInterface
      */
     public function __construct($configuration)
     {
+        $envDir = __DIR__ . '/../../../../';
+        $envFile = $envDir. '.env';
+        if (file_exists($envFile)) {
+            $dotenv = new Dotenv();
+            $dotenv->load($envFile);
+        }
+
         if (! is_string($configuration) || ! is_readable($configuration)) {
             throw new \common_exception_PreConditionFailure('TAO platform seems to be not installed.');
         }

--- a/models/classes/mvc/Bootstrap.php
+++ b/models/classes/mvc/Bootstrap.php
@@ -94,7 +94,7 @@ class Bootstrap implements ServiceManagerAwareInterface
         $envFile = $envDir. '.env';
         if (file_exists($envFile)) {
             $dotenv = new Dotenv();
-            $dotenv->load($envFile);
+            $dotenv->loadEnv($envFile);
         }
 
         if (! is_string($configuration) || ! is_readable($configuration)) {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1082,7 +1082,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('38.0.1');
         }
 
-        $this->skip('38.0.1', '38.1.1');
+        $this->skip('38.0.1', '38.2.0');
 
     }
 }


### PR DESCRIPTION
Reads variables from .env file in project dir if it is provided. If no `.env` file is provided, just does nothing.
This allows us to then access variables values in `$_ENV` global array.
Works for CLI, Apache, Nginx, ...

Example:

.env file:
```
GENERIS_CACHE_URI=http://my-redis.com/blah/blah/blah
```

.php file:
```
echo $_ENV['GENERIS_CACHE_URI']; // => http://my-redis.com/blah/blah/blah
```
