### PR TITLE
TTD-18 missed extending.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '39.2.0',
+    'version' => '39.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1240,6 +1240,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             }
             $this->setVersion('39.1.0');
         }
-        $this->skip('39.1.0', '39.2.0');
+        $this->skip('39.1.0', '39.2.1');
     }
 }

--- a/test/unit/model/security/xsrf/TokenStoreKeyValueTest.php
+++ b/test/unit/model/security/xsrf/TokenStoreKeyValueTest.php
@@ -19,10 +19,10 @@
 
 namespace oat\tao\test\unit\model\security\xsrf;
 
+use oat\generis\test\TestCase;
 use oat\oatbox\session\SessionService;
 use oat\tao\model\security\xsrf\Token;
 use oat\tao\model\security\xsrf\TokenStoreKeyValue;
-use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use oat\generis\test\MockObject;
 

--- a/test/unit/model/security/xsrf/TokenTest.php
+++ b/test/unit/model/security/xsrf/TokenTest.php
@@ -19,7 +19,8 @@
 
 namespace oat\tao\test\unit\model\security\xsrf;
 
-use PHPUnit\Framework\TestCase;
+
+use oat\generis\test\TestCase;
 use oat\tao\model\security\xsrf\Token;
 
 /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.