### PR TITLE
Feature/tao 9965/Update ui/dropdownForm

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '40.4.1',
+    'version' => '40.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1288,6 +1288,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('40.3.4');
         }
 
-        $this->skip('40.3.4', '40.4.1');
+        $this->skip('40.3.4', '40.5.0');
     }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -12,7 +12,7 @@
     "@oat-sa/expr-eval": "1.3.0",
     "@oat-sa/tao-core-libs": "0.3.0",
     "@oat-sa/tao-core-sdk": "0.9.0",
-    "@oat-sa/tao-core-ui": "0.26.1",
+    "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#feature/TAO-9965/make-submit-button-optional-in-simpleform",
     "async": "0.2.10",
     "decimal.js": "10.1.1",
     "dompurify": "1.0.11",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9965

Requires: 
 - [ ] https://github.com/oat-sa/tao-core-ui-fe/pull/82

Update the package `@oat-sa/tao-core-ui` in order to get the last version of the `ui/dropdownForm` component

**Review Checklist**
- [x] New code is covered by tests (if applicable)
- [x] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [x] New code is not subject to concurrency issues (if applicable)
- [x] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful