### PR TITLE
Feature/nex 560/add correlation ids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
         "oat-sa/composer-npm-bridge": "^0.3.0",
         "symfony/dotenv": "~4.3",
         "oat-sa/lib-correlation-ids-guzzle": "~0.1",
-        "oat-sa/lib-correlation-ids-monolog": "~0.1"
+        "oat-sa/lib-correlation-ids-monolog": "~0.1",
+        "oat-sa/lib-correlation-ids": "~0.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -43,20 +43,6 @@
             "arguments": ["--prefix", "views"]
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/oat-sa/lib-correlation-ids.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/oat-sa/lib-correlation-ids-guzzle.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/oat-sa/lib-correlation-ids-monolog.git"
-        }
-    ],
     "require": {
         "php": ">=5.6",
         "phpdocumentor/reflection-docblock": "2.*",

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,20 @@
             "arguments": ["--prefix", "views"]
         }
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/oat-sa/lib-correlation-ids.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/oat-sa/lib-correlation-ids-guzzle.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/oat-sa/lib-correlation-ids-monolog.git"
+        }
+    ],
     "require": {
         "php": ">=5.6",
         "phpdocumentor/reflection-docblock": "2.*",
@@ -57,7 +71,9 @@
         "imsglobal/lti": "^3.0",
         "paragonie/random_compat": "^2.0",
         "oat-sa/composer-npm-bridge": "^0.3.0",
-        "symfony/dotenv": "~4.3"
+        "symfony/dotenv": "~4.3",
+        "oat-sa/lib-correlation-ids-guzzle": "~0.1",
+        "oat-sa/lib-correlation-ids-monolog": "~0.1"
     },
     "autoload": {
         "psr-4": {

--- a/getFile.php
+++ b/getFile.php
@@ -41,6 +41,7 @@ list ($subPath, $file) = $parts;
 
 $bootStrap = new oat\tao\model\mvc\Bootstrap('../config/generis.conf.php');
 $config = common_ext_ExtensionsManager::singleton()->getExtensionById('tao')->getConfig('websource_' . $ap);
+$bootstrap->buildCorrelationId();
 common_Logger::singleton()->register();
 
 $compiledPath = $config['options']['path'];

--- a/getFileFlysystem.php
+++ b/getFileFlysystem.php
@@ -36,6 +36,7 @@ $root = dirname(__DIR__);
 $bootstrap = new Bootstrap($root .DIRECTORY_SEPARATOR. 'config' .DIRECTORY_SEPARATOR . 'generis.conf.php');
 
 $serviceManager = $bootstrap->getServiceLocator();
+$bootstrap->buildCorrelationId();
 common_Logger::singleton()->register();
 
 /** @var common_ext_ExtensionsManager $e */

--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '39.5.3',
+    'version' => '39.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/models/classes/api/ApiClientConnector.php
+++ b/models/classes/api/ApiClientConnector.php
@@ -20,12 +20,9 @@
 
 namespace oat\tao\model\api;
 
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Promise\PromiseInterface;
-use OAT\Library\CorrelationIdsGuzzle\Middleware\CorrelationIdsGuzzleMiddleware;
 use oat\oatbox\Configurable;
-use oat\tao\model\mvc\CorrelationIdsService;
+use oat\tao\model\http\HttpClientFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
@@ -137,7 +134,7 @@ class ApiClientConnector extends Configurable implements ClientInterface, Servic
      */
     protected function getClient()
     {
-        return new Client($this->getClientOptions());
+        return (new HttpClientFactory())->create($this->getClientOptions());
     }
 
     /**
@@ -156,20 +153,6 @@ class ApiClientConnector extends Configurable implements ClientInterface, Servic
             }
         }
 
-        // Adds correlation ids.
-        $registry = $this->getCorrelationIdsService()->getRegistry();
-        $handlerStack = HandlerStack::create();
-        $handlerStack->push(Middleware::mapRequest(new CorrelationIdsGuzzleMiddleware($registry)));
-        $options['handler'] = $handlerStack;
-        
         return $options;
-    }
-
-    /**
-     * @return CorrelationIdsService
-     */
-    private function getCorrelationIdsService()
-    {
-        return $this->getServiceLocator()->get(CorrelationIdsService::class);
     }
 }

--- a/models/classes/api/ApiClientConnector.php
+++ b/models/classes/api/ApiClientConnector.php
@@ -21,7 +21,7 @@
 namespace oat\tao\model\api;
 
 use GuzzleHttp\Promise\PromiseInterface;
-use oat\oatbox\Configurable;
+use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\http\HttpClientFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -29,8 +29,6 @@ use Psr\Http\Message\UriInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
-use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
 /**
  * Class ApiClientConnector
@@ -38,11 +36,9 @@ use Zend\ServiceManager\ServiceLocatorAwareTrait;
  * Class to handle a http connection.
  *
  */
-class ApiClientConnector extends Configurable implements ClientInterface, ServiceLocatorAwareInterface
+class ApiClientConnector extends ConfigurableService implements ClientInterface
 {
-    use ServiceLocatorAwareTrait;
-    
-    const OPTION_BASE_URI = 'base_uri';
+    public const OPTION_BASE_URI = 'base_uri';
 
     /**
      * Send an HTTP request.
@@ -145,12 +141,11 @@ class ApiClientConnector extends Configurable implements ClientInterface, Servic
     protected function getClientOptions()
     {
         $options = $this->getOptions();
-        if (!isset($options['headers']) || !isset($options['headers']['Content-Type'])) {
-            $options['headers']['Content-Type'] = ['application/json'];
-        } else {
-            if (!in_array('application/json', $options['headers']['Content-Type'])) {
-                $options['headers']['Content-Type'][] = ['application/json'];
-            }
+        if (!isset($options['headers']['Content-Type'])) {
+            $options['headers']['Content-Type'] = [];
+        } 
+        if (!in_array('application/json', $options['headers']['Content-Type'])) {
+            $options['headers']['Content-Type'][] = ['application/json'];
         }
 
         return $options;

--- a/models/classes/http/HttpClientFactory.php
+++ b/models/classes/http/HttpClientFactory.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\http;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use OAT\Library\CorrelationIdsGuzzle\Middleware\CorrelationIdsGuzzleMiddleware;
+use oat\tao\model\mvc\CorrelationIdsService;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+class HttpClientFactory implements ServiceLocatorAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+
+    /**
+     * @param $options
+     * @return mixed
+     */
+    public function create($options = [])
+    {
+        // Adds correlation ids.
+        $registry = $this->getCorrelationIdsService()->getRegistry();
+        $handlerStack = HandlerStack::create();
+        $handlerStack->push(Middleware::mapRequest(new CorrelationIdsGuzzleMiddleware($registry)));
+        $options['handler'] = $handlerStack;
+
+        return new Client($options);
+    }
+
+    /**
+     * @return CorrelationIdsService
+     */
+    private function getCorrelationIdsService()
+    {
+        return $this->getServiceLocator()->get(CorrelationIdsService::class);
+    }
+}

--- a/models/classes/mvc/Bootstrap.php
+++ b/models/classes/mvc/Bootstrap.php
@@ -24,7 +24,6 @@ namespace oat\tao\model\mvc;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
-use oat\generis\Helper\CorrelationIdsService;
 use oat\oatbox\service\ServiceConfigDriver;
 use oat\oatbox\service\ServiceManager;
 use oat\oatbox\service\ServiceManagerAwareInterface;
@@ -341,7 +340,7 @@ class Bootstrap implements ServiceManagerAwareInterface
     {
         /** @var CorrelationIdsService $correlationIdService */
         $correlationIdService = $this->getServiceLocator()->get(CorrelationIdsService::class);
-        $correlationIdService->getRegistry($request !== null ? $request->getHeaders() : []);
+        $correlationIdService->buildRegistry($request !== null ? $request->getHeaders() : []);
     }
     
 	/**

--- a/models/classes/mvc/Bootstrap.php
+++ b/models/classes/mvc/Bootstrap.php
@@ -222,7 +222,7 @@ class Bootstrap implements ServiceManagerAwareInterface
 	    if (count($params) < 1) {
 	        $report = new Report(Report::TYPE_ERROR, __('No action specified'));
 	    } else {
-	        $this->buildCorrelationId();
+            $this->buildCorrelationId();
             $actionIdentifier = array_shift($params);
             $cliController = new CliController();
             $this->propagate($cliController);
@@ -336,7 +336,7 @@ class Bootstrap implements ServiceManagerAwareInterface
      * Builds correlation id registry, optionally form http(s) request to make it ready for all subsequent call from logger, http client, ...
      * @param ServerRequestInterface $request optional request to retrieve previous correlation ids from.
      */
-	protected function buildCorrelationId(ServerRequestInterface $request = null)
+	public function buildCorrelationId(ServerRequestInterface $request = null)
     {
         /** @var CorrelationIdsService $correlationIdService */
         $correlationIdService = $this->getServiceLocator()->get(CorrelationIdsService::class);

--- a/models/classes/mvc/CorrelationIdsService.php
+++ b/models/classes/mvc/CorrelationIdsService.php
@@ -30,16 +30,23 @@ class CorrelationIdsService extends ConfigurableService
     private $registry;
 
     /**
-     * Builds a correlation ids registry.
-     * @param array $headers optional current request headers ([] if invoked from CLI)
+     * Returns correlation ids registry built with buildRegistry at application boostrap.
      * @return CorrelationIdsRegistryInterface
      */
-    public function getRegistry(array $headers): CorrelationIdsRegistryInterface
+    public function getRegistry(): CorrelationIdsRegistryInterface
+    {
+        return $this->registry;
+    }
+
+    /**
+     * Builds a correlation ids registry.
+     * @param array $headers optional current request headers ([] if invoked from CLI)
+     */
+    public function buildRegistry(array $headers): void
     {
         if ($this->registry === null) {
             $correlationIdsRegistryBuilder = new CorrelationIdsRegistryBuilder(new CorrelationIdGenerator());
             $this->registry = $correlationIdsRegistryBuilder->buildFromRequestHeaders($headers);
         }
-        return $this->registry;
     }
 }

--- a/models/classes/mvc/CorrelationIdsService.php
+++ b/models/classes/mvc/CorrelationIdsService.php
@@ -35,18 +35,21 @@ class CorrelationIdsService extends ConfigurableService
      */
     public function getRegistry(): CorrelationIdsRegistryInterface
     {
-        return $this->registry;
+        return $this->registry ?? $this->buildRegistry([]);
     }
 
     /**
      * Builds a correlation ids registry.
      * @param array $headers optional current request headers ([] if invoked from CLI)
+     * @return CorrelationIdsRegistryInterface
      */
-    public function buildRegistry(array $headers): void
+    public function buildRegistry(array $headers): CorrelationIdsRegistryInterface
     {
         if ($this->registry === null) {
             $correlationIdsRegistryBuilder = new CorrelationIdsRegistryBuilder(new CorrelationIdGenerator());
             $this->registry = $correlationIdsRegistryBuilder->buildFromRequestHeaders($headers);
         }
+        
+        return $this->registry;
     }
 }

--- a/models/classes/mvc/CorrelationIdsService.php
+++ b/models/classes/mvc/CorrelationIdsService.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+namespace oat\tao\model\mvc;
+
+use OAT\Library\CorrelationIds\Builder\CorrelationIdsRegistryBuilder;
+use OAT\Library\CorrelationIds\Generator\CorrelationIdGenerator;
+use OAT\Library\CorrelationIds\Registry\CorrelationIdsRegistryInterface;
+use oat\oatbox\service\ConfigurableService;
+
+class CorrelationIdsService extends ConfigurableService
+{
+    /** @var CorrelationIdsRegistryInterface */
+    private $registry;
+
+    /**
+     * Builds a correlation ids registry.
+     * @param array $headers optional current request headers ([] if invoked from CLI)
+     * @return CorrelationIdsRegistryInterface
+     */
+    public function getRegistry(array $headers): CorrelationIdsRegistryInterface
+    {
+        if ($this->registry === null) {
+            $correlationIdsRegistryBuilder = new CorrelationIdsRegistryBuilder(new CorrelationIdGenerator());
+            $this->registry = $correlationIdsRegistryBuilder->buildFromRequestHeaders($headers);
+        }
+        return $this->registry;
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1258,6 +1258,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('39.3.3');
         }
 
-        $this->skip('39.3.3', '39.5.3');
+        $this->skip('39.3.3', '39.6.0');
     }
 }

--- a/test/unit/models/classes/http/HttpClientFactoryTest.php
+++ b/test/unit/models/classes/http/HttpClientFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\http;
+
+use GuzzleHttp\Client;
+use oat\generis\test\TestCase;
+use OAT\Library\CorrelationIds\Registry\CorrelationIdsRegistryInterface;
+use oat\tao\model\mvc\CorrelationIdsService;
+
+class HttpClientFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $options = ['key' => 'value'];
+
+        $registry = $this->getMock(CorrelationIdsRegistryInterface::class);
+        
+        $correlationIdsService = $this->getMockBuilder(CorrelationIdsService::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getRegistry'])
+            ->getMock();
+        $correlationIdsService->method('getRegistry')->willReturn($registry);
+        
+        $serviceLocator = $this->getServiceLocatorMock([CorrelationIdsService::class => $correlationIdsService]);
+
+        $subject = new HttpClientFactory();
+        $subject->setServiceLocator($serviceLocator);
+
+        $client = $subject->create($options);
+        
+        $this->assertInstanceOf(Client::class, $client);
+    }
+}

--- a/test/unit/models/classes/http/HttpClientFactoryTest.php
+++ b/test/unit/models/classes/http/HttpClientFactoryTest.php
@@ -20,19 +20,23 @@
 namespace oat\tao\test\unit\model\http;
 
 use GuzzleHttp\Client;
+use function GuzzleHttp\choose_handler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
 use oat\generis\test\TestCase;
+use OAT\Library\CorrelationIds\Provider\CorrelationIdsHeaderNamesProviderInterface;
+use OAT\Library\CorrelationIds\Registry\CorrelationIdsRegistry;
 use OAT\Library\CorrelationIds\Registry\CorrelationIdsRegistryInterface;
 use oat\tao\model\http\HttpClientFactory;
 use oat\tao\model\mvc\CorrelationIdsService;
 
 class HttpClientFactoryTest extends TestCase
 {
-    public function testCreate()
+    public function testCreateWithoutHandlerCreatesDefaultHandlerStack()
     {
         $key = 'one key';
         $value = 'one value';
-        $options = [$key => $value];
 
         $registry = $this->createMock(CorrelationIdsRegistryInterface::class);
         $correlationIdsService = $this->createConfiguredMock(CorrelationIdsService::class, ['getRegistry' => $registry]);
@@ -41,12 +45,72 @@ class HttpClientFactoryTest extends TestCase
         $subject = new HttpClientFactory();
         $subject->setServiceLocator($serviceLocator);
 
-        $client = $subject->create($options);
+        $client = $subject->create([$key => $value]);
 
         $this->assertInstanceOf(Client::class, $client);
         /** @var Client $client */
 
         $this->assertInstanceOf(HandlerStack::class, $client->getConfig('handler'));
         $this->assertEquals($value, $client->getConfig($key));
+    }
+
+    public function testCreateWithExistingHandlerAddsCorrelationIdsHandler()
+    {
+        $currentId = 'current id';
+        $parentId = 'the parent id';
+        $rootId = 'id of the root';
+
+        $registry = new CorrelationIdsRegistry($currentId, $parentId, $rootId);
+        $correlationIdsService = $this->createConfiguredMock(CorrelationIdsService::class, ['getRegistry' => $registry]);
+        $serviceLocator = $this->getServiceLocatorMock([CorrelationIdsService::class => $correlationIdsService]);
+
+        $subject = new HttpClientFactory();
+        $subject->setServiceLocator($serviceLocator);
+
+        $calls = [];
+        $stack = HistoryAwareHandlerStack::create();
+        $stack->push(Middleware::history($calls), HistoryAwareHandlerStack::HISTORY_HANDLER_NAME);
+
+        $client = $subject->create([HttpClientFactory::OPTION_HANDLER_STACK => $stack]);
+        
+        $client->request('GET', 'http://example.com/');
+
+        $this->assertCount(1, $calls);
+        /** @var Request $request */
+        $request = $calls[0]['request'];
+
+        $this->assertTrue($request->hasHeader(CorrelationIdsHeaderNamesProviderInterface::DEFAULT_ROOT_CORRELATION_ID_HEADER_NAME));
+        $this->assertTrue($request->hasHeader(CorrelationIdsHeaderNamesProviderInterface::DEFAULT_PARENT_CORRELATION_ID_HEADER_NAME));
+        
+        $actualRootId = $request->getHeader(CorrelationIdsHeaderNamesProviderInterface::DEFAULT_ROOT_CORRELATION_ID_HEADER_NAME);
+        $this->assertEquals($rootId, $actualRootId[0]);
+
+        // Parent id for new request has to be this request current id.
+        $actualParentId = $request->getHeader(CorrelationIdsHeaderNamesProviderInterface::DEFAULT_PARENT_CORRELATION_ID_HEADER_NAME);        
+        $this->assertEquals($currentId, $actualParentId[0]);
+    }
+}
+
+class HistoryAwareHandlerStack extends HandlerStack
+{
+    public const HISTORY_HANDLER_NAME = 'history';
+
+    public static function create(callable $handler = null)
+    {
+        return new self(choose_handler());
+    }
+    
+    /**
+     * If an history middleware is present, insert before it, so that it can actually see the effects of the other middlewares inserted.
+     * @param callable $middleware
+     * @param string   $name
+     */
+    public function push(callable $middleware, $name = '')
+    {
+        if ($name === self::HISTORY_HANDLER_NAME) {
+            parent::push($middleware, $name);
+        } else {
+            $this->before(self::HISTORY_HANDLER_NAME, $middleware, $name);
+        }
     }
 }

--- a/test/unit/models/classes/http/HttpClientFactoryTest.php
+++ b/test/unit/models/classes/http/HttpClientFactoryTest.php
@@ -17,34 +17,36 @@
  * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
  */
 
-namespace oat\tao\model\http;
+namespace oat\tao\test\unit\model\http;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 use oat\generis\test\TestCase;
 use OAT\Library\CorrelationIds\Registry\CorrelationIdsRegistryInterface;
+use oat\tao\model\http\HttpClientFactory;
 use oat\tao\model\mvc\CorrelationIdsService;
 
 class HttpClientFactoryTest extends TestCase
 {
     public function testCreate()
     {
-        $options = ['key' => 'value'];
+        $key = 'one key';
+        $value = 'one value';
+        $options = [$key => $value];
 
-        $registry = $this->getMock(CorrelationIdsRegistryInterface::class);
-        
-        $correlationIdsService = $this->getMockBuilder(CorrelationIdsService::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getRegistry'])
-            ->getMock();
-        $correlationIdsService->method('getRegistry')->willReturn($registry);
-        
+        $registry = $this->createMock(CorrelationIdsRegistryInterface::class);
+        $correlationIdsService = $this->createConfiguredMock(CorrelationIdsService::class, ['getRegistry' => $registry]);
         $serviceLocator = $this->getServiceLocatorMock([CorrelationIdsService::class => $correlationIdsService]);
 
         $subject = new HttpClientFactory();
         $subject->setServiceLocator($serviceLocator);
 
         $client = $subject->create($options);
-        
+
         $this->assertInstanceOf(Client::class, $client);
+        /** @var Client $client */
+
+        $this->assertInstanceOf(HandlerStack::class, $client->getConfig('handler'));
+        $this->assertEquals($value, $client->getConfig($key));
     }
 }


### PR DESCRIPTION
This PR builds and consumes the correlation id registry implemented in lib-correlation-ids-guzzle.

It builds it at bootsrap time from request headers whan invoked from http(s) request, or from empty array when invoked from CLI.

Usage : `$registry = $this->getCorrelationIdsService()->getRegistry();`

~Depends on https://github.com/oat-sa/lib-correlation-ids/pull/6~