### PR TITLE
Fix/grunt npm fixes

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -53,7 +53,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '39.0.2',
+    'version' => '39.0.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.3.2',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1228,6 +1228,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('38.11.1');
         }
 
-        $this->skip('38.11.1', '39.0.2');
+        $this->skip('38.11.1', '39.0.3');
     }
 }

--- a/views/build/grunt/lint.js
+++ b/views/build/grunt/lint.js
@@ -49,7 +49,8 @@ module.exports = function(grunt) {
         `!${extensionRoot}/views/js/portableLib/**/*.js`,
         `!${extensionRoot}/views/js/pciCreator/dev/**/*.js`,
         `!${extensionRoot}/views/js/picCreator/dev/**/*.js`,
-        `!${extensionRoot}/views/js/**/jquery.*.js`
+        `!${extensionRoot}/views/js/**/jquery.*.js`,
+        `!${extensionRoot}/views/js/e2e/**/*.js`
     ];
 
     grunt.config.merge({

--- a/views/build/package-lock.json
+++ b/views/build/package-lock.json
@@ -3729,13 +3729,30 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
-      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
+      "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^1.3.0",
-        "regexpp": "^2.0.1"
+        "eslint-utils": "^1.4.2",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+          "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-jsdoc": {

--- a/views/build/package.json
+++ b/views/build/package.json
@@ -18,7 +18,7 @@
     "@oat-sa/grunt-tao-bundle": "^0.3.1",
     "@oat-sa/tao-e2e-runner": "^0.3.0",
     "almond": "^0.3.3",
-    "eslint-plugin-es": "^1.4.0",
+    "eslint-plugin-es": "^2.0.0",
     "eslint-plugin-jsdoc": "^4.8.3",
     "get-port-sync": "^1.0.0",
     "grunt": "^1.0.4",


### PR DESCRIPTION
- Added exclude for `views/js/e2e` folder in linting tasks
- Upgraded root `eslint-plugin-es` as per security recommendations
- However, 1 critical vulnerability is still present due to third party libs:
`grunt-eslint@22.0.0` (latest) > `eslint@6.0.1` > `eslint-utils@1.3.1` (vulnerable)