### PR TITLE
Feature/tao 8628/webhook event log

### DIFF
--- a/config/default/webhookEventLog.conf.php
+++ b/config/default/webhookEventLog.conf.php
@@ -1,0 +1,3 @@
+<?php
+
+return new \oat\tao\model\webhooks\log\WebhookRdsEventLogService();

--- a/config/default/webhookLogRepository.conf.php
+++ b/config/default/webhookLogRepository.conf.php
@@ -1,0 +1,7 @@
+<?php
+
+use \oat\tao\model\webhooks\log\WebhookLogRepository;
+
+return new WebhookLogRepository(
+    [WebhookLogRepository::OPTION_PERSISTENCE => 'default']
+);

--- a/manifest.php
+++ b/manifest.php
@@ -44,6 +44,7 @@ use oat\tao\scripts\install\RegisterActionService;
 use oat\tao\model\user\TaoRoles;
 use oat\tao\scripts\install\SetUpQueueTasks;
 use oat\tao\scripts\install\SetLocaleNumbersConfig;
+use \oat\tao\scripts\install\CreateWebhookEventLogTable;
 
 $extpath = dirname(__FILE__) . DIRECTORY_SEPARATOR;
 
@@ -52,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '38.9.5',
+    'version' => '38.10.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.1.0',
@@ -121,7 +122,8 @@ return array(
             RegisterTaskQueueServices::class,
             SetUpQueueTasks::class,
             RegisterSignatureGenerator::class,
-            SetDefaultCSPHeader::class
+            SetDefaultCSPHeader::class,
+            CreateWebhookEventLogTable::class,
         )
     ),
     'update' => 'oat\\tao\\scripts\\update\\Updater',

--- a/models/classes/webhooks/log/WebhookEventLogInterface.php
+++ b/models/classes/webhooks/log/WebhookEventLogInterface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\webhooks\log;
+
+interface WebhookEventLogInterface
+{
+    const SERVICE_ID = 'tao/webhookEventLog';
+
+    public function storeNetworkErrorLog(string $eventId, string $taskId, string $parentTaskId, ?string $networkError): void;
+
+    public function storeInvalidHttpStatusLog(string $eventId, string $taskId, string $parentTaskId, int $actualHttpStatusCode): void;
+
+    public function storeInvalidBodyFormat(string $eventId, string $taskId, string $parentTaskId, string $responseBody): void;
+
+    public function storeInvalidAcknowledgementLog($eventId, $taskId, $parentTaskId, string $responseBody, $actualAcknowledgement): void;
+
+    public function storeSuccessfulLog($eventId, $taskId, $parentTaskId, string $responseBody, string $acknowledgement): void;
+
+    public function storeInternalErrorLog(string $eventId, string $taskId, string $parentTaskId, ?string $internalError): void;
+}

--- a/models/classes/webhooks/log/WebhookEventLogInterface.php
+++ b/models/classes/webhooks/log/WebhookEventLogInterface.php
@@ -23,15 +23,15 @@ interface WebhookEventLogInterface
 {
     const SERVICE_ID = 'tao/webhookEventLog';
 
-    public function storeNetworkErrorLog($eventId, $taskId, $parentTaskId, $networkError = null);
+    public function storeNetworkErrorLog($eventId, $taskId, $networkError = null);
 
-    public function storeInvalidHttpStatusLog($eventId, $taskId, $parentTaskId, $actualHttpStatusCode);
+    public function storeInvalidHttpStatusLog($eventId, $taskId, $actualHttpStatusCode);
 
-    public function storeInvalidBodyFormat($eventId, $taskId, $parentTaskId, $responseBody = null);
+    public function storeInvalidBodyFormat($eventId, $taskId, $responseBody = null);
 
-    public function storeInvalidAcknowledgementLog($eventId, $taskId, $parentTaskId, $responseBody, $actualAcknowledgement = null);
+    public function storeInvalidAcknowledgementLog($eventId, $taskId, $responseBody, $actualAcknowledgement = null);
 
-    public function storeSuccessfulLog($eventId, $taskId, $parentTaskId, $responseBody, $acknowledgement);
+    public function storeSuccessfulLog($eventId, $taskId, $responseBody, $acknowledgement);
 
-    public function storeInternalErrorLog($eventId, $taskId, $parentTaskId, $internalError = null);
+    public function storeInternalErrorLog($eventId, $taskId, $internalError = null);
 }

--- a/models/classes/webhooks/log/WebhookEventLogInterface.php
+++ b/models/classes/webhooks/log/WebhookEventLogInterface.php
@@ -23,15 +23,15 @@ interface WebhookEventLogInterface
 {
     const SERVICE_ID = 'tao/webhookEventLog';
 
-    public function storeNetworkErrorLog(string $eventId, string $taskId, string $parentTaskId, ?string $networkError): void;
+    public function storeNetworkErrorLog($eventId, $taskId, $parentTaskId, $networkError = null);
 
-    public function storeInvalidHttpStatusLog(string $eventId, string $taskId, string $parentTaskId, int $actualHttpStatusCode): void;
+    public function storeInvalidHttpStatusLog($eventId, $taskId, $parentTaskId, $actualHttpStatusCode);
 
-    public function storeInvalidBodyFormat(string $eventId, string $taskId, string $parentTaskId, string $responseBody): void;
+    public function storeInvalidBodyFormat($eventId, $taskId, $parentTaskId, $responseBody = null);
 
-    public function storeInvalidAcknowledgementLog($eventId, $taskId, $parentTaskId, string $responseBody, $actualAcknowledgement): void;
+    public function storeInvalidAcknowledgementLog($eventId, $taskId, $parentTaskId, $responseBody, $actualAcknowledgement = null);
 
-    public function storeSuccessfulLog($eventId, $taskId, $parentTaskId, string $responseBody, string $acknowledgement): void;
+    public function storeSuccessfulLog($eventId, $taskId, $parentTaskId, $responseBody, $acknowledgement);
 
-    public function storeInternalErrorLog(string $eventId, string $taskId, string $parentTaskId, ?string $internalError): void;
+    public function storeInternalErrorLog($eventId, $taskId, $parentTaskId, $internalError = null);
 }

--- a/models/classes/webhooks/log/WebhookEventLogInterface.php
+++ b/models/classes/webhooks/log/WebhookEventLogInterface.php
@@ -19,19 +19,47 @@
 
 namespace oat\tao\model\webhooks\log;
 
+use oat\tao\model\webhooks\task\WebhookTaskContext;
+
 interface WebhookEventLogInterface
 {
     const SERVICE_ID = 'tao/webhookEventLog';
 
-    public function storeNetworkErrorLog($eventId, $taskId, $networkError = null);
+    /**
+     * @param WebhookTaskContext $webhookTaskContext
+     * @param string|null $networkError
+     */
+    public function storeNetworkErrorLog(WebhookTaskContext $webhookTaskContext, $networkError = null);
 
-    public function storeInvalidHttpStatusLog($eventId, $taskId, $actualHttpStatusCode);
+    /**
+     * @param WebhookTaskContext $webhookTaskContext
+     * @param int $actualHttpStatusCode
+     */
+    public function storeInvalidHttpStatusLog(WebhookTaskContext $webhookTaskContext, $actualHttpStatusCode);
 
-    public function storeInvalidBodyFormat($eventId, $taskId, $responseBody = null);
+    /**
+     * @param WebhookTaskContext $webhookTaskContext
+     * @param string|null $responseBody
+     */
+    public function storeInvalidBodyFormat(WebhookTaskContext $webhookTaskContext, $responseBody = null);
 
-    public function storeInvalidAcknowledgementLog($eventId, $taskId, $responseBody, $actualAcknowledgement = null);
+    /**
+     * @param WebhookTaskContext $webhookTaskContext
+     * @param string $responseBody
+     * @param string|null $actualAcknowledgement
+     */
+    public function storeInvalidAcknowledgementLog(WebhookTaskContext $webhookTaskContext, $responseBody, $actualAcknowledgement = null);
 
-    public function storeSuccessfulLog($eventId, $taskId, $responseBody, $acknowledgement);
+    /**
+     * @param WebhookTaskContext $webhookTaskContext
+     * @param string $responseBody
+     * @param string $acknowledgement
+     */
+    public function storeSuccessfulLog(WebhookTaskContext $webhookTaskContext, $responseBody, $acknowledgement);
 
-    public function storeInternalErrorLog($eventId, $taskId, $internalError = null);
+    /**
+     * @param WebhookTaskContext $webhookTaskContext
+     * @param string|null $internalError
+     */
+    public function storeInternalErrorLog(WebhookTaskContext $webhookTaskContext, $internalError = null);
 }

--- a/models/classes/webhooks/log/WebhookEventLogRecord.php
+++ b/models/classes/webhooks/log/WebhookEventLogRecord.php
@@ -27,6 +27,18 @@ class WebhookEventLogRecord
     /** @var string|null */
     private $taskId;
 
+    /** @var string|null */
+    private $webhookId;
+
+    /** @var string|null */
+    private $httpMethod;
+
+    /** @var string|null */
+    private $endpointUrl;
+
+    /** @var string|null */
+    private $eventName;
+
     /**
      * @var string|null
      * @example port refused (in case of network error)
@@ -174,7 +186,7 @@ class WebhookEventLogRecord
     /**
      * @return string|null
      */
-    public function getResult(): ?string
+    public function getResult()
     {
         return $this->result;
     }
@@ -202,10 +214,74 @@ class WebhookEventLogRecord
      * @param int $createdAt
      * @return $this
      */
-    public function setCreatedAt(int $createdAt)
+    public function setCreatedAt($createdAt)
     {
         $this->createdAt = $createdAt;
 
         return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getWebhookId()
+    {
+        return $this->webhookId;
+    }
+
+    /**
+     * @param string|null $webhookId
+     */
+    public function setWebhookId($webhookId)
+    {
+        $this->webhookId = $webhookId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getHttpMethod()
+    {
+        return $this->httpMethod;
+    }
+
+    /**
+     * @param string|null $httpMethod
+     */
+    public function setHttpMethod($httpMethod)
+    {
+        $this->httpMethod = $httpMethod;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getEndpointUrl()
+    {
+        return $this->endpointUrl;
+    }
+
+    /**
+     * @param string|null $endpointUrl
+     */
+    public function setEndpointUrl($endpointUrl)
+    {
+        $this->endpointUrl = $endpointUrl;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getEventName()
+    {
+        return $this->eventName;
+    }
+
+    /**
+     * @param string|null $eventName
+     */
+    public function setEventName($eventName)
+    {
+        $this->eventName = $eventName;
     }
 }

--- a/models/classes/webhooks/log/WebhookEventLogRecord.php
+++ b/models/classes/webhooks/log/WebhookEventLogRecord.php
@@ -27,9 +27,6 @@ class WebhookEventLogRecord
     /** @var string|null */
     private $taskId;
 
-    /** @var string|null */
-    private $parentTaskId;
-
     /**
      * @var string|null
      * @example port refused (in case of network error)
@@ -94,25 +91,6 @@ class WebhookEventLogRecord
     public function setTaskId($taskId)
     {
         $this->taskId = $taskId;
-
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getParentTaskId()
-    {
-        return $this->parentTaskId;
-    }
-
-    /**
-     * @param string|null $parentTaskId
-     * @return $this
-     */
-    public function setParentTaskId($parentTaskId)
-    {
-        $this->parentTaskId = $parentTaskId;
 
         return $this;
     }

--- a/models/classes/webhooks/log/WebhookEventLogRecord.php
+++ b/models/classes/webhooks/log/WebhookEventLogRecord.php
@@ -63,7 +63,7 @@ class WebhookEventLogRecord
     /**
      * @return string|null
      */
-    public function getEventId(): ?string
+    public function getEventId()
     {
         return $this->eventId;
     }
@@ -72,7 +72,7 @@ class WebhookEventLogRecord
      * @param string $eventId
      * @return $this
      */
-    public function setEventId(string $eventId)
+    public function setEventId($eventId)
     {
         $this->eventId = $eventId;
 
@@ -82,7 +82,7 @@ class WebhookEventLogRecord
     /**
      * @return string|null
      */
-    public function getTaskId(): ?string
+    public function getTaskId()
     {
         return $this->taskId;
     }
@@ -91,7 +91,7 @@ class WebhookEventLogRecord
      * @param string|null $taskId
      * @return $this
      */
-    public function setTaskId(?string $taskId)
+    public function setTaskId($taskId)
     {
         $this->taskId = $taskId;
 
@@ -101,7 +101,7 @@ class WebhookEventLogRecord
     /**
      * @return string|null
      */
-    public function getParentTaskId(): ?string
+    public function getParentTaskId()
     {
         return $this->parentTaskId;
     }
@@ -110,7 +110,7 @@ class WebhookEventLogRecord
      * @param string|null $parentTaskId
      * @return $this
      */
-    public function setParentTaskId(?string $parentTaskId)
+    public function setParentTaskId($parentTaskId)
     {
         $this->parentTaskId = $parentTaskId;
 
@@ -120,7 +120,7 @@ class WebhookEventLogRecord
     /**
      * @return string|null
      */
-    public function getResultMessage(): ?string
+    public function getResultMessage()
     {
         return $this->resultMessage;
     }
@@ -129,7 +129,7 @@ class WebhookEventLogRecord
      * @param string $resultMessage
      * @return $this
      */
-    public function setResultMessage(string $resultMessage)
+    public function setResultMessage($resultMessage)
     {
         $this->resultMessage = $resultMessage;
 
@@ -139,7 +139,7 @@ class WebhookEventLogRecord
     /**
      * @return int|null
      */
-    public function getHttpStatusCode(): ?int
+    public function getHttpStatusCode()
     {
         return $this->httpStatusCode;
     }
@@ -148,7 +148,7 @@ class WebhookEventLogRecord
      * @param int $httpStatusCode
      * @return $this
      */
-    public function setHttpStatusCode(int $httpStatusCode)
+    public function setHttpStatusCode($httpStatusCode)
     {
         $this->httpStatusCode = $httpStatusCode;
 
@@ -158,7 +158,7 @@ class WebhookEventLogRecord
     /**
      * @return string|null
      */
-    public function getResponseBody(): ?string
+    public function getResponseBody()
     {
         return $this->responseBody;
     }
@@ -167,7 +167,7 @@ class WebhookEventLogRecord
      * @param string|null $responseBody
      * @return $this
      */
-    public function setResponseBody(?string $responseBody)
+    public function setResponseBody($responseBody)
     {
         $this->responseBody = $responseBody;
 
@@ -177,7 +177,7 @@ class WebhookEventLogRecord
     /**
      * @return string|null
      */
-    public function getAcknowledgementStatus(): ?string
+    public function getAcknowledgementStatus()
     {
         return $this->acknowledgementStatus;
     }
@@ -186,7 +186,7 @@ class WebhookEventLogRecord
      * @param string $acknowledgementStatus
      * @return $this
      */
-    public function setAcknowledgementStatus(string $acknowledgementStatus)
+    public function setAcknowledgementStatus($acknowledgementStatus)
     {
         $this->acknowledgementStatus = $acknowledgementStatus;
 
@@ -205,7 +205,7 @@ class WebhookEventLogRecord
      * @param string $result
      * @return $this
      */
-    public function setResult(string $result)
+    public function setResult($result)
     {
         $this->result = $result;
 
@@ -215,7 +215,7 @@ class WebhookEventLogRecord
     /**
      * @return int|null
      */
-    public function getCreatedAt(): ?int
+    public function getCreatedAt()
     {
         return $this->createdAt;
     }

--- a/models/classes/webhooks/log/WebhookEventLogRecord.php
+++ b/models/classes/webhooks/log/WebhookEventLogRecord.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\webhooks\log;
+
+class WebhookEventLogRecord
+{
+    /** @var string|null */
+    private $eventId;
+
+    /** @var string|null */
+    private $taskId;
+
+    /** @var string|null */
+    private $parentTaskId;
+
+    /**
+     * @var string|null
+     * @example port refused (in case of network error)
+     * @example unknown host (in case of network error)
+     * @example Undefined index: key (in case of internal error)
+     */
+    private $resultMessage;
+
+    /** @var int|null */
+    private $httpStatusCode;
+
+    /** @var string|null */
+    private $responseBody;
+
+    /** @var string|null */
+    private $acknowledgementStatus;
+
+    /** @var string|null */
+    private $createdAt;
+
+    /** @var string|null */
+    private $result;
+
+    const RESULT_INTERNAL_ERROR = 'internal_error';
+    const RESULT_NETWORK_ERROR = 'network_error';
+    const RESULT_INVALID_BODY_FORMAT = 'invalid_body_format';
+    const RESULT_INVALID_HTTP_STATUS = 'invalid_http_status';
+    const RESULT_INVALID_ACKNOWLEDGEMENT = 'invalid_acknowledgement';
+    const RESULT_OK = 'ok';
+
+    /**
+     * @return string|null
+     */
+    public function getEventId(): ?string
+    {
+        return $this->eventId;
+    }
+
+    /**
+     * @param string $eventId
+     * @return $this
+     */
+    public function setEventId(string $eventId)
+    {
+        $this->eventId = $eventId;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTaskId(): ?string
+    {
+        return $this->taskId;
+    }
+
+    /**
+     * @param string|null $taskId
+     * @return $this
+     */
+    public function setTaskId(?string $taskId)
+    {
+        $this->taskId = $taskId;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getParentTaskId(): ?string
+    {
+        return $this->parentTaskId;
+    }
+
+    /**
+     * @param string|null $parentTaskId
+     * @return $this
+     */
+    public function setParentTaskId(?string $parentTaskId)
+    {
+        $this->parentTaskId = $parentTaskId;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getResultMessage(): ?string
+    {
+        return $this->resultMessage;
+    }
+
+    /**
+     * @param string $resultMessage
+     * @return $this
+     */
+    public function setResultMessage(string $resultMessage)
+    {
+        $this->resultMessage = $resultMessage;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getHttpStatusCode(): ?int
+    {
+        return $this->httpStatusCode;
+    }
+
+    /**
+     * @param int $httpStatusCode
+     * @return $this
+     */
+    public function setHttpStatusCode(int $httpStatusCode)
+    {
+        $this->httpStatusCode = $httpStatusCode;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getResponseBody(): ?string
+    {
+        return $this->responseBody;
+    }
+
+    /**
+     * @param string|null $responseBody
+     * @return $this
+     */
+    public function setResponseBody(?string $responseBody)
+    {
+        $this->responseBody = $responseBody;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAcknowledgementStatus(): ?string
+    {
+        return $this->acknowledgementStatus;
+    }
+
+    /**
+     * @param string $acknowledgementStatus
+     * @return $this
+     */
+    public function setAcknowledgementStatus(string $acknowledgementStatus)
+    {
+        $this->acknowledgementStatus = $acknowledgementStatus;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getResult(): ?string
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param string $result
+     * @return $this
+     */
+    public function setResult(string $result)
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getCreatedAt(): ?int
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param int $createdAt
+     * @return $this
+     */
+    public function setCreatedAt(int $createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+}

--- a/models/classes/webhooks/log/WebhookLogRepository.php
+++ b/models/classes/webhooks/log/WebhookLogRepository.php
@@ -19,6 +19,7 @@
 
 namespace oat\tao\model\webhooks\log;
 
+use common_persistence_Manager;
 use Doctrine\DBAL\Query\QueryBuilder;
 use oat\oatbox\log\LoggerAwareTrait;
 use oat\oatbox\service\ConfigurableService;
@@ -53,7 +54,9 @@ class WebhookLogRepository extends ConfigurableService implements WebhookLogRepo
     private function getPersistence()
     {
         $persistenceId = $this->getOption(self::OPTION_PERSISTENCE) ?: 'default';
-        return $this->getServiceLocator()->get(\common_persistence_Manager::SERVICE_ID)->getPersistenceById($persistenceId);
+        /** @var common_persistence_Manager $persistenceManager */
+        $persistenceManager = $this->getServiceManager()->get(common_persistence_Manager::SERVICE_ID);
+        $this->persistence = $persistenceManager->getPersistenceById($persistenceId);
     }
 
     /**

--- a/models/classes/webhooks/log/WebhookLogRepository.php
+++ b/models/classes/webhooks/log/WebhookLogRepository.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\webhooks\log;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use oat\oatbox\log\LoggerAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+
+class WebhookLogRepository extends ConfigurableService implements WebhookLogRepositoryInterface
+{
+    use LoggerAwareTrait;
+
+    const OPTION_PERSISTENCE = 'persistence';
+
+    /**
+     * Constants for the database creation and data access
+     */
+    const TABLE_NAME = 'webhook_event_log';
+    const COLUMN_ID = 'id';
+    const COLUMN_EVENT_ID = 'event_id';
+    const COLUMN_TASK_ID = 'task_id';
+    const COLUMN_PARENT_TASK_ID = 'parent_task_id';
+    const COLUMN_HTTP_STATUS_CODE = 'http_status_code';
+    const COLUMN_RESPONSE_BODY = 'response_body';
+    const COLUMN_ACKNOWLEDGEMENT_STATUS = 'acknowledgement_status';
+    const COLUMN_CREATED_AT = 'created_at';
+    const COLUMN_RESULT = 'result';
+    const COLUMN_RESULT_MESSAGE = 'result_message';
+
+    private function getPersistence(): \common_persistence_Persistence
+    {
+        $persistenceId = $this->getOption(self::OPTION_PERSISTENCE) ?: 'default';
+        return $this->getServiceLocator()->get(\common_persistence_Manager::SERVICE_ID)->getPersistenceById($persistenceId);
+    }
+
+    private function getQueryBuilder(): QueryBuilder
+    {
+        /**@var \common_persistence_sql_pdo_mysql_Driver $driver */
+        return $this->getPersistence()->getPlatForm()->getQueryBuilder();
+    }
+
+    public function storeLog(WebhookEventLogRecord $webhookEventLog): void
+    {
+        $this->getPersistence()->insert(self::TABLE_NAME, [
+            self::COLUMN_EVENT_ID => $webhookEventLog->getEventId(),
+            self::COLUMN_TASK_ID => $webhookEventLog->getTaskId(),
+            self::COLUMN_PARENT_TASK_ID => $webhookEventLog->getParentTaskId(),
+            self::COLUMN_HTTP_STATUS_CODE => $webhookEventLog->getHttpStatusCode(),
+            self::COLUMN_RESPONSE_BODY => $webhookEventLog->getResponseBody(),
+            self::COLUMN_ACKNOWLEDGEMENT_STATUS => $webhookEventLog->getAcknowledgementStatus(),
+            self::COLUMN_CREATED_AT => $webhookEventLog->getCreatedAt(),
+            self::COLUMN_RESULT => $webhookEventLog->getResult(),
+            self::COLUMN_RESULT_MESSAGE => $webhookEventLog->getResultMessage(),
+        ]);
+    }
+}

--- a/models/classes/webhooks/log/WebhookLogRepository.php
+++ b/models/classes/webhooks/log/WebhookLogRepository.php
@@ -36,7 +36,6 @@ class WebhookLogRepository extends ConfigurableService implements WebhookLogRepo
     const COLUMN_ID = 'id';
     const COLUMN_EVENT_ID = 'event_id';
     const COLUMN_TASK_ID = 'task_id';
-    const COLUMN_PARENT_TASK_ID = 'parent_task_id';
     const COLUMN_HTTP_STATUS_CODE = 'http_status_code';
     const COLUMN_RESPONSE_BODY = 'response_body';
     const COLUMN_ACKNOWLEDGEMENT_STATUS = 'acknowledgement_status';
@@ -70,7 +69,6 @@ class WebhookLogRepository extends ConfigurableService implements WebhookLogRepo
         $this->getPersistence()->insert(self::TABLE_NAME, [
             self::COLUMN_EVENT_ID => $webhookEventLog->getEventId(),
             self::COLUMN_TASK_ID => $webhookEventLog->getTaskId(),
-            self::COLUMN_PARENT_TASK_ID => $webhookEventLog->getParentTaskId(),
             self::COLUMN_HTTP_STATUS_CODE => $webhookEventLog->getHttpStatusCode(),
             self::COLUMN_RESPONSE_BODY => $webhookEventLog->getResponseBody(),
             self::COLUMN_ACKNOWLEDGEMENT_STATUS => $webhookEventLog->getAcknowledgementStatus(),

--- a/models/classes/webhooks/log/WebhookLogRepository.php
+++ b/models/classes/webhooks/log/WebhookLogRepository.php
@@ -36,6 +36,10 @@ class WebhookLogRepository extends ConfigurableService implements WebhookLogRepo
     const COLUMN_ID = 'id';
     const COLUMN_EVENT_ID = 'event_id';
     const COLUMN_TASK_ID = 'task_id';
+    const COLUMN_WEBHOOK_ID = 'webhook_id';
+    const COLUMN_HTTP_METHOD = 'http_method';
+    const COLUMN_ENDPOINT_URL = 'endpoint_url';
+    const COLUMN_EVENT_NAME = 'event_name';
     const COLUMN_HTTP_STATUS_CODE = 'http_status_code';
     const COLUMN_RESPONSE_BODY = 'response_body';
     const COLUMN_ACKNOWLEDGEMENT_STATUS = 'acknowledgement_status';
@@ -69,6 +73,10 @@ class WebhookLogRepository extends ConfigurableService implements WebhookLogRepo
         $this->getPersistence()->insert(self::TABLE_NAME, [
             self::COLUMN_EVENT_ID => $webhookEventLog->getEventId(),
             self::COLUMN_TASK_ID => $webhookEventLog->getTaskId(),
+            self::COLUMN_WEBHOOK_ID => $webhookEventLog->getWebhookId(),
+            self::COLUMN_HTTP_METHOD => $webhookEventLog->getHttpMethod(),
+            self::COLUMN_ENDPOINT_URL => $webhookEventLog->getEndpointUrl(),
+            self::COLUMN_EVENT_NAME => $webhookEventLog->getEventName(),
             self::COLUMN_HTTP_STATUS_CODE => $webhookEventLog->getHttpStatusCode(),
             self::COLUMN_RESPONSE_BODY => $webhookEventLog->getResponseBody(),
             self::COLUMN_ACKNOWLEDGEMENT_STATUS => $webhookEventLog->getAcknowledgementStatus(),

--- a/models/classes/webhooks/log/WebhookLogRepository.php
+++ b/models/classes/webhooks/log/WebhookLogRepository.php
@@ -44,19 +44,28 @@ class WebhookLogRepository extends ConfigurableService implements WebhookLogRepo
     const COLUMN_RESULT = 'result';
     const COLUMN_RESULT_MESSAGE = 'result_message';
 
-    private function getPersistence(): \common_persistence_Persistence
+    /**
+     * @return \common_persistence_Persistence
+     */
+    private function getPersistence()
     {
         $persistenceId = $this->getOption(self::OPTION_PERSISTENCE) ?: 'default';
         return $this->getServiceLocator()->get(\common_persistence_Manager::SERVICE_ID)->getPersistenceById($persistenceId);
     }
 
-    private function getQueryBuilder(): QueryBuilder
+    /**
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder()
     {
         /**@var \common_persistence_sql_pdo_mysql_Driver $driver */
         return $this->getPersistence()->getPlatForm()->getQueryBuilder();
     }
 
-    public function storeLog(WebhookEventLogRecord $webhookEventLog): void
+    /**
+     * @inheritDoc
+     */
+    public function storeLog(WebhookEventLogRecord $webhookEventLog)
     {
         $this->getPersistence()->insert(self::TABLE_NAME, [
             self::COLUMN_EVENT_ID => $webhookEventLog->getEventId(),

--- a/models/classes/webhooks/log/WebhookLogRepository.php
+++ b/models/classes/webhooks/log/WebhookLogRepository.php
@@ -61,8 +61,7 @@ class WebhookLogRepository extends ConfigurableService implements WebhookLogRepo
      */
     private function getQueryBuilder()
     {
-        /**@var \common_persistence_sql_pdo_mysql_Driver $driver */
-        return $this->getPersistence()->getPlatForm()->getQueryBuilder();
+        return $this->getPersistence()->getPlatform()->getQueryBuilder();
     }
 
     /**

--- a/models/classes/webhooks/log/WebhookLogRepositoryInterface.php
+++ b/models/classes/webhooks/log/WebhookLogRepositoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\webhooks\log;
+
+interface WebhookLogRepositoryInterface
+{
+    const SERVICE_ID = 'tao/webhookLogRepository';
+
+    /**
+     * @param WebhookEventLogRecord $webhookEventLog
+     * @return void
+     */
+    public function storeLog(WebhookEventLogRecord $webhookEventLog);
+}

--- a/models/classes/webhooks/log/WebhookRdsEventLogService.php
+++ b/models/classes/webhooks/log/WebhookRdsEventLogService.php
@@ -23,7 +23,7 @@ use oat\oatbox\service\ConfigurableService;
 
 class WebhookRdsEventLogService extends ConfigurableService implements WebhookEventLogInterface
 {
-    const HTTP_OK_STATUS_CODE = '200';
+    const HTTP_OK_STATUS_CODE = 200;
 
     /**
      * @param string $eventId

--- a/models/classes/webhooks/log/WebhookRdsEventLogService.php
+++ b/models/classes/webhooks/log/WebhookRdsEventLogService.php
@@ -25,7 +25,14 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
 {
     const HTTP_OK_STATUS_CODE = '200';
 
-    public function storeNetworkErrorLog(string $eventId, string $taskId, string $parentTaskId, ?string $networkError): void
+    /**
+     * @param string $eventId
+     * @param string $taskId
+     * @param string $parentTaskId
+     * @param string|null $networkError
+     * @throws \Exception
+     */
+    public function storeNetworkErrorLog($eventId, $taskId, $parentTaskId, $networkError = null)
     {
         $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
             ->setResultMessage(sprintf('Network error: %s', $networkError))
@@ -34,7 +41,14 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
         $this->getRepository()->storeLog($record);
     }
 
-    public function storeInvalidHttpStatusLog(string $eventId, string $taskId, string $parentTaskId, int $actualHttpStatusCode): void
+    /**
+     * @param string $eventId
+     * @param string $taskId
+     * @param string $parentTaskId
+     * @param int $actualHttpStatusCode
+     * @throws \Exception
+     */
+    public function storeInvalidHttpStatusLog($eventId, $taskId, $parentTaskId, $actualHttpStatusCode)
     {
         $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
             ->setHttpStatusCode($actualHttpStatusCode)
@@ -44,7 +58,14 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
         $this->getRepository()->storeLog($record);
     }
 
-    public function storeInvalidBodyFormat(string $eventId, string $taskId, string $parentTaskId, string $responseBody): void
+    /**
+     * @param string $eventId
+     * @param string $taskId
+     * @param string $parentTaskId
+     * @param string|null $responseBody
+     * @throws \Exception
+     */
+    public function storeInvalidBodyFormat($eventId, $taskId, $parentTaskId, $responseBody = null)
     {
         $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
             ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
@@ -55,7 +76,15 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
         $this->getRepository()->storeLog($record);
     }
 
-    public function storeInvalidAcknowledgementLog($eventId, $taskId, $parentTaskId, string $responseBody, $actualAcknowledgement): void
+    /**
+     * @param string $eventId
+     * @param string $taskId
+     * @param string $parentTaskId
+     * @param string $responseBody
+     * @param string|null $actualAcknowledgement
+     * @throws \Exception
+     */
+    public function storeInvalidAcknowledgementLog($eventId, $taskId, $parentTaskId, $responseBody, $actualAcknowledgement = null)
     {
         $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
             ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
@@ -67,7 +96,15 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
         $this->getRepository()->storeLog($record);
     }
 
-    public function storeSuccessfulLog($eventId, $taskId, $parentTaskId, string $responseBody, string $acknowledgement): void
+    /**
+     * @param string $eventId
+     * @param string $taskId
+     * @param string $parentTaskId
+     * @param string $responseBody
+     * @param string $acknowledgement
+     * @throws \Exception
+     */
+    public function storeSuccessfulLog($eventId, $taskId, $parentTaskId, $responseBody, $acknowledgement)
     {
         $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
             ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
@@ -79,7 +116,14 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
         $this->getRepository()->storeLog($record);
     }
 
-    public function storeInternalErrorLog(string $eventId, string $taskId, string $parentTaskId, ?string $internalError): void
+    /**
+     * @param string $eventId
+     * @param string $taskId
+     * @param string $parentTaskId
+     * @param string|null $internalError
+     * @throws \Exception
+     */
+    public function storeInternalErrorLog($eventId, $taskId, $parentTaskId, $internalError = null)
     {
         $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
             ->setResultMessage(sprintf('Internal error: %s', $internalError))
@@ -88,7 +132,14 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
         $this->getRepository()->storeLog($record);
     }
 
-    private function createRecordSkeleton($eventId, $taskId, $parentTaskId): WebhookEventLogRecord
+    /**
+     * @param string $eventId
+     * @param string $taskId
+     * @param string $parentTaskId
+     * @return WebhookEventLogRecord
+     * @throws \Exception
+     */
+    private function createRecordSkeleton($eventId, $taskId, $parentTaskId)
     {
         $record = new WebhookEventLogRecord();
 
@@ -103,7 +154,10 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
         return $record;
     }
 
-    private function getRepository(): WebhookLogRepository
+    /**
+     * @return WebhookLogRepository
+     */
+    private function getRepository()
     {
         return $this->getServiceLocator()->get(WebhookLogRepository::SERVICE_ID);
     }

--- a/models/classes/webhooks/log/WebhookRdsEventLogService.php
+++ b/models/classes/webhooks/log/WebhookRdsEventLogService.php
@@ -21,11 +21,10 @@ namespace oat\tao\model\webhooks\log;
 
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\webhooks\task\WebhookTaskContext;
+use Slim\Http\StatusCode;
 
 class WebhookRdsEventLogService extends ConfigurableService implements WebhookEventLogInterface
 {
-    const HTTP_OK_STATUS_CODE = 200;
-
     /**
      * @inheritDoc
      * @throws \Exception
@@ -60,7 +59,7 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     public function storeInvalidBodyFormat(WebhookTaskContext $webhookTaskContext, $responseBody = null)
     {
         $record = $this->applyContext($webhookTaskContext)
-            ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
+            ->setHttpStatusCode(StatusCode::HTTP_OK)
             ->setResultMessage(sprintf('Invalid body format'))
             ->setResponseBody($responseBody)
             ->setResult(WebhookEventLogRecord::RESULT_INVALID_BODY_FORMAT);
@@ -75,7 +74,7 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     public function storeInvalidAcknowledgementLog(WebhookTaskContext $webhookTaskContext, $responseBody, $actualAcknowledgement = null)
     {
         $record = $this->applyContext($webhookTaskContext)
-            ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
+            ->setHttpStatusCode(StatusCode::HTTP_OK)
             ->setResponseBody($responseBody)
             ->setAcknowledgementStatus($actualAcknowledgement)
             ->setResultMessage(sprintf('Acknowledgement "%s" unexpected', $actualAcknowledgement))
@@ -91,7 +90,7 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     public function storeSuccessfulLog(WebhookTaskContext $webhookTaskContext, $responseBody, $acknowledgement)
     {
         $record = $this->applyContext($webhookTaskContext)
-            ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
+            ->setHttpStatusCode(StatusCode::HTTP_OK)
             ->setResponseBody($responseBody)
             ->setAcknowledgementStatus($acknowledgement)
             ->setResultMessage('OK')
@@ -146,6 +145,7 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
      */
     private function getRepository()
     {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->getServiceLocator()->get(WebhookLogRepository::SERVICE_ID);
     }
 }

--- a/models/classes/webhooks/log/WebhookRdsEventLogService.php
+++ b/models/classes/webhooks/log/WebhookRdsEventLogService.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\webhooks\log;
+
+use oat\oatbox\service\ConfigurableService;
+
+class WebhookRdsEventLogService extends ConfigurableService implements WebhookEventLogInterface
+{
+    const HTTP_OK_STATUS_CODE = '200';
+
+    public function storeNetworkErrorLog(string $eventId, string $taskId, string $parentTaskId, ?string $networkError): void
+    {
+        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+            ->setResultMessage(sprintf('Network error: %s', $networkError))
+            ->setResult(WebhookEventLogRecord::RESULT_NETWORK_ERROR);
+
+        $this->getRepository()->storeLog($record);
+    }
+
+    public function storeInvalidHttpStatusLog(string $eventId, string $taskId, string $parentTaskId, int $actualHttpStatusCode): void
+    {
+        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+            ->setHttpStatusCode($actualHttpStatusCode)
+            ->setResultMessage(sprintf('HTTP status code %d unexpected', $actualHttpStatusCode))
+            ->setResult(WebhookEventLogRecord::RESULT_INVALID_HTTP_STATUS);
+
+        $this->getRepository()->storeLog($record);
+    }
+
+    public function storeInvalidBodyFormat(string $eventId, string $taskId, string $parentTaskId, string $responseBody): void
+    {
+        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+            ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
+            ->setResultMessage(sprintf('Invalid body format'))
+            ->setResponseBody($responseBody)
+            ->setResult(WebhookEventLogRecord::RESULT_INVALID_BODY_FORMAT);
+
+        $this->getRepository()->storeLog($record);
+    }
+
+    public function storeInvalidAcknowledgementLog($eventId, $taskId, $parentTaskId, string $responseBody, $actualAcknowledgement): void
+    {
+        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+            ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
+            ->setResponseBody($responseBody)
+            ->setAcknowledgementStatus($actualAcknowledgement)
+            ->setResultMessage(sprintf('Acknowledgement "%s" unexpected', $actualAcknowledgement))
+            ->setResult(WebhookEventLogRecord::RESULT_INVALID_HTTP_STATUS);
+
+        $this->getRepository()->storeLog($record);
+    }
+
+    public function storeSuccessfulLog($eventId, $taskId, $parentTaskId, string $responseBody, string $acknowledgement): void
+    {
+        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+            ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
+            ->setResponseBody($responseBody)
+            ->setAcknowledgementStatus($acknowledgement)
+            ->setResultMessage('OK')
+            ->setResult(WebhookEventLogRecord::RESULT_OK);
+
+        $this->getRepository()->storeLog($record);
+    }
+
+    public function storeInternalErrorLog(string $eventId, string $taskId, string $parentTaskId, ?string $internalError): void
+    {
+        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+            ->setResultMessage(sprintf('Internal error: %s', $internalError))
+            ->setResult(WebhookEventLogRecord::RESULT_INTERNAL_ERROR);
+
+        $this->getRepository()->storeLog($record);
+    }
+
+    private function createRecordSkeleton($eventId, $taskId, $parentTaskId): WebhookEventLogRecord
+    {
+        $record = new WebhookEventLogRecord();
+
+        $createdAt = new \DateTimeImmutable();
+
+        $record
+            ->setEventId($eventId)
+            ->setTaskId($taskId)
+            ->setParentTaskId($parentTaskId)
+            ->setCreatedAt($createdAt->getTimestamp());
+
+        return $record;
+    }
+
+    private function getRepository(): WebhookLogRepository
+    {
+        return $this->getServiceLocator()->get(WebhookLogRepository::SERVICE_ID);
+    }
+}

--- a/models/classes/webhooks/log/WebhookRdsEventLogService.php
+++ b/models/classes/webhooks/log/WebhookRdsEventLogService.php
@@ -28,13 +28,12 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     /**
      * @param string $eventId
      * @param string $taskId
-     * @param string $parentTaskId
      * @param string|null $networkError
      * @throws \Exception
      */
-    public function storeNetworkErrorLog($eventId, $taskId, $parentTaskId, $networkError = null)
+    public function storeNetworkErrorLog($eventId, $taskId, $networkError = null)
     {
-        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+        $record = $this->createRecordSkeleton($eventId, $taskId)
             ->setResultMessage(sprintf('Network error: %s', $networkError))
             ->setResult(WebhookEventLogRecord::RESULT_NETWORK_ERROR);
 
@@ -44,13 +43,12 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     /**
      * @param string $eventId
      * @param string $taskId
-     * @param string $parentTaskId
      * @param int $actualHttpStatusCode
      * @throws \Exception
      */
-    public function storeInvalidHttpStatusLog($eventId, $taskId, $parentTaskId, $actualHttpStatusCode)
+    public function storeInvalidHttpStatusLog($eventId, $taskId, $actualHttpStatusCode)
     {
-        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+        $record = $this->createRecordSkeleton($eventId, $taskId)
             ->setHttpStatusCode($actualHttpStatusCode)
             ->setResultMessage(sprintf('HTTP status code %d unexpected', $actualHttpStatusCode))
             ->setResult(WebhookEventLogRecord::RESULT_INVALID_HTTP_STATUS);
@@ -61,13 +59,12 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     /**
      * @param string $eventId
      * @param string $taskId
-     * @param string $parentTaskId
      * @param string|null $responseBody
      * @throws \Exception
      */
-    public function storeInvalidBodyFormat($eventId, $taskId, $parentTaskId, $responseBody = null)
+    public function storeInvalidBodyFormat($eventId, $taskId, $responseBody = null)
     {
-        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+        $record = $this->createRecordSkeleton($eventId, $taskId)
             ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
             ->setResultMessage(sprintf('Invalid body format'))
             ->setResponseBody($responseBody)
@@ -79,14 +76,13 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     /**
      * @param string $eventId
      * @param string $taskId
-     * @param string $parentTaskId
      * @param string $responseBody
      * @param string|null $actualAcknowledgement
      * @throws \Exception
      */
-    public function storeInvalidAcknowledgementLog($eventId, $taskId, $parentTaskId, $responseBody, $actualAcknowledgement = null)
+    public function storeInvalidAcknowledgementLog($eventId, $taskId, $responseBody, $actualAcknowledgement = null)
     {
-        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+        $record = $this->createRecordSkeleton($eventId, $taskId)
             ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
             ->setResponseBody($responseBody)
             ->setAcknowledgementStatus($actualAcknowledgement)
@@ -99,14 +95,13 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     /**
      * @param string $eventId
      * @param string $taskId
-     * @param string $parentTaskId
      * @param string $responseBody
      * @param string $acknowledgement
      * @throws \Exception
      */
-    public function storeSuccessfulLog($eventId, $taskId, $parentTaskId, $responseBody, $acknowledgement)
+    public function storeSuccessfulLog($eventId, $taskId, $responseBody, $acknowledgement)
     {
-        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+        $record = $this->createRecordSkeleton($eventId, $taskId)
             ->setHttpStatusCode(self::HTTP_OK_STATUS_CODE)
             ->setResponseBody($responseBody)
             ->setAcknowledgementStatus($acknowledgement)
@@ -119,13 +114,12 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     /**
      * @param string $eventId
      * @param string $taskId
-     * @param string $parentTaskId
      * @param string|null $internalError
      * @throws \Exception
      */
-    public function storeInternalErrorLog($eventId, $taskId, $parentTaskId, $internalError = null)
+    public function storeInternalErrorLog($eventId, $taskId, $internalError = null)
     {
-        $record = $this->createRecordSkeleton($eventId, $taskId, $parentTaskId)
+        $record = $this->createRecordSkeleton($eventId, $taskId)
             ->setResultMessage(sprintf('Internal error: %s', $internalError))
             ->setResult(WebhookEventLogRecord::RESULT_INTERNAL_ERROR);
 
@@ -135,11 +129,10 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
     /**
      * @param string $eventId
      * @param string $taskId
-     * @param string $parentTaskId
      * @return WebhookEventLogRecord
      * @throws \Exception
      */
-    private function createRecordSkeleton($eventId, $taskId, $parentTaskId)
+    private function createRecordSkeleton($eventId, $taskId)
     {
         $record = new WebhookEventLogRecord();
 
@@ -148,7 +141,6 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
         $record
             ->setEventId($eventId)
             ->setTaskId($taskId)
-            ->setParentTaskId($parentTaskId)
             ->setCreatedAt($createdAt->getTimestamp());
 
         return $record;

--- a/models/classes/webhooks/task/WebhookTaskContext.php
+++ b/models/classes/webhooks/task/WebhookTaskContext.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\webhooks\task;
+
+use oat\tao\model\webhooks\configEntity\WebhookInterface;
+
+class WebhookTaskContext
+{
+    /** @var string|null */
+    private $taskId;
+
+    /** @var WebhookTaskParams|null */
+    private $webhookTaskParams;
+
+    /** @var WebhookInterface|null */
+    private $webhookConfig;
+
+    /**
+     * @return string|null
+     */
+    public function getTaskId()
+    {
+        return $this->taskId;
+    }
+
+    /**
+     * @param string|null $taskId
+     */
+    public function setTaskId($taskId)
+    {
+        $this->taskId = $taskId;
+    }
+
+    /**
+     * @return WebhookTaskParams|null
+     */
+    public function getWebhookTaskParams()
+    {
+        return $this->webhookTaskParams;
+    }
+
+    /**
+     * @param WebhookTaskParams|null $webhookTaskParams
+     */
+    public function setWebhookTaskParams($webhookTaskParams)
+    {
+        $this->webhookTaskParams = $webhookTaskParams;
+    }
+
+    /**
+     * @return WebhookInterface|null
+     */
+    public function getWebhookConfig()
+    {
+        return $this->webhookConfig;
+    }
+
+    /**
+     * @param WebhookInterface|null $webhookConfig
+     */
+    public function setWebhookConfig($webhookConfig)
+    {
+        $this->webhookConfig = $webhookConfig;
+    }
+}

--- a/scripts/install/CreateWebhookEventLogTable.php
+++ b/scripts/install/CreateWebhookEventLogTable.php
@@ -75,6 +75,11 @@ class CreateWebhookEventLogTable extends AbstractAction
             [WebhookLogRepository::COLUMN_EVENT_ID],
             'IDX_' . WebhookLogRepository::TABLE_NAME . '_event_id');
 
+
+        $logTable->addIndex(
+            [WebhookLogRepository::COLUMN_WEBHOOK_ID],
+            'IDX_' . WebhookLogRepository::TABLE_NAME . '_webhook_id');
+
         $logTable->addIndex(
             [WebhookLogRepository::COLUMN_CREATED_AT],
             'IDX_' . WebhookLogRepository::TABLE_NAME . '_created_at');

--- a/scripts/install/CreateWebhookEventLogTable.php
+++ b/scripts/install/CreateWebhookEventLogTable.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\scripts\install;
+
+use common_report_Report as Report;
+use oat\oatbox\extension\AbstractAction;
+use oat\tao\model\webhooks\log\WebhookLogRepository;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Deploys the webhook_event_log schema
+ *
+ * Class CreateWebhookEventLog
+ * @package oat\taoQtiTest\scripts\install
+ */
+class CreateWebhookEventLogTable extends AbstractAction
+{
+    /**
+     * @param array $params
+     * @return Report
+     * @throws \common_Exception
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
+     */
+    public function __invoke($params)
+    {
+        $persistenceId = count($params) > 0 ? reset($params) : 'default';
+        /** @var \common_persistence_Persistence $persistence */
+        $persistence = $this->getServiceLocator()->get(\common_persistence_Manager::SERVICE_KEY)->getPersistenceById($persistenceId);
+
+        /** @var \common_persistence_sql_dbal_SchemaManager $schemaManager */
+        $schemaManager = $persistence->getDriver()->getSchemaManager();
+        $schema = $schemaManager->createSchema();
+        $fromSchema = clone $schema;
+
+        if ($schema->hasTable(WebhookLogRepository::TABLE_NAME)) {
+            return new Report(Report::TYPE_INFO, 'Webhook event log table already created, exit');
+        }
+
+        $logTable = $schema->createTable(WebhookLogRepository::TABLE_NAME);
+        $logTable->addOption('engine', 'InnoDB');
+
+        $logTable->addColumn(WebhookLogRepository::COLUMN_ID, Type::INTEGER, array('autoincrement' => true));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_EVENT_ID, Type::STRING, array('notnull' => false, 'length' => 255));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_TASK_ID, Type::STRING, array('notnull' => false, 'length' => 255));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_PARENT_TASK_ID, Type::STRING, array('notnull' => true, 'length' => 255));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_HTTP_STATUS_CODE, Type::SMALLINT, array('notnull' => false));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_RESPONSE_BODY, Type::TEXT, array('notnull' => false));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_ACKNOWLEDGEMENT_STATUS, Type::STRING, array('notnull' => false, 'length' => 255));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_CREATED_AT, Type::INTEGER, array('notnull' => true));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_RESULT, Type::STRING, array('notnull' => true, 'length' => 255));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_RESULT_MESSAGE, Type::TEXT, array('notnull' => false));
+
+        $logTable->addUniqueIndex(
+            [WebhookLogRepository::COLUMN_EVENT_ID],
+            'IDX_' . WebhookLogRepository::TABLE_NAME . '_event_id');
+
+        $queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $schema);
+        foreach ($queries as $query) {
+            $persistence->exec($query);
+        }
+
+        return new Report(Report::TYPE_SUCCESS, 'RDS schema for WebhookLogRepository is now installed');
+    }
+}

--- a/scripts/install/CreateWebhookEventLogTable.php
+++ b/scripts/install/CreateWebhookEventLogTable.php
@@ -60,7 +60,6 @@ class CreateWebhookEventLogTable extends AbstractAction
         $logTable->addColumn(WebhookLogRepository::COLUMN_ID, Type::INTEGER, array('autoincrement' => true));
         $logTable->addColumn(WebhookLogRepository::COLUMN_EVENT_ID, Type::STRING, array('notnull' => false, 'length' => 255));
         $logTable->addColumn(WebhookLogRepository::COLUMN_TASK_ID, Type::STRING, array('notnull' => false, 'length' => 255));
-        $logTable->addColumn(WebhookLogRepository::COLUMN_PARENT_TASK_ID, Type::STRING, array('notnull' => true, 'length' => 255));
         $logTable->addColumn(WebhookLogRepository::COLUMN_HTTP_STATUS_CODE, Type::SMALLINT, array('notnull' => false));
         $logTable->addColumn(WebhookLogRepository::COLUMN_RESPONSE_BODY, Type::TEXT, array('notnull' => false));
         $logTable->addColumn(WebhookLogRepository::COLUMN_ACKNOWLEDGEMENT_STATUS, Type::STRING, array('notnull' => false, 'length' => 255));

--- a/scripts/install/CreateWebhookEventLogTable.php
+++ b/scripts/install/CreateWebhookEventLogTable.php
@@ -71,9 +71,13 @@ class CreateWebhookEventLogTable extends AbstractAction
         $logTable->addColumn(WebhookLogRepository::COLUMN_RESULT, Type::STRING, array('notnull' => true, 'length' => 255));
         $logTable->addColumn(WebhookLogRepository::COLUMN_RESULT_MESSAGE, Type::TEXT, array('notnull' => false));
 
-        $logTable->addUniqueIndex(
+        $logTable->addIndex(
             [WebhookLogRepository::COLUMN_EVENT_ID],
             'IDX_' . WebhookLogRepository::TABLE_NAME . '_event_id');
+
+        $logTable->addIndex(
+            [WebhookLogRepository::COLUMN_CREATED_AT],
+            'IDX_' . WebhookLogRepository::TABLE_NAME . '_created_at');
 
         $queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $schema);
         foreach ($queries as $query) {

--- a/scripts/install/CreateWebhookEventLogTable.php
+++ b/scripts/install/CreateWebhookEventLogTable.php
@@ -60,6 +60,10 @@ class CreateWebhookEventLogTable extends AbstractAction
         $logTable->addColumn(WebhookLogRepository::COLUMN_ID, Type::INTEGER, array('autoincrement' => true));
         $logTable->addColumn(WebhookLogRepository::COLUMN_EVENT_ID, Type::STRING, array('notnull' => false, 'length' => 255));
         $logTable->addColumn(WebhookLogRepository::COLUMN_TASK_ID, Type::STRING, array('notnull' => false, 'length' => 255));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_WEBHOOK_ID, Type::STRING, array('notnull' => false, 'length' => 255));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_HTTP_METHOD, Type::STRING, array('notnull' => false, 'length' => 255));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_ENDPOINT_URL, Type::STRING, array('notnull' => false, 'length' => 255));
+        $logTable->addColumn(WebhookLogRepository::COLUMN_EVENT_NAME, Type::STRING, array('notnull' => false, 'length' => 255));
         $logTable->addColumn(WebhookLogRepository::COLUMN_HTTP_STATUS_CODE, Type::SMALLINT, array('notnull' => false));
         $logTable->addColumn(WebhookLogRepository::COLUMN_RESPONSE_BODY, Type::TEXT, array('notnull' => false));
         $logTable->addColumn(WebhookLogRepository::COLUMN_ACKNOWLEDGEMENT_STATUS, Type::STRING, array('notnull' => false, 'length' => 255));

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -89,6 +89,10 @@ use oat\tao\model\user\implementation\NoUserLocksService;
 use oat\tao\model\user\import\OntologyUserMapper;
 use oat\tao\model\user\import\UserCsvImporterFactory;
 use oat\tao\model\user\UserLocks;
+use oat\tao\model\webhooks\log\WebhookEventLogInterface;
+use oat\tao\model\webhooks\log\WebhookLogRepository;
+use oat\tao\model\webhooks\log\WebhookLogRepositoryInterface;
+use oat\tao\model\webhooks\log\WebhookRdsEventLogService;
 use oat\tao\model\webhooks\task\JsonWebhookPayloadFactory;
 use oat\tao\model\webhooks\task\JsonWebhookResponseFactory;
 use oat\tao\model\webhooks\task\WebhookPayloadFactoryInterface;
@@ -100,6 +104,7 @@ use oat\tao\model\webhooks\WebhookRegistryInterface;
 use oat\tao\model\webhooks\WebhookTaskService;
 use oat\tao\model\webhooks\WebhookTaskServiceInterface;
 use oat\tao\scripts\install\AddArchiveService;
+use oat\tao\scripts\install\CreateWebhookEventLogTable;
 use oat\tao\scripts\install\InstallNotificationTable;
 use oat\tao\scripts\install\AddTmpFsHandlers;
 use oat\tao\scripts\install\RegisterSignatureGenerator;
@@ -1183,5 +1188,20 @@ class Updater extends \common_ext_ExtensionUpdater {
 
         $this->skip('38.9.0', '38.9.5');
 
+        if ($this->isVersion('38.9.5')) {
+            $notifInstaller = new CreateWebhookEventLogTable();
+            $notifInstaller->setServiceLocator($this->getServiceManager());
+            $notifInstaller->__invoke([]);
+
+            $this->getServiceManager()->register(
+                WebhookLogRepositoryInterface::SERVICE_ID,
+                new WebhookLogRepository([WebhookLogRepository::OPTION_PERSISTENCE => 'default'])
+            );
+            $this->getServiceManager()->register(
+                WebhookEventLogInterface::SERVICE_ID,
+                new WebhookRdsEventLogService()
+            );
+            $this->setVersion('38.10.0');
+        }
     }
 }


### PR DESCRIPTION
According to https://oat-sa.atlassian.net/browse/TAO-8628, 
- the `webhook_event_log` table created,
- the table is to be deployed both when installing & updating,
- the `WebhookLogRepository` introduced at the level of persistence, this is to be a persistence wrapper on top of the table while the `WebhookRdsEventLogService ` is to be a business layer.

Both services operate the `WebhookEventLogRecord` entity. `WebhookLogRepository` only cares about how to hydrate the entity and `WebhookLogRepository` can build a row according to business rules.

Tests to be added soon.