### PR TITLE
Fix/tao 9303/default settings storage values

### DIFF
--- a/install/services/SetupSettingsStorage.php
+++ b/install/services/SetupSettingsStorage.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019  (original work) Open Assessment Technologies SA;
+ *
+ * @author Oleksandr Zagovorychev <zagovorichev@gmail.com>
+ */
+
+namespace oat\tao\install\services;
+
+
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\settings\CspHeaderSettingsInterface;
+use oat\tao\model\settings\SettingsStorageInterface;
+
+class SetupSettingsStorage extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $settingsStorageService = $this->getServiceLocator()->get(SettingsStorageInterface::SERVICE_ID);
+        $settingsStorageService->set(CspHeaderSettingsInterface::CSP_HEADER_SETTING, 'self');
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '39.0.5',
+    'version' => '39.0.6',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.3.2',

--- a/manifest.php
+++ b/manifest.php
@@ -21,6 +21,7 @@
  *
  */
 
+use oat\tao\install\services\SetupSettingsStorage;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\routing\ApiRoute;
 use oat\tao\model\routing\LegacyRoute;
@@ -124,6 +125,7 @@ return array(
             RegisterSignatureGenerator::class,
             SetDefaultCSPHeader::class,
             CreateWebhookEventLogTable::class,
+            SetupSettingsStorage::class,
         )
     ),
     'update' => 'oat\\tao\\scripts\\update\\Updater',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1228,6 +1228,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('38.11.1');
         }
 
-        $this->skip('38.11.1', '39.0.5');
+        $this->skip('38.11.1', '39.0.6');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-9303

reason
Default CSP_HEADER_SETTING is not provided, that's why we have an issue on the tao installation

solution
CSP_HEADER_SETTING = 'self' by default