### PR TITLE
Fix/tao 9965/Update ui/dropdownForm - Fix a package version issue

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '40.5.0',
+    'version' => '40.5.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1288,6 +1288,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('40.3.4');
         }
 
-        $this->skip('40.3.4', '40.5.0');
+        $this->skip('40.3.4', '40.5.1');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "@oat-sa/tao-core-ui": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-0.26.1.tgz",
-      "integrity": "sha512-hzrgOoYmvIxXmcYU6wgUUgN9cSn14yRFP2njEOHpkUGsaV7v1kOhl8I199aTEe67T1/5VoXGnq+MQtXssTH6+Q=="
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-0.27.0.tgz",
+      "integrity": "sha512-uCTobo3V1bsDzm+tIh579kfHCNs4b6e3e7/lSr3gsTgjJzoPWx8kRkTOds9SCv0QfCSCpC4oTsWj90JYbAUFyw=="
     },
     "amdefine": {
       "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "GPL-2.0",
   "description": "tao core dependencies",
   "repository": {
@@ -12,7 +12,7 @@
     "@oat-sa/expr-eval": "1.3.0",
     "@oat-sa/tao-core-libs": "0.3.0",
     "@oat-sa/tao-core-sdk": "0.9.0",
-    "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#feature/TAO-9965/make-submit-button-optional-in-simpleform",
+    "@oat-sa/tao-core-ui": "0.27.0",
     "async": "0.2.10",
     "decimal.js": "10.1.1",
     "dompurify": "1.0.11",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9965

Requires: 
 - [x] https://github.com/oat-sa/tao-core-ui-fe/pull/82

Update the package `@oat-sa/tao-core-ui` in order to get the last version of the `ui/dropdownForm` component
Fix a package versions issue (last PR was merged too quickly)

**Review Checklist**
- [ ] New code is covered by tests (if applicable)
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful