### PR TITLE
fix webhook request schema to pass unit tests

### DIFF
--- a/test/unit/webhooks/task/webhookRequestSchema.json
+++ b/test/unit/webhooks/task/webhookRequestSchema.json
@@ -17,7 +17,7 @@
       "examples": [
         "https://someinstance.taocloud.org/"
       ],
-      "minLength": 8
+      "minLength": 1
     },
     "events": {
       "$id": "#/properties/events",


### PR DESCRIPTION
Unit test failed on some envs:

oat\tao\test\unit\webhooks\task\JsonWebhookPayloadFactoryTest::testCreatePayloadSchema
[source] Must be at least 8 characters long

due to minLength requirement in tests for string produced by:
```
return defined('ROOT_URL')
            ? ROOT_URL
            : gethostname();
```