### PR TITLE
NEX-487 - Error displayed after deleting a role, even though role is deleted

### DIFF
--- a/actions/class.Roles.php
+++ b/actions/class.Roles.php
@@ -148,9 +148,10 @@ class tao_actions_Roles extends tao_actions_RdfController
 
             // Gather users associated with the role.
             $userClass = $this->getClass(GenerisRdf::CLASS_GENERIS_USER);
-            $options = ['recursive' => true, 'like' => false];
-            $filters = [GenerisRdf::PROPERTY_USER_ROLES => $role->getUri()];
-            $users = $userClass->searchInstances($filters, $options);
+            $users = $userClass->searchInstances(
+                [GenerisRdf::PROPERTY_USER_ROLES => $role->getUri()],
+                ['recursive' => true, 'like' => false]
+            );
 
             if (!empty($users)) {
                 throw new UserErrorException(__('This role is still given to one or more users. Please remove the role to these users first.'));

--- a/actions/class.Roles.php
+++ b/actions/class.Roles.php
@@ -125,10 +125,10 @@ class tao_actions_Roles extends tao_actions_RdfController
     }
 
     /**
-     * Delete a group or a group class
+     * Delete a role.
+     *
      * @throws UserErrorException
      * @throws common_exception_BadRequest
-     * @throws common_exception_Error
      * @throws common_exception_MissingParameter
      * @return void
      */
@@ -136,31 +136,34 @@ class tao_actions_Roles extends tao_actions_RdfController
     {
         if (!$this->isXmlHttpRequest()) {
             throw new common_exception_BadRequest('wrong request mode');
-        } else {
-            $deleted = false;
-            if ($this->getRequestParameter('uri')) {
-                $role = $this->getCurrentInstance();
-
-                if (!in_array($role->getUri(), $this->forbidden)) {
-                    //check if no user is using this role:
-                    $userClass = $this->getClass(GenerisRdf::CLASS_GENERIS_USER);
-                    $options = array('recursive' => true, 'like' => false);
-                    $filters = array(GenerisRdf::PROPERTY_USER_ROLES => $role->getUri());
-                    $users = $userClass->searchInstances($filters, $options);
-                    if (empty($users)) {
-                        //delete role here:
-                        $deleted = $this->getClassService()->removeRole($role);
-                    } else {
-                        //set message error
-                        throw new UserErrorException(__('This role is still given to one or more users. Please remove the role to these users first.'));
-                    }
-                } else {
-                    throw new UserErrorException($role->getLabel() . ' could not be deleted');
-                }
-            }
-
-            $this->returnJson(array('deleted' => $deleted));
         }
+
+        $deleted = false;
+        if ($this->getRequestParameter('uri')) {
+            $role = $this->getCurrentInstance();
+
+            if (!in_array($role->getUri(), $this->forbidden)) {
+                //check if no user is using this role:
+                $userClass = $this->getClass(GenerisRdf::CLASS_GENERIS_USER);
+                $options = ['recursive' => true, 'like' => false];
+                $filters = [GenerisRdf::PROPERTY_USER_ROLES => $role->getUri()];
+                $users = $userClass->searchInstances($filters, $options);
+                if (empty($users)) {
+                    //delete role here:
+                    $deleted = $this->getClassService()->removeRole($role);
+                } else {
+                    //set message error
+                    throw new UserErrorException(__('This role is still given to one or more users. Please remove the role to these users first.'));
+                }
+            } else {
+                throw new UserErrorException($role->getLabel() . ' could not be deleted');
+            }
+        }
+
+        $this->returnJson([
+            'deleted' => $deleted,
+            'success' => $deleted
+        ]);
     }
 
     /**

--- a/actions/class.Roles.php
+++ b/actions/class.Roles.php
@@ -138,27 +138,32 @@ class tao_actions_Roles extends tao_actions_RdfController
             throw new common_exception_BadRequest('wrong request mode');
         }
 
-        $deleted = false;
-        if ($this->getRequestParameter('uri')) {
-            $role = $this->getCurrentInstance();
-
-            if (in_array($role->getUri(), $this->forbidden)) {
-                throw new UserErrorException($role->getLabel() . ' could not be deleted');
-            }
-
-            // Gather users associated with the role.
-            $userClass = $this->getClass(GenerisRdf::CLASS_GENERIS_USER);
-            $users = $userClass->searchInstances(
-                [GenerisRdf::PROPERTY_USER_ROLES => $role->getUri()],
-                ['recursive' => true, 'like' => false]
-            );
-
-            if (!empty($users)) {
-                throw new UserErrorException(__('This role is still given to one or more users. Please remove the role to these users first.'));
-            }
-
-            $deleted = $this->getClassService()->removeRole($role);
+        if (!$this->getRequestParameter('uri')) {
+            $this->returnJson([
+                'deleted' => false,
+                'success' => false
+            ]);
+            return;
         }
+
+        $role = $this->getCurrentInstance();
+
+        if (in_array($role->getUri(), $this->forbidden)) {
+            throw new UserErrorException($role->getLabel() . ' could not be deleted');
+        }
+
+        // Gather users associated with the role.
+        $userClass = $this->getClass(GenerisRdf::CLASS_GENERIS_USER);
+        $users = $userClass->searchInstances(
+            [GenerisRdf::PROPERTY_USER_ROLES => $role->getUri()],
+            ['recursive' => true, 'like' => false]
+        );
+
+        if (!empty($users)) {
+            throw new UserErrorException(__('This role is still given to one or more users. Please remove the role to these users first.'));
+        }
+
+        $deleted = $this->getClassService()->removeRole($role);
 
         $this->returnJson([
             'deleted' => $deleted,

--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '39.3.3',
+    'version' => '39.3.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1257,5 +1257,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             }
             $this->setVersion('39.3.3');
         }
+
+        $this->skip('39.3.3', '39.3.4');
     }
 }


### PR DESCRIPTION
The response missed the `success => true` parameter, which is used by the front-end to verify if the request was successful.