### PR TITLE
fix generation of file name of tao update log

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '39.3.5',
+    'version' => '39.3.6',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/models/classes/extension/UpdateLogger.php
+++ b/models/classes/extension/UpdateLogger.php
@@ -32,19 +32,19 @@ class UpdateLogger extends ConfigurableService implements LoggerInterface
     use LoggerTrait;
     
     const SERVICE_ID = 'tao/updatelog';
-    
     const OPTION_FILESYSTEM = 'filesystem';
-    
-    public function log($level, $message, array $context = array())
+
+    /**
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     */
+    public function log($level, $message, array $context = [])
     {
         $service = $this->getServiceLocator()->get(FileSystemService::SERVICE_ID);
         $filesystem = $service->getFileSystem($this->getOption(self::OPTION_FILESYSTEM));
         
-        $updateId = 'update_'.time();
-        while ($filesystem->has($updateId.'.log')) {
-            $count = isset($count) ? $count + 1 : 0;
-            $updateId = 'update_'.time().'_'.$count;
-        }
+        $updateId = uniqid('update_' . time() . '_', true);
         $filesystem->write($updateId.'.log', $message);
     }
     

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1258,6 +1258,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('39.3.3');
         }
 
-        $this->skip('39.3.3', '39.3.5');
+        $this->skip('39.3.3', '39.3.6');
     }
 }

--- a/test/integration/extension/UpdateLoggerTest.php
+++ b/test/integration/extension/UpdateLoggerTest.php
@@ -21,7 +21,6 @@
 use oat\tao\test\TaoPhpUnitTestRunner;
 use oat\tao\model\extension\UpdateLogger;
 use oat\oatbox\filesystem\Directory;
-use oat\oatbox\filesystem\FileSystemService;
 
 /**
  * @package tao
@@ -31,21 +30,21 @@ class UpdateLoggerTest extends TaoPhpUnitTestRunner
     public function testLog()
     {
         $tmpDir = $this->getTempDirectory();
-        $logger = new UpdateLogger(array(UpdateLogger::OPTION_FILESYSTEM => $tmpDir->getFileSystemId()));
+        $logger = new UpdateLogger([UpdateLogger::OPTION_FILESYSTEM => $tmpDir->getFileSystemId()]);
         $logger->setServiceLocator($tmpDir->getServiceLocator());
         
-        $files = array();
+        $files = [];
         foreach ($tmpDir->getIterator(Directory::ITERATOR_FILE) as $file) {
             $files[] = $file;
         }
-        $this->assertEquals(0, count($files));
+        $this->assertCount(0, $files);
         $logger->error('SampleError');
-        
-        $files = array();
+        $logger->error('SampleError 2');
+
         foreach ($tmpDir->getIterator(Directory::ITERATOR_FILE) as $file) {
             $files[] = $file;
         }
-        $this->assertEquals(1, count($files));
+        $this->assertCount(2, $files);
         $file = reset($files);
         
         $content = $file->read();


### PR DESCRIPTION
tao update script failed on one of ACT production environments, because it was configured to store log file in s3 storage.
During scaling of services several instances tried to create file with the same name:
```

{
    "severity": "ERROR",
    "tag": "tao",
    "message": "php error(1) in /var/www/html/tao/vendor/league/flysystem/src/Filesystem.php@405: Uncaught League\\Flysystem\\FileExistsException: File already exists at path: update_1572002737.log in /var/www/html/tao/vendor/league/flysystem/src/Filesystem.php:405\nStack trace:\n#0 /var/www/html/tao/vendor/league/flysystem/src/Filesystem.php(66): League\\Flysystem\\Filesystem->assertAbsent('update_15720027...')\n#1 /var/www/html/tao/generis/common/oatbox/filesystem/utils/FileSystemWrapperTrait.php(117): League\\Flysystem\\Filesystem->write('update_15720027...', 'Running extensi...', Array)\n#2 /var/www/html/tao/tao/models/classes/extension/UpdateLogger.php(48): oat\\oatbox\\filesystem\\FileSystem->write('update_15720027...', 'Running extensi...')\n#3 /var/www/html/tao/generis/common/oatbox/log/LoggerAggregator.php(69): oat\\tao\\model\\extension\\UpdateLogger->log('info', 'Running extensi...', Array)\n#4 /var/www/html/tao/vendor/psr/log/Psr/Log/LoggerTrait.php(114): oat\\oatbox\\log\\LoggerAggregator->log('info', 'Running extensi...', Array)\n#5 /var/www/html/tao/generis/common/oatbox/log/LoggerAwareTrait.php(105): oat\\oatbox\\",
    "code_file": "undefined",
    "code_line": "0",
    "instance_id": "i-0c1024515ae7bdeb7",
    "stack": "usact04dep",
    "host_type": "taocloud/ws/delivery"
}
```