### PR TITLE
Make the user-modifiable model id not hardcoded any more.

### DIFF
--- a/install/class.Installator.php
+++ b/install/class.Installator.php
@@ -246,6 +246,7 @@ class tao_install_Installator {
 			// Init model creator and create the Generis User.
             $this->log('d', 'Creating generis user..');
 			$modelCreator = new tao_install_utils_ModelCreator(LOCAL_NAMESPACE);
+            $modelCreator->setServiceLocator($this->getServiceManager());
 			$modelCreator->insertGenerisUser(helpers_Random::generateString(8));
 
 			/*

--- a/install/utils/class.ModelCreator.php
+++ b/install/utils/class.ModelCreator.php
@@ -20,6 +20,9 @@
  * 
  */
 
+use core_kernel_api_ModelFactory as ModelFactory;
+use \Zend\ServiceManager\ServiceLocatorAwareTrait;
+use \Zend\ServiceManager\ServiceLocatorAwareInterface;
 
 /**
  * The ModelCreator enables you to import Ontologies into a TAO module
@@ -29,8 +32,10 @@
  
  *
  */
-class tao_install_utils_ModelCreator{
-
+class tao_install_utils_ModelCreator implements ServiceLocatorAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+    
 	/**
 	 * @var string the module namesapce
 	 */
@@ -140,16 +145,15 @@ class tao_install_utils_ModelCreator{
 	 * @param string $model the XML data
 	 * @return boolean true if inserted
 	 */
-	public function insertModel($namespace, $model){
-
-		$returnValue = false;
+	public function insertModel($namespace, $model)
+    {
 		if(!preg_match("/#$/", $namespace)){
 			$namespace .= '#';
 		}
 
-		
-        $modFactory = new core_kernel_api_ModelFactory();
-        $returnValue = $modFactory->createModel($namespace, $model);
+        /** @var ModelFactory $modelFactory */
+        $modelFactory = $this->getServiceLocator()->get(ModelFactory::SERVICE_ID);
+        $returnValue = $modelFactory->createModel($namespace, $model);
                
 
         return $returnValue;

--- a/scripts/update/OntologyUpdater.php
+++ b/scripts/update/OntologyUpdater.php
@@ -35,7 +35,11 @@ class OntologyUpdater {
     
     static public function syncModels() {
         $currentModel = ModelManager::getModel();
-        $modelIds = array_diff($currentModel->getReadableModels(),array('1'));
+
+        // Excludes the writable model.
+        $modelFactory = new \core_kernel_api_ModelFactory();
+        $writableModelId = $modelFactory->getModelId(LOCAL_NAMESPACE);
+        $modelIds = array_diff($currentModel->getReadableModels(), [$writableModelId]);
         
         $persistence = common_persistence_SqlPersistence::getPersistence('default');
         


### PR DESCRIPTION
This PR requires https://github.com/oat-sa/generis/pull/636.
Make the user-modifiable model id not hard-coded any more.