### PR TITLE
Used ROOT_PATH to locate the .env file.

### DIFF
--- a/models/classes/mvc/Bootstrap.php
+++ b/models/classes/mvc/Bootstrap.php
@@ -90,8 +90,7 @@ class Bootstrap implements ServiceManagerAwareInterface
      */
     public function __construct($configuration)
     {
-        $envDir = __DIR__ . '/../../../../';
-        $envFile = $envDir. '.env';
+        $envFile = ROOT_PATH . '.env';
         if (file_exists($envFile)) {
             $dotenv = new Dotenv();
             $dotenv->loadEnv($envFile);


### PR DESCRIPTION
Based on Jonathan's comment (https://github.com/oat-sa/tao-core/pull/2233#discussion_r309123955), this amends the directory separator problem by using a global constant.