### PR TITLE
Feature/update tao core fe

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -52,7 +52,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '38.4.0',
+    'version' => '38.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.1.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1156,5 +1156,6 @@ class Updater extends \common_ext_ExtensionUpdater {
 
             $this->setVersion('38.4.0');
         }
+        $this->skip('38.4.0', '38.5.0');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -13,24 +13,29 @@
         "regenerator-runtime": "^0.13.2"
       }
     },
+    "@oat-sa/expr-eval": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/expr-eval/-/expr-eval-1.3.0.tgz",
+      "integrity": "sha512-z9ezG0Z+26qaCz3w/sYzN/JyBLmN2xhzCfNihYRA7CMYukEbkeY3/tLknVhwm+rp4584yDDuSHPVMuoYmwZP1A=="
+    },
     "@oat-sa/tao-core-libs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.1.1.tgz",
-      "integrity": "sha512-+aT54BW1dYfZ0QcmqypCSLGJU1GOpw38lX38YcGm5lBmK3p3V6MoMTt5qR5syyJ8BcLWJLnHF5ued9WfonYBcw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.2.0.tgz",
+      "integrity": "sha512-oEKv7JJ5UIYD/kqvj32b/QQQ/17GPNIizT/KRwxmvPMpDxQcx6RtyQ8dumnn4aT8EVCgMccpQI9rhayiT6R7jw=="
     },
     "@oat-sa/tao-core-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-0.7.0.tgz",
-      "integrity": "sha512-T/0+Dgl/RokTz+T+RtYKpV6jmE1uS8ZJqOns1hNA9WvcBOStcj9CHTH5a0sXCKPzHM6y7kFX9U3b6hVxhkFZQA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-0.9.0.tgz",
+      "integrity": "sha512-Ah/PzUwFslDjoPKyhbo2MnZMt8xLzDwbAUj5PyfWuIrQ6hT2JC4++rfTcd+9VkyRFkSK44z5+xSY9Ca1ujEZ3Q==",
       "requires": {
         "idb-wrapper": "1.7.0",
         "webcrypto-shim": "0.1.4"
       }
     },
     "@oat-sa/tao-core-ui": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-0.21.3.tgz",
-      "integrity": "sha512-lMmToSkfQtgI7bWZFUb3SktdTJZxSIsFEWBCMJmdbkwpoCyYO4ddqvm4bqr3Q1Qt4J4DaHFRWAPLt03mTKnAXA=="
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-0.21.4.tgz",
+      "integrity": "sha512-l7mvqqyvfSugSgxR87ZCco/dPJpY261FhKAgyeErqmXSnltN5h1M0g6Pex1eO5onA/op7ppm6ChVwO1+Mm1/WQ=="
     },
     "amdefine": {
       "version": "1.0.1",
@@ -41,13 +46,31 @@
     "async": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-      "optional": true
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+    },
+    "decimal.js": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.1.1.tgz",
+      "integrity": "sha512-vEEgyk1fWVEnv7lPjkNedAIjzxQDue5Iw4FeX4UkNUDSVyD/jZTD0Bw2kAO7k6iyyJRAhM9oxxI0D1ET6k0Mmg=="
+    },
+    "dompurify": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.11.tgz",
+      "integrity": "sha512-XywCTXZtc/qCX3iprD1pIklRVk/uhl8BKpkTxr+ZyMVUzSUg7wkQXRBp/euJ5J5moa1QvfpvaPQVP71z1O59dQ=="
+    },
+    "eve": {
+      "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+      "from": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+    },
+    "gamp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/gamp/-/gamp-0.2.1.tgz",
+      "integrity": "sha1-Xx/NCJ3vWQ+WQCjNt+jCBY9s0Ik="
     },
     "handlebars": {
       "version": "1.3.0",
@@ -62,6 +85,11 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.0.tgz",
       "integrity": "sha1-Cn+yxw4OF3+RGOZHPGdTVrXmKD4="
+    },
+    "interactjs": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.2.8.tgz",
+      "integrity": "sha1-8o2cawgwE9quPHfwJiBPndGYPtk="
     },
     "jquery": {
       "version": "1.9.1",
@@ -78,6 +106,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.1.tgz",
       "integrity": "sha1-v0AmQTZA0bgCRnzzU2B/hGTWr0c="
     },
+    "moment-timezone": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.10.tgz",
+      "integrity": "sha1-N2YknC0xfQjwfYltMDPCb4fEris=",
+      "requires": {
+        "moment": ">= 2.6.0"
+      }
+    },
     "optimist": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
@@ -86,10 +122,28 @@
         "wordwrap": "~0.0.2"
       }
     },
+    "popper.js": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+    },
+    "raphael": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.1.4.tgz",
+      "integrity": "sha1-sJymZK0Ei4FLsv9dTR51g4yrnJc=",
+      "requires": {
+        "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
       "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+    },
+    "select2": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-3.5.1.tgz",
+      "integrity": "sha1-8oGUibvGX9bTKL5yu+K5XdfofP4="
     },
     "source-map": {
       "version": "0.1.43",
@@ -98,6 +152,14 @@
       "optional": true,
       "requires": {
         "amdefine": ">=0.0.4"
+      }
+    },
+    "tooltip.js": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.3.2.tgz",
+      "integrity": "sha512-DeDr9JxYx/lSvQ53ZCRFLxXrmrSyU3fLz6k+ITUTw69AIYtpWij/NmOJQscJ7BwY5lcEwWJWSfqqQWVvTMYZiw==",
+      "requires": {
+        "popper.js": "^1.0.2"
       }
     },
     "uglify-js": {

--- a/views/package.json
+++ b/views/package.json
@@ -9,12 +9,23 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.4",
-    "@oat-sa/tao-core-libs": "~0.1.0",
-    "@oat-sa/tao-core-sdk": "~0.7.0",
-    "@oat-sa/tao-core-ui": "~0.21.3",
+    "@oat-sa/tao-core-libs": "0.2.0",
+    "@oat-sa/tao-core-sdk": "0.9.0",
+    "@oat-sa/tao-core-ui": "0.21.4",
     "handlebars": "1.3.0",
     "jquery": "1.9.1",
     "lodash": "2.4.1",
-    "moment": "2.11.1"
+    "moment": "2.11.1",
+    "moment-timezone": "0.5.10",
+    "async": "0.2.10",
+    "decimal.js": "10.1.1",
+    "dompurify": "1.0.11",
+    "gamp": "0.2.1",
+    "interactjs": "1.2.8",
+    "popper.js": "1.15.0",
+    "tooltip.js": "1.3.2",
+    "select2": "3.5.1",
+    "@oat-sa/expr-eval": "1.3.0",
+    "raphael": "2.1.4"
   }
 }


### PR DESCRIPTION
Fix the version of the dependencies (no tild or carret versions anymore)

Update tao-core-sdk to 0.9.0 : 
 - Add JWT handler support
 - Enables development modes
 - Use the `core/moduleLoader` instead of require in `core/logger`

Update tao-core-libs to 0.2.0 : 
 - Brings more default libraries as source (unmatrix, calculator, iframenotifier, nouislider and class.js)
 - Brings more default libraries as peerDependencies ( moment-timezone, async, decimal.js, dompurify, gamp, interactjs, popper.js, tooltip.js, select2, @oat-sa/expr-eval, raphael)

Update tao-core-libs to 0.21.4 : 
 - update to tao-core-libs 0.2.0