### PR TITLE
Fix/tao 9965/fix bundling

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -54,7 +54,7 @@ return array(
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '40.5.1',
+    'version' => '40.5.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1288,6 +1288,6 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('40.3.4');
         }
 
-        $this->skip('40.3.4', '40.5.1');
+        $this->skip('40.3.4', '40.5.2');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "@oat-sa/tao-core-ui": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-0.27.0.tgz",
-      "integrity": "sha512-uCTobo3V1bsDzm+tIh579kfHCNs4b6e3e7/lSr3gsTgjJzoPWx8kRkTOds9SCv0QfCSCpC4oTsWj90JYbAUFyw=="
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-0.27.1.tgz",
+      "integrity": "sha512-rRl/iOHhWdyyxKTaMtM/GrRrWllsW/afWBueLOJQxL8Bhj14R6W8DAXn3+STL4Q5HykZZrnflPR/Hqln4inj7w=="
     },
     "amdefine": {
       "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "GPL-2.0",
   "description": "tao core dependencies",
   "repository": {
@@ -12,7 +12,7 @@
     "@oat-sa/expr-eval": "1.3.0",
     "@oat-sa/tao-core-libs": "0.3.0",
     "@oat-sa/tao-core-sdk": "0.9.0",
-    "@oat-sa/tao-core-ui": "0.27.0",
+    "@oat-sa/tao-core-ui": "0.27.1",
     "async": "0.2.10",
     "decimal.js": "10.1.1",
     "dompurify": "1.0.11",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9965

The previously published package for `@oat-sa/tao-core-ui` was containing corrupted bundles. A component from a TAO extension has been added somehow in the dist folder.