### PR TITLE
Fix/tao 9282/webhook task logging

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '39.0.2',
+    'version' => '39.0.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.3.2',

--- a/models/classes/webhooks/log/WebhookEventLogInterface.php
+++ b/models/classes/webhooks/log/WebhookEventLogInterface.php
@@ -34,8 +34,13 @@ interface WebhookEventLogInterface
     /**
      * @param WebhookTaskContext $webhookTaskContext
      * @param int $actualHttpStatusCode
+     * @param string|null $responseBody
      */
-    public function storeInvalidHttpStatusLog(WebhookTaskContext $webhookTaskContext, $actualHttpStatusCode);
+    public function storeInvalidHttpStatusLog(
+        WebhookTaskContext $webhookTaskContext,
+        $actualHttpStatusCode,
+        $responseBody = null
+    );
 
     /**
      * @param WebhookTaskContext $webhookTaskContext

--- a/models/classes/webhooks/log/WebhookRdsEventLogService.php
+++ b/models/classes/webhooks/log/WebhookRdsEventLogService.php
@@ -42,10 +42,14 @@ class WebhookRdsEventLogService extends ConfigurableService implements WebhookEv
      * @inheritDoc
      * @throws \Exception
      */
-    public function storeInvalidHttpStatusLog(WebhookTaskContext $webhookTaskContext, $actualHttpStatusCode)
-    {
+    public function storeInvalidHttpStatusLog(
+        WebhookTaskContext $webhookTaskContext,
+        $actualHttpStatusCode,
+        $responseBody = null
+    ) {
         $record = $this->applyContext($webhookTaskContext)
             ->setHttpStatusCode($actualHttpStatusCode)
+            ->setResponseBody($responseBody)
             ->setResultMessage(sprintf('HTTP status code %d unexpected', $actualHttpStatusCode))
             ->setResult(WebhookEventLogRecord::RESULT_INVALID_HTTP_STATUS);
 

--- a/models/classes/webhooks/task/WebhookTask.php
+++ b/models/classes/webhooks/task/WebhookTask.php
@@ -224,7 +224,8 @@ class WebhookTask extends AbstractAction implements TaskAwareInterface
     /**
      * @return WebhookTaskReports
      */
-    private function getWebhookTaskReports() {
+    private function getWebhookTaskReports()
+    {
         /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->getServiceLocator()->get(WebhookTaskReports::class);
     }

--- a/models/classes/webhooks/task/WebhookTaskContext.php
+++ b/models/classes/webhooks/task/WebhookTaskContext.php
@@ -42,10 +42,12 @@ class WebhookTaskContext
 
     /**
      * @param string|null $taskId
+     * @return $this
      */
     public function setTaskId($taskId)
     {
         $this->taskId = $taskId;
+        return $this;
     }
 
     /**
@@ -58,10 +60,12 @@ class WebhookTaskContext
 
     /**
      * @param WebhookTaskParams|null $webhookTaskParams
+     * @return $this
      */
     public function setWebhookTaskParams($webhookTaskParams)
     {
         $this->webhookTaskParams = $webhookTaskParams;
+        return $this;
     }
 
     /**
@@ -74,9 +78,11 @@ class WebhookTaskContext
 
     /**
      * @param WebhookInterface|null $webhookConfig
+     * @return $this
      */
     public function setWebhookConfig($webhookConfig)
     {
         $this->webhookConfig = $webhookConfig;
+        return $this;
     }
 }

--- a/models/classes/webhooks/task/WebhookTaskReports.php
+++ b/models/classes/webhooks/task/WebhookTaskReports.php
@@ -98,7 +98,7 @@ class WebhookTaskReports extends ConfigurableService
      * @param ResponseInterface $response
      * @return \common_report_Report
      */
-    public function reportInvalidStatusCode(WebhookTaskContext $taskContext, $response)
+    public function reportInvalidStatusCode(WebhookTaskContext $taskContext, ResponseInterface $response)
     {
         $statusCode = $response->getStatusCode();
         $this->getWebhookEventLog()->storeInvalidHttpStatusLog($taskContext, $statusCode);
@@ -110,7 +110,7 @@ class WebhookTaskReports extends ConfigurableService
      * @param ResponseInterface $response
      * @return \common_report_Report
      */
-    public function reportInvalidBodyFormat(WebhookTaskContext $taskContext, $response)
+    public function reportInvalidBodyFormat(WebhookTaskContext $taskContext, ResponseInterface $response)
     {
         $this->getWebhookEventLog()->storeInvalidBodyFormat($taskContext, $response->getBody());
         return $this->reportError(

--- a/models/classes/webhooks/task/WebhookTaskReports.php
+++ b/models/classes/webhooks/task/WebhookTaskReports.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\webhooks\task;
+
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\webhooks\log\WebhookEventLogInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class WebhookTaskReports extends ConfigurableService
+{
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @param \Exception $exception
+     * @return \common_report_Report
+     */
+    public function reportInternalException(WebhookTaskContext $taskContext, \Exception $exception)
+    {
+        $message = $this->getExceptionMessage($exception, true);
+        $this->getWebhookEventLog()->storeInternalErrorLog($taskContext, $message);
+        return $this->reportError($taskContext, 'Internal error: ' . $message);
+    }
+
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @param ConnectException $exception
+     * @return \common_report_Report
+     */
+    public function reportConnectException(WebhookTaskContext $taskContext, ConnectException $exception)
+    {
+        $this->getWebhookEventLog()->storeNetworkErrorLog($taskContext, $exception->getMessage());
+        return $this->reportError($taskContext, 'Connection exception: ' . $exception->getMessage());
+    }
+
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @param RequestException $exception
+     * @return \common_report_Report
+     */
+    public function reportRequestException(WebhookTaskContext $taskContext, RequestException $exception)
+    {
+        $message = $exception->getMessage();
+        if ($response = $exception->getResponse()) {
+            $this->getWebhookEventLog()->storeInvalidHttpStatusLog(
+                $taskContext,
+                $response->getStatusCode(),
+                $response->getBody()
+            );
+            return $this->reportError($taskContext, 'Request exception: ' . $exception->getMessage(), $response);
+        }
+
+        $this->getWebhookEventLog()->storeNetworkErrorLog($taskContext, $message);
+        return $this->reportError($taskContext, 'Request exception: ' . $exception->getMessage());
+    }
+
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @param BadResponseException $badResponseException
+     * @return \common_report_Report
+     */
+    public function reportBadResponseException(
+        WebhookTaskContext $taskContext,
+        BadResponseException $badResponseException
+    ) {
+        $statusCode = $badResponseException->getResponse()
+            ? $badResponseException->getResponse()->getStatusCode()
+            : 0;
+        $this->getWebhookEventLog()->storeInvalidHttpStatusLog($taskContext, $statusCode);
+
+        return $this->reportError(
+            $taskContext,
+            'Bad response: ' . $badResponseException->getMessage(),
+            $badResponseException->getResponse()
+        );
+    }
+
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @param ResponseInterface $response
+     * @return \common_report_Report
+     */
+    public function reportInvalidStatusCode(WebhookTaskContext $taskContext, $response)
+    {
+        $statusCode = $response->getStatusCode();
+        $this->getWebhookEventLog()->storeInvalidHttpStatusLog($taskContext, $statusCode);
+        return $this->reportError($taskContext, "Response status code is $statusCode", $response);
+    }
+
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @param ResponseInterface $response
+     * @return \common_report_Report
+     */
+    public function reportInvalidBodyFormat(WebhookTaskContext $taskContext, $response)
+    {
+        $this->getWebhookEventLog()->storeInvalidBodyFormat($taskContext, $response->getBody());
+        return $this->reportError(
+            $taskContext,
+            "Event '" . $this->getEventId($taskContext) . "' wasn't delivered.",
+            $response
+        );
+    }
+
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @param ResponseInterface $response
+     * @param WebhookResponse $parsedResponse
+     * @return \common_report_Report
+     */
+    public function reportInvalidAcknowledgement(WebhookTaskContext $taskContext, $response, $parsedResponse)
+    {
+        $eventId = $this->getEventId($taskContext);
+
+        $this->getWebhookEventLog()->storeInvalidAcknowledgementLog(
+            $taskContext,
+            $parsedResponse->getStatus($eventId)
+        );
+
+        return $this->reportError(
+            $taskContext,
+            "Event '" . $eventId . "' wasn't delivered.",
+            $response,
+            $parsedResponse
+        );
+    }
+
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @param ResponseInterface $response
+     * @param string $eventStatus
+     * @return \common_report_Report
+     */
+    public function reportSuccess(WebhookTaskContext $taskContext, $response, $eventStatus)
+    {
+        $this->getWebhookEventLog()->storeSuccessfulLog($taskContext, $response->getBody(), $eventStatus);
+        return \common_report_Report::createSuccess("Event delivered with '$eventStatus' status");
+    }
+
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @param string $message
+     * @param array $context
+     */
+    private function logErrorWithContext(WebhookTaskContext $taskContext, $message, $context = [])
+    {
+        $context['taskId'] = $taskContext->getTaskId();
+        $context['eventId'] = $this->getEventId($taskContext);
+        $this->logError($message, $context);
+    }
+
+    /**
+     * Adds error to log and returns report
+     * @param WebhookTaskContext $taskContext
+     * @param string $message
+     * @param ResponseInterface|null $response
+     * @param WebhookResponse|null $parsedResponse
+     * @return \common_report_Report
+     */
+    private function reportError(
+        WebhookTaskContext $taskContext,
+        $message,
+        ResponseInterface $response = null,
+        WebhookResponse $parsedResponse = null
+    ) {
+        $errors = [
+            'message' => $message
+        ];
+        $context = [];
+
+        if ($parsedResponse) {
+            if ($parsedResponse->getParseError()) {
+                $errors['parse'] = 'Parse error: ' . $parsedResponse->getParseError();
+            }
+            $status = $parsedResponse->getStatus($this->getEventId($taskContext));
+            $errors['status'] = $status !== null
+                ? "Event status: '$status'"
+                : 'eventId not found in response';
+        }
+
+        if ($response) {
+            $context['httpStatus'] = $response->getStatusCode();
+            $context['responseBody'] = (string)$response->getBody();
+        }
+
+        $this->logErrorWithContext($taskContext, implode('; ', $errors), $context);
+
+        unset($errors['parse']);
+        return \common_report_Report::createFailure(implode(PHP_EOL, $errors));
+    }
+
+    /**
+     * Get exception message, append UserMessage if exception is common_exception_ClientException
+     * @param \Exception|\common_exception_ClientException $exception
+     * @param bool $includeSourceInfo Add information about file, line and exception type
+     * @return string|null
+     */
+    private function getExceptionMessage(\Exception $exception, $includeSourceInfo = false) {
+        $messages = [];
+        if ($includeSourceInfo) {
+            $messages[] = sprintf(
+                '%s in %s:%d',
+                get_class($exception),
+                $exception->getFile(),
+                $exception->getLine()
+            );
+        }
+        if ($exception->getMessage() !== null) {
+            $messages[] = $exception->getMessage();
+        }
+        if ($exception instanceof \common_exception_ClientException) {
+            $messages[] = 'User message: ' . $exception->getUserMessage();
+        }
+        if (count($messages) > 0) {
+            return implode('. ', $messages);
+        }
+        return null;
+    }
+
+    /**
+     * @param WebhookTaskContext $taskContext
+     * @return string
+     */
+    private function getEventId(WebhookTaskContext $taskContext) {
+        $taskParams = $taskContext->getWebhookTaskParams();
+        if (!$taskParams) {
+            throw new \InvalidArgumentException("Task context doesn't contain task params");
+        }
+        return $taskParams->getEventId();
+    }
+
+    /**
+     * @return WebhookEventLogInterface
+     */
+    private function getWebhookEventLog()
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $this->getServiceLocator()->get(WebhookEventLogInterface::SERVICE_ID);
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1228,6 +1228,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('38.11.1');
         }
 
-        $this->skip('38.11.1', '39.0.2');
+        $this->skip('38.11.1', '39.0.3');
     }
 }

--- a/test/unit/webhooks/task/WebhookTaskReportsTest.php
+++ b/test/unit/webhooks/task/WebhookTaskReportsTest.php
@@ -1,0 +1,430 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\test\unit\webhooks\task;
+
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use oat\generis\test\TestCase;
+use oat\tao\model\webhooks\log\WebhookEventLogInterface;
+use oat\tao\model\webhooks\task\WebhookResponse;
+use oat\tao\model\webhooks\task\WebhookTaskContext;
+use oat\tao\model\webhooks\task\WebhookTaskParams;
+use oat\tao\model\webhooks\task\WebhookTaskReports;
+use Psr\Log\LoggerInterface;
+
+class WebhookTaskReportsTest extends TestCase
+{
+    /**
+     * @var WebhookEventLogInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $webhookEventLogMock;
+
+    /**
+     * @var LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $loggerMock;
+
+    public function setUp()
+    {
+        $this->webhookEventLogMock = $this->createMock(WebhookEventLogInterface::class);
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+    }
+
+    public function testReportInternalException()
+    {
+        $reports = new WebhookTaskReports();
+        $reports->setServiceLocator($this->getServiceLocatorMock([
+            WebhookEventLogInterface::SERVICE_ID => $this->webhookEventLogMock,
+        ]));
+        $reports->setLogger($this->loggerMock);
+
+        /** @var WebhookTaskParams|\PHPUnit_Framework_MockObject_MockObject $taskParamsMock */
+        $taskParamsMock = $this->createMock(WebhookTaskParams::class);
+        $taskParamsMock->method('getEventId')->willReturn('eventId');
+
+        /** @var WebhookTaskContext|\PHPUnit_Framework_MockObject_MockObject $taskContextMock */
+        $taskContextMock = $this->createMock(WebhookTaskContext::class);
+        $taskContextMock->method('getTaskId')->willReturn('taskId');
+        $taskContextMock->method('getWebhookTaskParams')->willReturn($taskParamsMock);
+
+        $exception = new \Exception('e_msg');
+
+        $this->webhookEventLogMock->expects($this->once())
+            ->method('storeInternalErrorLog')
+            ->with(
+                $taskContextMock,
+                $this->callback(function ($message) {
+                    return strpos($message, 'e_msg') !== false &&
+                        strpos($message, 'Exception') !== false;
+                }));
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->callback(function ($message) {
+                    return strpos($message, 'e_msg') !== false &&
+                        strpos($message, 'Exception') !== false &&
+                        strpos($message, __FILE__) !== false;
+                }),
+                $this->callback(function ($context) {
+                    return $context['taskId'] === 'taskId' &&
+                        $context['eventId'] === 'eventId';
+                })
+            );
+
+        $report = $reports->reportInternalException($taskContextMock, $exception);
+
+        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertContains('e_msg', $report->getMessage());
+        $this->assertContains('Exception', $report->getMessage());
+        $this->assertContains(__FILE__, $report->getMessage());
+    }
+
+    public function testReportConnectException()
+    {
+        $reports = new WebhookTaskReports();
+        $reports->setServiceLocator($this->getServiceLocatorMock([
+            WebhookEventLogInterface::SERVICE_ID => $this->webhookEventLogMock,
+        ]));
+        $reports->setLogger($this->loggerMock);
+
+        /** @var WebhookTaskParams|\PHPUnit_Framework_MockObject_MockObject $taskParamsMock */
+        $taskParamsMock = $this->createMock(WebhookTaskParams::class);
+        $taskParamsMock->method('getEventId')->willReturn('eventId');
+
+        /** @var WebhookTaskContext|\PHPUnit_Framework_MockObject_MockObject $taskContextMock */
+        $taskContextMock = $this->createMock(WebhookTaskContext::class);
+        $taskContextMock->method('getTaskId')->willReturn('taskId');
+        $taskContextMock->method('getWebhookTaskParams')->willReturn($taskParamsMock);
+
+        $exception = new ConnectException('e_msg', new Request('POST', 'uru'));
+
+        $this->webhookEventLogMock->expects($this->once())
+            ->method('storeNetworkErrorLog')
+            ->with($taskContextMock, 'e_msg');
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->callback(function ($message) {
+                    return strpos($message, 'e_msg') !== false;
+                }),
+                $this->callback(function ($context) {
+                    return $context['taskId'] === 'taskId' &&
+                        $context['eventId'] === 'eventId';
+                })
+            );
+
+        $report = $reports->reportConnectException($taskContextMock, $exception);
+        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertContains('e_msg', $report->getMessage());
+    }
+
+    public function testRequestExceptionWithResponse()
+    {
+        $reports = new WebhookTaskReports();
+        $reports->setServiceLocator($this->getServiceLocatorMock([
+            WebhookEventLogInterface::SERVICE_ID => $this->webhookEventLogMock,
+        ]));
+        $reports->setLogger($this->loggerMock);
+
+        /** @var WebhookTaskParams|\PHPUnit_Framework_MockObject_MockObject $taskParamsMock */
+        $taskParamsMock = $this->createMock(WebhookTaskParams::class);
+        $taskParamsMock->method('getEventId')->willReturn('eventId');
+
+        /** @var WebhookTaskContext|\PHPUnit_Framework_MockObject_MockObject $taskContextMock */
+        $taskContextMock = $this->createMock(WebhookTaskContext::class);
+        $taskContextMock->method('getTaskId')->willReturn('taskId');
+        $taskContextMock->method('getWebhookTaskParams')->willReturn($taskParamsMock);
+
+        $exception = new RequestException(
+            'e_msg',
+            new Request('POST', 'uru'),
+            new Response(400, [], 'resp_body')
+        );
+
+        $this->webhookEventLogMock->expects($this->once())
+            ->method('storeInvalidHttpStatusLog')
+            ->with($taskContextMock, 400, 'resp_body');
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->callback(function ($message) {
+                    return strpos($message, 'e_msg') !== false;
+                }),
+                $this->callback(function ($context) {
+                    return $context['taskId'] === 'taskId' &&
+                        $context['eventId'] === 'eventId' &&
+                        $context['httpStatus'] === 400 &&
+                        $context['responseBody'] === 'resp_body';
+                })
+            );
+
+        $report = $reports->reportRequestException($taskContextMock, $exception);
+        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertContains('e_msg', $report->getMessage());
+    }
+
+    public function testRequestExceptionWithoutResponse()
+    {
+        $reports = new WebhookTaskReports();
+        $reports->setServiceLocator($this->getServiceLocatorMock([
+            WebhookEventLogInterface::SERVICE_ID => $this->webhookEventLogMock,
+        ]));
+        $reports->setLogger($this->loggerMock);
+
+        /** @var WebhookTaskParams|\PHPUnit_Framework_MockObject_MockObject $taskParamsMock */
+        $taskParamsMock = $this->createMock(WebhookTaskParams::class);
+        $taskParamsMock->method('getEventId')->willReturn('eventId');
+
+        /** @var WebhookTaskContext|\PHPUnit_Framework_MockObject_MockObject $taskContextMock */
+        $taskContextMock = $this->createMock(WebhookTaskContext::class);
+        $taskContextMock->method('getTaskId')->willReturn('taskId');
+        $taskContextMock->method('getWebhookTaskParams')->willReturn($taskParamsMock);
+
+        $exception = new RequestException('e_msg', new Request('POST', 'uru'), null);
+
+        $this->webhookEventLogMock->expects($this->once())
+            ->method('storeNetworkErrorLog')
+            ->with($taskContextMock, 'e_msg');
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->callback(function ($message) {
+                    return strpos($message, 'e_msg') !== false;
+                }),
+                $this->callback(function ($context) {
+                    return $context['taskId'] === 'taskId' &&
+                        $context['eventId'] === 'eventId';
+                })
+            );
+
+        $report = $reports->reportRequestException($taskContextMock, $exception);
+        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertContains('e_msg', $report->getMessage());
+    }
+
+    public function testReportBadResponseException()
+    {
+        $reports = new WebhookTaskReports();
+        $reports->setServiceLocator($this->getServiceLocatorMock([
+            WebhookEventLogInterface::SERVICE_ID => $this->webhookEventLogMock,
+        ]));
+        $reports->setLogger($this->loggerMock);
+
+        /** @var WebhookTaskParams|\PHPUnit_Framework_MockObject_MockObject $taskParamsMock */
+        $taskParamsMock = $this->createMock(WebhookTaskParams::class);
+        $taskParamsMock->method('getEventId')->willReturn('eventId');
+
+        /** @var WebhookTaskContext|\PHPUnit_Framework_MockObject_MockObject $taskContextMock */
+        $taskContextMock = $this->createMock(WebhookTaskContext::class);
+        $taskContextMock->method('getTaskId')->willReturn('taskId');
+        $taskContextMock->method('getWebhookTaskParams')->willReturn($taskParamsMock);
+
+        $exception = new BadResponseException(
+            'e_msg',
+            new Request('POST', 'uru'),
+            new Response(403, [], 'resp_body')
+        );
+
+        $this->webhookEventLogMock->expects($this->once())
+            ->method('storeInvalidHttpStatusLog')
+            ->with($taskContextMock, 403);
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->callback(function ($message) {
+                    return strpos($message, 'e_msg') !== false;
+                }),
+                $this->callback(function ($context) {
+                    return $context['taskId'] === 'taskId' &&
+                        $context['eventId'] === 'eventId' &&
+                        $context['httpStatus'] === 403 &&
+                        $context['responseBody'] === 'resp_body';
+                })
+            );
+
+        $report = $reports->reportBadResponseException($taskContextMock, $exception);
+        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertContains('e_msg', $report->getMessage());
+    }
+
+    public function testReportInvalidStatusCode()
+    {
+        $reports = new WebhookTaskReports();
+        $reports->setServiceLocator($this->getServiceLocatorMock([
+            WebhookEventLogInterface::SERVICE_ID => $this->webhookEventLogMock,
+        ]));
+        $reports->setLogger($this->loggerMock);
+
+        /** @var WebhookTaskParams|\PHPUnit_Framework_MockObject_MockObject $taskParamsMock */
+        $taskParamsMock = $this->createMock(WebhookTaskParams::class);
+        $taskParamsMock->method('getEventId')->willReturn('eventId');
+
+        /** @var WebhookTaskContext|\PHPUnit_Framework_MockObject_MockObject $taskContextMock */
+        $taskContextMock = $this->createMock(WebhookTaskContext::class);
+        $taskContextMock->method('getTaskId')->willReturn('taskId');
+        $taskContextMock->method('getWebhookTaskParams')->willReturn($taskParamsMock);
+
+        $response = new Response(301, [], 'resp_body');
+
+        $this->webhookEventLogMock->expects($this->once())
+            ->method('storeInvalidHttpStatusLog')
+            ->with($taskContextMock, 301);
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->callback(function ($message) {
+                    return strpos($message, '301') !== false;
+                }),
+                $this->callback(function ($context) {
+                    return $context['taskId'] === 'taskId' &&
+                        $context['eventId'] === 'eventId' &&
+                        $context['httpStatus'] === 301 &&
+                        $context['responseBody'] === 'resp_body';
+                })
+            );
+
+        $report = $reports->reportInvalidStatusCode($taskContextMock, $response);
+        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertContains('301', $report->getMessage());
+    }
+
+    public function testReportInvalidBodyFormat()
+    {
+        $reports = new WebhookTaskReports();
+        $reports->setServiceLocator($this->getServiceLocatorMock([
+            WebhookEventLogInterface::SERVICE_ID => $this->webhookEventLogMock,
+        ]));
+        $reports->setLogger($this->loggerMock);
+
+        /** @var WebhookTaskParams|\PHPUnit_Framework_MockObject_MockObject $taskParamsMock */
+        $taskParamsMock = $this->createMock(WebhookTaskParams::class);
+        $taskParamsMock->method('getEventId')->willReturn('eventId');
+
+        /** @var WebhookTaskContext|\PHPUnit_Framework_MockObject_MockObject $taskContextMock */
+        $taskContextMock = $this->createMock(WebhookTaskContext::class);
+        $taskContextMock->method('getTaskId')->willReturn('taskId');
+        $taskContextMock->method('getWebhookTaskParams')->willReturn($taskParamsMock);
+
+        $response = new Response(200, [], 'resp_body');
+
+        $this->webhookEventLogMock->expects($this->once())
+            ->method('storeInvalidBodyFormat')
+            ->with($taskContextMock, 'resp_body');
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->callback(function ($message) {
+                    return strpos($message, 'eventId') !== false;
+                }),
+                $this->callback(function ($context) {
+                    return $context['taskId'] === 'taskId' &&
+                        $context['eventId'] === 'eventId' &&
+                        $context['httpStatus'] === 200 &&
+                        $context['responseBody'] === 'resp_body';
+                })
+            );
+
+        $report = $reports->reportInvalidBodyFormat($taskContextMock, $response);
+        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertContains('eventId', $report->getMessage());
+    }
+
+    public function testReportInvalidAcknowledgement()
+    {
+        $reports = new WebhookTaskReports();
+        $reports->setServiceLocator($this->getServiceLocatorMock([
+            WebhookEventLogInterface::SERVICE_ID => $this->webhookEventLogMock,
+        ]));
+        $reports->setLogger($this->loggerMock);
+
+        /** @var WebhookTaskParams|\PHPUnit_Framework_MockObject_MockObject $taskParamsMock */
+        $taskParamsMock = $this->createMock(WebhookTaskParams::class);
+        $taskParamsMock->method('getEventId')->willReturn('eventId');
+
+        /** @var WebhookTaskContext|\PHPUnit_Framework_MockObject_MockObject $taskContextMock */
+        $taskContextMock = $this->createMock(WebhookTaskContext::class);
+        $taskContextMock->method('getTaskId')->willReturn('taskId');
+        $taskContextMock->method('getWebhookTaskParams')->willReturn($taskParamsMock);
+
+        $response = new Response(200, [], 'resp_body');
+
+        $parsedResponse = new WebhookResponse(['eventId' => WebhookResponse::STATUS_ERROR], 'parseErr');
+
+        $this->webhookEventLogMock->expects($this->once())
+            ->method('storeInvalidAcknowledgementLog')
+            ->with($taskContextMock, WebhookResponse::STATUS_ERROR);
+
+        $this->loggerMock->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->callback(function ($message) {
+                    return strpos($message, 'parseErr') !== false &&
+                        strpos($message, 'eventId') !== false &&
+                        strpos($message, 'error') !== false;
+                }),
+                $this->callback(function ($context) {
+                    return $context['taskId'] === 'taskId' &&
+                        $context['eventId'] === 'eventId';
+                })
+            );
+
+        $report = $reports->reportInvalidAcknowledgement($taskContextMock, $response, $parsedResponse);
+        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertContains('eventId', $report->getMessage());
+        $this->assertContains('error', $report->getMessage());
+    }
+
+    public function testReportSuccess()
+    {
+        $reports = new WebhookTaskReports();
+        $reports->setServiceLocator($this->getServiceLocatorMock([
+            WebhookEventLogInterface::SERVICE_ID => $this->webhookEventLogMock,
+        ]));
+        $reports->setLogger($this->loggerMock);
+
+        /** @var WebhookTaskParams|\PHPUnit_Framework_MockObject_MockObject $taskParamsMock */
+        $taskParamsMock = $this->createMock(WebhookTaskParams::class);
+        $taskParamsMock->method('getEventId')->willReturn('eventId');
+
+        /** @var WebhookTaskContext|\PHPUnit_Framework_MockObject_MockObject $taskContextMock */
+        $taskContextMock = $this->createMock(WebhookTaskContext::class);
+        $taskContextMock->method('getTaskId')->willReturn('taskId');
+        $taskContextMock->method('getWebhookTaskParams')->willReturn($taskParamsMock);
+
+        $response = new Response(200, [], 'resp_body');
+
+        $this->webhookEventLogMock->expects($this->once())
+            ->method('storeSuccessfulLog')
+            ->with($taskContextMock, 'resp_body', WebhookResponse::STATUS_ACCEPTED);
+
+        $report = $reports->reportSuccess($taskContextMock, $response, WebhookResponse::STATUS_ACCEPTED);
+        $this->assertSame(\common_report_Report::TYPE_SUCCESS, $report->getType());
+    }
+}

--- a/test/unit/webhooks/task/WebhookTaskTest.php
+++ b/test/unit/webhooks/task/WebhookTaskTest.php
@@ -38,8 +38,10 @@ use oat\tao\model\webhooks\task\WebhookResponse;
 use oat\tao\model\webhooks\task\WebhookResponseFactoryInterface;
 use oat\tao\model\webhooks\task\WebhookSender;
 use oat\tao\model\webhooks\task\WebhookTask;
+use oat\tao\model\webhooks\task\WebhookTaskContext;
 use oat\tao\model\webhooks\task\WebhookTaskParams;
 use oat\tao\model\webhooks\task\WebhookTaskParamsFactory;
+use oat\tao\model\webhooks\task\WebhookTaskReports;
 use oat\tao\model\webhooks\WebhookRegistryInterface;
 use oat\tao\model\webhooks\WebhookTaskServiceInterface;
 use PHPUnit_Framework_MockObject_MockObject;
@@ -49,7 +51,6 @@ use Psr\Log\LoggerInterface;
 
 class WebhookTaskTest extends TestCase
 {
-
     private $serviceLocatorMock;
 
     /**
@@ -113,10 +114,14 @@ class WebhookTaskTest extends TestCase
     private $webhookLogServiceMock;
 
     /**
-     * @var ResponseInterface
+     * @var ResponseInterface | PHPUnit_Framework_MockObject_MockObject
      */
     private $responseMock;
 
+    /**
+     * @var WebhookTaskReports | PHPUnit_Framework_MockObject_MockObject
+     */
+    private $webhookTaskReports;
 
     public function setUp()
     {
@@ -128,8 +133,10 @@ class WebhookTaskTest extends TestCase
         $this->webhookTaskServiceMock = $this->createMock(WebhookTaskServiceInterface::class);
         $this->logerMock = $this->createMock(LoggerService::class);
         $this->webhookLogServiceMock = $this->createMock(WebhookEventLogInterface::class);
+        $this->webhookTaskReports = $this->createMock(WebhookTaskReports::class);
 
         $this->serviceLocatorMock = $this->getServiceLocatorMock([
+            WebhookTaskReports::class => $this->webhookTaskReports,
             WebhookRegistryInterface::SERVICE_ID => $this->webhookRegistryMock,
             WebhookPayloadFactoryInterface::SERVICE_ID => $this->webhookPayloadFactoryInterfaceMock,
             WebhookTaskParamsFactory::class => $this->webhookTaskParamsFactoryMock,
@@ -166,7 +173,18 @@ class WebhookTaskTest extends TestCase
         $this->webhookTaskParamsMock->expects($this->once())->method('increaseRetryCount');
         $this->webhookTaskServiceMock->expects($this->once())->method('createTask');
 
-        $this->webhookLogServiceMock->expects($this->once())->method('storeInvalidHttpStatusLog');
+        $report = \common_report_Report::createFailure('rep_msg');
+        $this->webhookTaskReports->expects($this->once())
+            ->method('reportInvalidStatusCode')
+            ->with(
+                $this->callback(function (WebhookTaskContext $context) {
+                    return 'someId' === $context->getTaskId() &&
+                        $this->webhookTaskParamsMock === $context->getWebhookTaskParams() &&
+                        $this->webhookConfigMock === $context->getWebhookConfig();
+                }),
+                $this->responseMock
+            )
+            ->willReturn($report);
 
         $paramArray = [];
         $webhookTask = new WebhookTask();
@@ -174,8 +192,7 @@ class WebhookTaskTest extends TestCase
         $webhookTask->setServiceLocator($this->serviceLocatorMock);
         /* @noinspection PhpUnhandledExceptionInspection */
         $result = $webhookTask($paramArray);
-        $this->assertInstanceOf(\common_report_Report::class, $result);
-        $this->assertSame('error', $result->getType());
+        $this->assertSame($report, $result);
     }
 
     public function testInvokeRetryMechanismConnectionException()
@@ -191,9 +208,10 @@ class WebhookTaskTest extends TestCase
         $this->webhookPayloadFactoryInterfaceMock->method('getContentType')->willReturn('html/php');
         $this->webhookResponseFactoryInterfaceMock->method('getAcceptedContentType')->willReturn('*');
         $this->requestMock = $this->createMock(RequestInterface::class);
+        $connectException = new ConnectException('timeout', $this->requestMock);
         $this->webhookSenderMock
             ->method('performRequest')
-            ->willThrowException(new ConnectException('timeout', $this->requestMock));
+            ->willThrowException($connectException);
         $this->webhookTaskParamsMock->method('isMaxRetryCountReached')->willReturn(false);
         $this->webhookResponseMock = $this->createMock(WebhookResponse::class);
         $this->webhookResponseFactoryInterfaceMock->method('create')->willReturn($this->webhookResponseMock);
@@ -201,7 +219,18 @@ class WebhookTaskTest extends TestCase
         $this->webhookTaskParamsMock->expects($this->once())->method('increaseRetryCount');
         $this->webhookTaskServiceMock->expects($this->once())->method('createTask');
 
-        $this->webhookLogServiceMock->expects($this->once())->method('storeNetworkErrorLog');
+        $report = \common_report_Report::createFailure('rep_msg');
+        $this->webhookTaskReports->expects($this->once())
+            ->method('reportConnectException')
+            ->with(
+                $this->callback(function (WebhookTaskContext $context) {
+                    return 'someId' === $context->getTaskId() &&
+                        $this->webhookTaskParamsMock === $context->getWebhookTaskParams() &&
+                        $this->webhookConfigMock === $context->getWebhookConfig();
+                }),
+                $connectException
+            )
+            ->willReturn($report);
 
         $paramArray = [];
         $webhookTask = new WebhookTask();
@@ -209,8 +238,7 @@ class WebhookTaskTest extends TestCase
         $webhookTask->setServiceLocator($this->serviceLocatorMock);
         /* @noinspection PhpUnhandledExceptionInspection */
         $result = $webhookTask($paramArray);
-        $this->assertInstanceOf(\common_report_Report::class, $result);
-        $this->assertSame('error', $result->getType());
+        $this->assertSame($report, $result);
     }
 
     /**
@@ -218,7 +246,7 @@ class WebhookTaskTest extends TestCase
      */
     public function testInvokeValid()
     {
-        $whConfig = new Webhook('wh1', 'http://myurl', 'HMETHOD', new WebhookAuth('authClass', []));
+        $whConfig = new Webhook('wh1', 'http://myurl', 'HMETHOD', 0, new WebhookAuth('authClass', []));
         $webhookRegistry = $this->createWebhookRegistryMock(
             ['Test\Event' => ['wh1']],
             [
@@ -228,13 +256,14 @@ class WebhookTaskTest extends TestCase
 
         $payloadFactory = $this->createWebhookPayloadFactoryMock('payloadCT', 'pay-load');
 
-        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock(new WebhookTaskParams([
+        $taskParams = new WebhookTaskParams([
             WebhookTaskParams::EVENT_NAME => 'eventName',
             WebhookTaskParams::EVENT_ID => 'eventId',
             WebhookTaskParams::TRIGGERED_TIMESTAMP => 1234565,
             WebhookTaskParams::EVENT_DATA => ['d' => 4],
             WebhookTaskParams::WEBHOOK_CONFIG_ID => 'wh1'
-        ]));
+        ]);
+        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock($taskParams);
 
         $webhookResponse = new WebhookResponse(['eventId' => 'accepted']);
         $webhookResponseFactory = $this->createWebhookResponseFactory('accCT', $webhookResponse);
@@ -251,7 +280,7 @@ class WebhookTaskTest extends TestCase
             WebhookTaskParamsFactory::class => $taskParamsFactory,
             WebhookResponseFactoryInterface::SERVICE_ID => $webhookResponseFactory,
             WebhookSender::class => $webhookSender,
-            WebhookEventLogInterface::SERVICE_ID => $this->webhookLogServiceMock,
+            WebhookTaskReports::class => $this->webhookTaskReports
         ]));
         $task->setTask($queueTask);
 
@@ -268,12 +297,23 @@ class WebhookTaskTest extends TestCase
                 return $auth === $whConfig->getAuth();
             })
         );
-        $this->webhookLogServiceMock->expects($this->once())->method('storeSuccessfulLog');
+        $report = \common_report_Report::createSuccess('success_text');
+        $this->webhookTaskReports->expects($this->once())
+            ->method('reportSuccess')
+            ->with(
+                $this->callback(function (WebhookTaskContext $context) use ($taskParams, $whConfig) {
+                    return 'queueTaskId' === $context->getTaskId() &&
+                        $taskParams === $context->getWebhookTaskParams() &&
+                        $whConfig === $context->getWebhookConfig();
+                }),
+                $psrResponse,
+                'accepted'
+            )
+            ->willReturn($report);
 
-        $report = $task(['ppp']);
+        $result = $task(['ppp']);
 
-        $this->assertEmpty($report->getErrors());
-        $this->assertSame(\common_report_Report::TYPE_SUCCESS, $report->getType());
+        $this->assertSame($result, $report);
     }
 
     /**
@@ -286,16 +326,16 @@ class WebhookTaskTest extends TestCase
             []
         );
 
-        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock(new WebhookTaskParams([
+        $taskParams = new WebhookTaskParams([
             WebhookTaskParams::EVENT_NAME => 'eventName',
             WebhookTaskParams::EVENT_ID => 'eventId',
             WebhookTaskParams::TRIGGERED_TIMESTAMP => 1234565,
             WebhookTaskParams::EVENT_DATA => ['d' => 4],
             WebhookTaskParams::WEBHOOK_CONFIG_ID => 'wh1'
-        ]));
+        ]);
+        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock($taskParams);
 
         $queueTask = $this->createTaskMock('queueTaskId');
-        $loggerMock = $this->createLoggerMock();
 
         $task = new WebhookTask();
 
@@ -303,17 +343,29 @@ class WebhookTaskTest extends TestCase
             WebhookRegistryInterface::SERVICE_ID => $webhookRegistry,
             WebhookTaskParamsFactory::class => $taskParamsFactory,
             WebhookEventLogInterface::SERVICE_ID => $this->webhookLogServiceMock,
+            WebhookTaskReports::class => $this->webhookTaskReports
         ]));
         $task->setTask($queueTask);
-        $task->setLogger($loggerMock);
 
         $taskParamsFactory->method('createFromArray')->with(['ppp']);
-        $loggerMock->expects($this->once())->method('error');
-        $this->webhookLogServiceMock->expects($this->once())->method('storeInternalErrorLog');
+        $report = \common_report_Report::createFailure('failure_text');
+        $this->webhookTaskReports->expects($this->once())
+            ->method('reportInternalException')
+            ->with(
+                $this->callback(function (WebhookTaskContext $context) use ($taskParams) {
+                    return 'queueTaskId' === $context->getTaskId() &&
+                        $taskParams === $context->getWebhookTaskParams() &&
+                        null === $context->getWebhookConfig();
+                }),
+                $this->callback(function (\Exception $exception) {
+                    return $exception instanceof \common_exception_NotFound;
+                })
+            )
+            ->willReturn($report);
 
-        $report = $task(['ppp']);
+        $result = $task(['ppp']);
 
-        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertSame($report, $result);
     }
 
     /**
@@ -321,7 +373,7 @@ class WebhookTaskTest extends TestCase
      */
     public function testEventNotDelivered()
     {
-        $whConfig = new Webhook('wh1', 'http://myurl', 'HMETHOD', new WebhookAuth('authClass', []));
+        $whConfig = new Webhook('wh1', 'http://myurl', 'HMETHOD', 0, new WebhookAuth('authClass', []));
         $webhookRegistry = $this->createWebhookRegistryMock(
             ['Test\Event' => ['wh1']],
             [
@@ -331,13 +383,14 @@ class WebhookTaskTest extends TestCase
 
         $payloadFactory = $this->createWebhookPayloadFactoryMock('payloadCT', 'pay-load');
 
-        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock(new WebhookTaskParams([
+        $taskParams = new WebhookTaskParams([
             WebhookTaskParams::EVENT_NAME => 'eventName',
             WebhookTaskParams::EVENT_ID => 'eventId',
             WebhookTaskParams::TRIGGERED_TIMESTAMP => 1234565,
             WebhookTaskParams::EVENT_DATA => ['d' => 4],
             WebhookTaskParams::WEBHOOK_CONFIG_ID => 'wh1'
-        ]));
+        ]);
+        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock($taskParams);
 
         $webhookResponse = new WebhookResponse(['eventId' => 'error']);
         $webhookResponseFactory = $this->createWebhookResponseFactory('accCT', $webhookResponse);
@@ -345,7 +398,6 @@ class WebhookTaskTest extends TestCase
         $psrResponse = new Response(200, ['Content-Type' => 'accCT'], 'resp_body');
         $webhookSender = $this->createWebhookSenderMock($psrResponse);
         $queueTask = $this->createTaskMock('queueTaskId');
-        $loggerMock = $this->createLoggerMock();
 
         $task = new WebhookTask();
 
@@ -355,16 +407,26 @@ class WebhookTaskTest extends TestCase
             WebhookTaskParamsFactory::class => $taskParamsFactory,
             WebhookResponseFactoryInterface::SERVICE_ID => $webhookResponseFactory,
             WebhookSender::class => $webhookSender,
-            WebhookEventLogInterface::SERVICE_ID => $this->webhookLogServiceMock,
+            WebhookTaskReports::class => $this->webhookTaskReports
         ]));
         $task->setTask($queueTask);
-        $task->setLogger($loggerMock);
-        $loggerMock->expects($this->once())->method('error');
-        $this->webhookLogServiceMock->expects($this->once())->method('storeInvalidAcknowledgementLog');
+        $report = \common_report_Report::createFailure('failure_text');
+        $this->webhookTaskReports->expects($this->once())
+            ->method('reportInvalidAcknowledgement')
+            ->with(
+                $this->callback(function (WebhookTaskContext $context) use ($whConfig, $taskParams) {
+                    return 'queueTaskId' === $context->getTaskId() &&
+                        $taskParams === $context->getWebhookTaskParams() &&
+                        $whConfig === $context->getWebhookConfig();
+                }),
+                $psrResponse,
+                $webhookResponse
+            )
+            ->willReturn($report);
 
-        $report = $task(['ppp']);
+        $result = $task(['ppp']);
 
-        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertSame($report, $result);
     }
 
     /**
@@ -382,13 +444,14 @@ class WebhookTaskTest extends TestCase
 
         $payloadFactory = $this->createWebhookPayloadFactoryMock('payloadCT', 'pay-load');
 
-        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock(new WebhookTaskParams([
+        $taskParams = new WebhookTaskParams([
             WebhookTaskParams::EVENT_NAME => 'eventName',
             WebhookTaskParams::EVENT_ID => 'eventId',
             WebhookTaskParams::TRIGGERED_TIMESTAMP => 1234565,
             WebhookTaskParams::EVENT_DATA => ['d' => 4],
             WebhookTaskParams::WEBHOOK_CONFIG_ID => 'wh1'
-        ]));
+        ]);
+        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock($taskParams);
 
         $webhookResponse = new WebhookResponse([], 'parseError');
         $webhookResponseFactory = $this->createWebhookResponseFactory('accCT', $webhookResponse);
@@ -396,7 +459,6 @@ class WebhookTaskTest extends TestCase
         $psrResponse = new Response(200, ['Content-Type' => 'WRONG_CC'], 'resp_body');
         $webhookSender = $this->createWebhookSenderMock($psrResponse);
         $queueTask = $this->createTaskMock('queueTaskId');
-        $loggerMock = $this->createLoggerMock();
 
         $task = new WebhookTask();
 
@@ -406,17 +468,26 @@ class WebhookTaskTest extends TestCase
             WebhookTaskParamsFactory::class => $taskParamsFactory,
             WebhookResponseFactoryInterface::SERVICE_ID => $webhookResponseFactory,
             WebhookSender::class => $webhookSender,
-            WebhookEventLogInterface::SERVICE_ID => $this->webhookLogServiceMock,
+            WebhookTaskReports::class => $this->webhookTaskReports
         ]));
         $task->setTask($queueTask);
-        $task->setLogger($loggerMock);
-        $loggerMock->expects($this->once())->method('error');
 
-        $this->webhookLogServiceMock->expects($this->once())->method('storeInvalidBodyFormat');
+        $report = \common_report_Report::createFailure('failure_text');
+        $this->webhookTaskReports->expects($this->once())
+            ->method('reportInvalidBodyFormat')
+            ->with(
+                $this->callback(function (WebhookTaskContext $context) use ($whConfig, $taskParams) {
+                    return 'queueTaskId' === $context->getTaskId() &&
+                        $taskParams === $context->getWebhookTaskParams() &&
+                        $whConfig === $context->getWebhookConfig();
+                }),
+                $psrResponse
+            )
+            ->willReturn($report);
 
-        $report = $task(['ppp']);
+        $result = $task(['ppp']);
 
-        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertSame($report, $result);
     }
 
     /**
@@ -435,7 +506,7 @@ class WebhookTaskTest extends TestCase
 
         $payloadFactory = $this->createWebhookPayloadFactoryMock('payloadCT', 'pay-load');
 
-        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock(new WebhookTaskParams([
+        $taskParams = new WebhookTaskParams([
             WebhookTaskParams::EVENT_NAME => 'eventName',
             WebhookTaskParams::EVENT_ID => 'eventId',
             WebhookTaskParams::TRIGGERED_TIMESTAMP => 1234565,
@@ -443,18 +514,19 @@ class WebhookTaskTest extends TestCase
             WebhookTaskParams::WEBHOOK_CONFIG_ID => 'wh1',
             WebhookTaskParams::RETRY_COUNT => 0,
             WebhookTaskParams::RETRY_MAX => 1,
-        ]));
+        ]);
+        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock($taskParams);
 
         $webhookResponse = new WebhookResponse([], 'parseError');
         $webhookResponseFactory = $this->createWebhookResponseFactory('accCT', $webhookResponse);
 
-        $webhookSender = $this->createWebhookSenderMock(null, new ServerException(
+        $serverException = new ServerException(
             's_exc_m',
             new Request('POST', 'http://myurl'),
             new Response(500)
-        ));
+        );
+        $webhookSender = $this->createWebhookSenderMock(null, $serverException);
         $queueTask = $this->createTaskMock('queueTaskId');
-        $loggerMock = $this->createLoggerMock();
 
         $task = new WebhookTask();
 
@@ -465,18 +537,27 @@ class WebhookTaskTest extends TestCase
             WebhookTaskServiceInterface::SERVICE_ID => $this->webhookTaskServiceMock,
             WebhookResponseFactoryInterface::SERVICE_ID => $webhookResponseFactory,
             WebhookSender::class => $webhookSender,
-            WebhookEventLogInterface::SERVICE_ID => $this->webhookLogServiceMock,
+            WebhookTaskReports::class => $this->webhookTaskReports
         ]));
         $task->setTask($queueTask);
-        $task->setLogger($loggerMock);
-        $loggerMock->expects($this->once())->method('error');
-
-        $this->webhookLogServiceMock->expects($this->once())->method('storeInvalidHttpStatusLog');
         $this->webhookTaskServiceMock->expects($this->once())->method('createTask');
 
-        $report = $task(['ppp']);
+        $report = \common_report_Report::createFailure('failure_text');
+        $this->webhookTaskReports->expects($this->once())
+            ->method('reportBadResponseException')
+            ->with(
+                $this->callback(function (WebhookTaskContext $context) use ($whConfig, $taskParams) {
+                    return 'queueTaskId' === $context->getTaskId() &&
+                        $taskParams === $context->getWebhookTaskParams() &&
+                        $whConfig === $context->getWebhookConfig();
+                }),
+                $serverException
+            )
+            ->willReturn($report);
 
-        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $result = $task(['ppp']);
+
+        $this->assertSame($report, $result);
     }
 
     /**
@@ -495,7 +576,7 @@ class WebhookTaskTest extends TestCase
 
         $payloadFactory = $this->createWebhookPayloadFactoryMock('payloadCT', 'pay-load');
 
-        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock(new WebhookTaskParams([
+        $taskParams = new WebhookTaskParams([
             WebhookTaskParams::EVENT_NAME => 'eventName',
             WebhookTaskParams::EVENT_ID => 'eventId',
             WebhookTaskParams::TRIGGERED_TIMESTAMP => 1234565,
@@ -503,77 +584,19 @@ class WebhookTaskTest extends TestCase
             WebhookTaskParams::WEBHOOK_CONFIG_ID => 'wh1',
             WebhookTaskParams::RETRY_COUNT => 0,
             WebhookTaskParams::RETRY_MAX => 1,
-        ]));
+        ]);
+        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock($taskParams);
 
         $webhookResponse = new WebhookResponse([], 'parseError');
         $webhookResponseFactory = $this->createWebhookResponseFactory('accCT', $webhookResponse);
 
-        $webhookSender = $this->createWebhookSenderMock(null, new RequestException(
+        $requestException = new RequestException(
             's_exc_m',
             new Request('POST', 'http://myurl'),
             new Response(400)
-        ));
-        $queueTask = $this->createTaskMock('queueTaskId');
-        $loggerMock = $this->createLoggerMock();
-
-        $task = new WebhookTask();
-
-        $task->setServiceLocator($this->getServiceLocatorMock([
-            WebhookRegistryInterface::SERVICE_ID => $webhookRegistry,
-            WebhookPayloadFactoryInterface::SERVICE_ID => $payloadFactory,
-            WebhookTaskParamsFactory::class => $taskParamsFactory,
-            WebhookTaskServiceInterface::SERVICE_ID => $this->webhookTaskServiceMock,
-            WebhookResponseFactoryInterface::SERVICE_ID => $webhookResponseFactory,
-            WebhookSender::class => $webhookSender,
-            WebhookEventLogInterface::SERVICE_ID => $this->webhookLogServiceMock,
-        ]));
-        $task->setTask($queueTask);
-        $task->setLogger($loggerMock);
-        $loggerMock->expects($this->once())->method('error');
-
-        $this->webhookLogServiceMock->expects($this->once())->method('storeInvalidHttpStatusLog');
-
-        $report = $task(['ppp']);
-
-        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
-    }
-
-    /**
-     * @throws GuzzleException
-     */
-    public function testRequestExceptionNoResponse()
-    {
-        $this->webhookTaskParamsMock = $this->createMock(WebhookTaskParams::class);
-        $whConfig = new Webhook('wh1', 'http://myurl', 'HMETHOD', 1, new WebhookAuth('authClass', []));
-        $webhookRegistry = $this->createWebhookRegistryMock(
-            ['Test\Event' => ['wh1']],
-            [
-                'wh1' => $whConfig
-            ]
         );
-
-        $payloadFactory = $this->createWebhookPayloadFactoryMock('payloadCT', 'pay-load');
-
-        $taskParamsFactory = $this->createWebhookTaskParamsFactoryMock(new WebhookTaskParams([
-            WebhookTaskParams::EVENT_NAME => 'eventName',
-            WebhookTaskParams::EVENT_ID => 'eventId',
-            WebhookTaskParams::TRIGGERED_TIMESTAMP => 1234565,
-            WebhookTaskParams::EVENT_DATA => ['d' => 4],
-            WebhookTaskParams::WEBHOOK_CONFIG_ID => 'wh1',
-            WebhookTaskParams::RETRY_COUNT => 0,
-            WebhookTaskParams::RETRY_MAX => 1,
-        ]));
-
-        $webhookResponse = new WebhookResponse([], 'parseError');
-        $webhookResponseFactory = $this->createWebhookResponseFactory('accCT', $webhookResponse);
-
-        $webhookSender = $this->createWebhookSenderMock(null, new RequestException(
-            's_exc_m',
-            new Request('POST', 'http://myurl'),
-            null
-        ));
+        $webhookSender = $this->createWebhookSenderMock(null, $requestException);
         $queueTask = $this->createTaskMock('queueTaskId');
-        $loggerMock = $this->createLoggerMock();
 
         $task = new WebhookTask();
 
@@ -584,17 +607,26 @@ class WebhookTaskTest extends TestCase
             WebhookTaskServiceInterface::SERVICE_ID => $this->webhookTaskServiceMock,
             WebhookResponseFactoryInterface::SERVICE_ID => $webhookResponseFactory,
             WebhookSender::class => $webhookSender,
-            WebhookEventLogInterface::SERVICE_ID => $this->webhookLogServiceMock,
+            WebhookTaskReports::class => $this->webhookTaskReports
         ]));
         $task->setTask($queueTask);
-        $task->setLogger($loggerMock);
-        $loggerMock->expects($this->once())->method('error');
 
-        $this->webhookLogServiceMock->expects($this->once())->method('storeNetworkErrorLog');
+        $report = \common_report_Report::createFailure('failure_text');
+        $this->webhookTaskReports->expects($this->once())
+            ->method('reportRequestException')
+            ->with(
+                $this->callback(function (WebhookTaskContext $context) use ($whConfig, $taskParams) {
+                    return 'queueTaskId' === $context->getTaskId() &&
+                        $taskParams === $context->getWebhookTaskParams() &&
+                        $whConfig === $context->getWebhookConfig();
+                }),
+                $requestException
+            )
+            ->willReturn($report);
 
-        $report = $task(['ppp']);
+        $result = $task(['ppp']);
 
-        $this->assertSame(\common_report_Report::TYPE_ERROR, $report->getType());
+        $this->assertSame($report, $result);
     }
 
     /**


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-9282

During testing of salesforce authorization I noticed our log messages not always informative enough.

`OAuth2AuthType` for example, throws guzzle's `RequestException` which isn't properly handled in `WebhookTask`. Also it throws `common_exception_ValidationFailed` without message (while `getUserMessage()` has one)

After CodeClimate complaints (methods count exceeded) I had to split WebhooksTask class and I extracted logging and reporting logic to separate WebhookTaskReports class