### PR TITLE
TAO-8725 version bump

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '38.2.1',
+    'version' => '38.2.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=11.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1108,7 +1108,7 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('38.1.3');
         }
-        $this->skip('38.1.3', '38.2.1');
+        $this->skip('38.1.3', '38.2.2');
 
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -28,9 +28,9 @@
       }
     },
     "@oat-sa/tao-core-ui": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-0.20.1.tgz",
-      "integrity": "sha512-Lj2Mhmy1uS5605CxOZngoRBaXhDAxY7sLXaCFAQkFxblqPNakH/VwYCmJA1mDo3W/M6loyuLpi8MSgX+x3wK4Q=="
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-0.21.1.tgz",
+      "integrity": "sha512-7EBdK4yzT7I41J5Y2lRbcrXD/LNopvbp1hUKlkgzPioLyrcPLfGMKgG33o/4Ng+0XnyGcJwwPV6w2UiEQC0jPQ=="
     },
     "amdefine": {
       "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -11,7 +11,7 @@
     "@babel/polyfill": "^7.4.4",
     "@oat-sa/tao-core-libs": "~0.1.0",
     "@oat-sa/tao-core-sdk": "~0.7.0",
-    "@oat-sa/tao-core-ui": "~0.20.1",
+    "@oat-sa/tao-core-ui": "~0.21.1",
     "handlebars": "1.3.0",
     "jquery": "1.9.1",
     "lodash": "2.4.1",


### PR DESCRIPTION
**task:** https://oat-sa.atlassian.net/browse/TAO-8725
**description:** 
on hybrid laptops ( both with keyboard and touchscreen) all plugins (widgets) of test runner were unable to move through the touchscreen instead of mouse or touchpad. 

**solution**
interactjs lib which is responsible for all interface interactions was updated to latest version which supports modern " pointer events" browser API which solved the issue.

**related sdk release**
https://github.com/oat-sa/tao-core-ui-fe/releases/tag/0.21.1