### PR TITLE
add body hash validation stub in OauthService

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '39.5.4',
+    'version' => '39.5.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/models/classes/oauth/OauthService.php
+++ b/models/classes/oauth/OauthService.php
@@ -29,6 +29,7 @@ use oat\oatbox\service\ConfigurableService;
 use common_http_Request;
 use IMSGlobal\LTI\OAuth\OAuthException;
 use Psr\Http\Message\ServerRequestInterface;
+use tao_models_classes_oauth_Exception;
 
 /**
  * Oauth Services based on the TAO DataStore implementation
@@ -42,35 +43,41 @@ class OauthService extends ConfigurableService implements \common_http_Signature
     const SERVICE_ID = 'tao/OauthService';
     
     const OPTION_DATASTORE = 'store';
-    
+
+    const OAUTH_BODY_HASH_PARAM = 'oauth_body_hash';
+
     /**
      * Adds a signature to the request
      *
      * @access public
-     * @author Joel Bout, <joel@taotesting.com>
+     * @param common_http_Request $request
+     * @param common_http_Credentials $credentials
      * @param $authorizationHeader boolean Move the signature parameters into the Authorization header of the request
      * @return common_http_Request
+     * @throws tao_models_classes_oauth_Exception
+     * @author Joel Bout, <joel@taotesting.com>
      */
     public function sign(common_http_Request $request, common_http_Credentials $credentials, $authorizationHeader = false) {
         
         if (!$credentials instanceof \tao_models_classes_oauth_Credentials) {
-            throw new \tao_models_classes_oauth_Exception('Invalid credentals: '.gettype($credentials));
+            throw new tao_models_classes_oauth_Exception('Invalid credentals: '.gettype($credentials));
         }
-        
         
         $oauthRequest = $this->getOauthRequest($request); 
         $dataStore = $this->getDataStore();
         $consumer = $dataStore->getOauthConsumer($credentials);
         $token = $dataStore->new_request_token($consumer);
 
-        $allInitialParameters = array();
-        $allInitialParameters = array_merge($allInitialParameters, $request->getParams());
-        $allInitialParameters = array_merge($allInitialParameters, $request->getHeaders());
+        $allInitialParameters = array_merge($request->getParams(), $request->getHeaders());
         
         //oauth_body_hash is used for the signing computation
         if ($authorizationHeader) {
-        $oauth_body_hash = base64_encode(sha1($request->getBody(), true));//the signature should be ciomputed from encoded versions
-        $allInitialParameters = array_merge($allInitialParameters, array("oauth_body_hash" =>$oauth_body_hash));
+            // the signature should be computed from encoded versions
+            $oauthBodyHash = $this->calculateOauthBodyHash($request->getBody());
+            $allInitialParameters = array_merge(
+                $allInitialParameters,
+                [self::OAUTH_BODY_HASH_PARAM => $oauthBodyHash]
+            );
         }
 
         $signedRequest = OAuthRequest::from_consumer_and_token(
@@ -87,8 +94,10 @@ class OauthService extends ConfigurableService implements \common_http_Signature
         if ($authorizationHeader) {
             $combinedParameters = $signedRequest->get_parameters();
             $signatureParameters = array_diff_assoc($combinedParameters, $allInitialParameters);
-           
-            $signatureParameters["oauth_body_hash"] = base64_encode(sha1($request->getBody(), true));
+
+            // if $authorizationHeader is true then $oauthBodyHash should be defined
+            /** @noinspection PhpUndefinedVariableInspection */
+            $signatureParameters[self::OAUTH_BODY_HASH_PARAM] = $oauthBodyHash;
             $signatureHeaders = array("Authorization" => $this->buildAuthorizationHeader($signatureParameters));
             $signedRequest = new common_http_Request(
                 $signedRequest->to_url(),
@@ -119,13 +128,19 @@ class OauthService extends ConfigurableService implements \common_http_Signature
      * @throws common_http_InvalidSignatureException
      * @author Joel Bout, <joel@taotesting.com>
      */
-    public function validate(common_http_Request $request, common_http_Credentials $credentials = null) {
+    public function validate(common_http_Request $request, common_http_Credentials $credentials = null)
+    {
         $server = new OAuthServer($this->getDataStore());
 		$method = new OAuthSignatureMethod_HMAC_SHA1();
         $server->add_signature_method($method);
-        
+
+        $oauthRequest = $this->getOauthRequest($request);
+        $oauthBodyHash = $oauthRequest->get_parameter('oauth_body_hash');
+        if ($oauthBodyHash !== null && !$this->validateBodyHash($request->getBody(), $oauthBodyHash)) {
+            throw new common_http_InvalidSignatureException('Validation failed: invalid body hash');
+        }
+
         try {
-            $oauthRequest = $this->getOauthRequest($request);
             return $server->verify_request($oauthRequest);
         } catch (OAuthException $e) {
             throw new common_http_InvalidSignatureException('Validation failed: '.$e->getMessage());
@@ -173,6 +188,29 @@ class OauthService extends ConfigurableService implements \common_http_Signature
             $request->getHeaders(),
             $body
         );
+    }
+
+    /**
+     * Check if $bodyHash is valid hash for $body contents
+     * @param string $body
+     * @param string $bodyHash
+     * @return bool
+     */
+    protected function validateBodyHash($body, $bodyHash)
+    {
+        // Check should be added here after ensuring it will not break existing LTI clients
+        // This method was initially added to be overwritten in \oat\taoLti\models\classes\Lis\LisOauthService
+        // where we need to perform real check
+        return true;
+    }
+
+    /**
+     * @param string $body
+     * @return string
+     */
+    protected function calculateOauthBodyHash($body)
+    {
+        return base64_encode(sha1($body, true));
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1258,7 +1258,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('39.3.3');
         }
 
-        $this->skip('39.3.3', '39.5.4');
+        $this->skip('39.3.3', '39.5.5');
 
     }
 }


### PR DESCRIPTION
Task: https://oat-sa.atlassian.net/browse/NEX-320

Add methods to check that oauth_body_hash matches with body contents in OauthService, but do not perform actual check due to compatibility with unknown LTI clients. (should be fixed in the feature)

So, this PR should not change OauthService behavior, it only defines `protected function validateBodyHash(...)` which was overridden in https://github.com/oat-sa/extension-tao-lti/pull/215 