### PR TITLE
Fix/ncc 110/trigger select on items list loaded

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '40.9.0',
+    'version' => '40.9.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.7.0',

--- a/manifest.php
+++ b/manifest.php
@@ -55,7 +55,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '40.8.0',
+    'version' => '40.8.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1298,6 +1298,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('40.7.0');
         }
 
-        $this->skip('40.7.0', '40.8.0');
+        $this->skip('40.7.0', '40.8.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1307,5 +1307,6 @@ class Updater extends \common_ext_ExtensionUpdater
             }
             $this->setVersion('40.9.0');
         }
+        $this->skip('40.9.0', '40.9.1');
     }
 }

--- a/views/js/generis.tree.select.js
+++ b/views/js/generis.tree.select.js
@@ -132,36 +132,26 @@ define([
                     //when a node is selected
                     onselect: function(NODE, TREE_OBJ) {
                         var servOptions = {};
+                        var $NODE = $(NODE);
+                        var $nodeParent = $(NODE)
+                            .parent()
+                            .parent();
+
                         if (instance.serverParameters.hasOwnProperty('order')) {
                             servOptions.order = instance.serverParameters.order;
                         }
                         if (instance.serverParameters.hasOwnProperty('orderdir')) {
                             servOptions.orderdir = instance.serverParameters.orderdir;
                         }
-                        if ($(NODE).hasClass('paginate-more')) {
-                            instance.paginateInstances(
-                                $(NODE)
-                                    .parent()
-                                    .parent(),
-                                TREE_OBJ,
-                                servOptions
-                            );
+                        if ($NODE.hasClass('paginate-more')) {
+                            instance.paginateInstances($nodeParent, TREE_OBJ, servOptions);
                             return;
                         }
-                        if ($(NODE).hasClass('paginate-all')) {
-                            var parentNodeId = $(NODE)
-                                .parent()
-                                .parent()
-                                .prop('id');
+                        if ($NODE.hasClass('paginate-all')) {
+                            var parentNodeId = $nodeParent.prop('id');
                             servOptions.limit =
                                 instance.getMeta(parentNodeId, 'count') - instance.getMeta(parentNodeId, 'displayed');
-                            instance.paginateInstances(
-                                $(NODE)
-                                    .parent()
-                                    .parent(),
-                                TREE_OBJ,
-                                servOptions
-                            );
+                            instance.paginateInstances($nodeParent, TREE_OBJ, servOptions);
                             return;
                         }
 
@@ -353,16 +343,12 @@ define([
                                     .find('ul:first')
                                     .children()
                                     .each(function() {
-                                        if ($(this).hasClass('node-instance')) {
-                                            $(this)
-                                                .find('a:not(.checked, .undetermined)')
-                                                .each(function() {
-                                                    instance.checkedNodes.push(
-                                                        $(this)
-                                                            .parent()
-                                                            .prop('id')
-                                                    );
-                                                });
+                                        var $this = $(this);
+
+                                        if ($this.hasClass('node-instance')) {
+                                            $this.find('a:not(.checked, .undetermined)').each(function() {
+                                                instance.checkedNodes.push($this.parent().prop('id'));
+                                            });
                                         }
                                     });
                             } else {

--- a/views/js/generis.tree.select.js
+++ b/views/js/generis.tree.select.js
@@ -133,9 +133,7 @@ define([
                     onselect: function(NODE, TREE_OBJ) {
                         var servOptions = {};
                         var $NODE = $(NODE);
-                        var $nodeParent = $(NODE)
-                            .parent()
-                            .parent();
+                        var $nodeParent = $NODE.parent().parent();
 
                         if (instance.serverParameters.hasOwnProperty('order')) {
                             servOptions.order = instance.serverParameters.order;
@@ -154,7 +152,6 @@ define([
                             instance.paginateInstances($nodeParent, TREE_OBJ, servOptions);
                             return;
                         }
-
                         return true;
                     },
                     ondata: function(DATA, TREE_OBJ) {

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/views/package.json
+++ b/views/package.json
@@ -1,32 +1,32 @@
 {
-  "name": "@oat-sa/tao",
-  "version": "0.6.1",
-  "license": "GPL-2.0",
-  "description": "tao core dependencies",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/oat-sa/tao-core.git"
-  },
-  "dependencies": {
-    "@babel/polyfill": "^7.4.4",
-    "@oat-sa/expr-eval": "1.3.0",
-    "@oat-sa/tao-core-libs": "0.3.0",
-    "@oat-sa/tao-core-sdk": "0.9.0",
-    "@oat-sa/tao-core-ui": "0.28.0",
-    "async": "0.2.10",
-    "decimal.js": "10.1.1",
-    "dompurify": "1.0.11",
-    "gamp": "0.2.1",
-    "handlebars": "1.3.0",
-    "interactjs": "1.3.4",
-    "jquery": "1.9.1",
-    "lodash": "2.4.1",
-    "moment": "2.11.1",
-    "moment-timezone": "0.5.10",
-    "popper.js": "1.15.0",
-    "raphael": "2.1.4",
-    "select2": "3.5.1",
-    "tooltip.js": "1.3.2",
-    "url-polyfill": "1.1.7"
-  }
+    "name": "@oat-sa/tao",
+    "version": "0.6.2",
+    "license": "GPL-2.0",
+    "description": "tao core dependencies",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/oat-sa/tao-core.git"
+    },
+    "dependencies": {
+        "@babel/polyfill": "^7.4.4",
+        "@oat-sa/expr-eval": "1.3.0",
+        "@oat-sa/tao-core-libs": "0.3.0",
+        "@oat-sa/tao-core-sdk": "0.9.0",
+        "@oat-sa/tao-core-ui": "0.28.0",
+        "async": "0.2.10",
+        "decimal.js": "10.1.1",
+        "dompurify": "1.0.11",
+        "gamp": "0.2.1",
+        "handlebars": "1.3.0",
+        "interactjs": "1.3.4",
+        "jquery": "1.9.1",
+        "lodash": "2.4.1",
+        "moment": "2.11.1",
+        "moment-timezone": "0.5.10",
+        "popper.js": "1.15.0",
+        "raphael": "2.1.4",
+        "select2": "3.5.1",
+        "tooltip.js": "1.3.2",
+        "url-polyfill": "1.1.7"
+    }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "license": "GPL-2.0",
     "description": "tao core dependencies",
     "repository": {


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/NCC-110
**Description:**
On the "new assignment" when the user clicks on a sub-folder, event "change" is fired and handler subscribed on that event checks if folders has any selected items.
In case there is at least one selected item the button "Assign" change state to enabled.
The problem is on the first click on sub-folder there is no items and we do request to load them
When data for items is loaded the "change" event has been fired before items are rendered.
That's why we have to notify handler that items are loaded and rendered

**Steps to reproduce:** 
1. Log in as Sponsor
2. Go to Child Organization
3. Go to test Assignments
4. Click the "Add New assignment" button
5. Click the folder containing the desired battery

**Unit tests cli:** `npm run test`