### PR TITLE
prevent count warning on recent php>=7.2

### DIFF
--- a/helpers/form/class.FormContainer.php
+++ b/helpers/form/class.FormContainer.php
@@ -102,7 +102,6 @@ abstract class tao_helpers_form_FormContainer
 
         // set the values in case of default values
         if ($this->data && count($this->data) > 0) {
-        :qa
             $this->form->setValues($this->data);
         }
 

--- a/helpers/form/class.FormContainer.php
+++ b/helpers/form/class.FormContainer.php
@@ -101,7 +101,8 @@ abstract class tao_helpers_form_FormContainer
         }
 
         // set the values in case of default values
-        if (count($this->data) > 0) {
+        if ($this->data && count($this->data) > 0) {
+        :qa
             $this->form->setValues($this->data);
         }
 

--- a/helpers/form/class.FormContainer.php
+++ b/helpers/form/class.FormContainer.php
@@ -101,7 +101,7 @@ abstract class tao_helpers_form_FormContainer
         }
 
         // set the values in case of default values
-        if ($this->data && count($this->data) > 0) {
+        if (is_array($this->data) && !empty($this->data)) {
             $this->form->setValues($this->data);
         }
 

--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '39.5.0',
+    'version' => '39.5.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1258,6 +1258,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('39.3.3');
         }
 
-        $this->skip('39.3.3', '39.5.0');
+        $this->skip('39.3.3', '39.5.1');
     }
 }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-9602

Prevents the PHP warning :
![image](https://user-images.githubusercontent.com/468620/68684218-66f08d80-0568-11ea-9cd2-34ee00f37648.png)

How to reproduce : 
 - PHP >= 7.2
 - Open a page using a `FormContainer` and check the error logs 

