### PR TITLE
Fix/ACTP-295/Guzzle support for Rest API Test Runner

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '40.11.1',
+    'version' => '40.11.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.12.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1324,7 +1324,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('40.9.6');
         }
 
-        $this->skip('40.9.6', '40.11.1');
+        $this->skip('40.9.6', '40.11.2');
 
     }
 }

--- a/test/integration/RestTestRunner.php
+++ b/test/integration/RestTestRunner.php
@@ -2,37 +2,59 @@
 
 namespace oat\tao\test\integration;
 
-use oat\generis\model\GenerisRdf;
-use oat\generis\test\GenerisPhpUnitTestRunner;
+use GuzzleHttp\Client;
 use oat\tao\model\TaoOntology;
 use oat\tao\model\user\TaoRoles;
+use oat\generis\model\GenerisRdf;
+use Psr\Http\Message\ResponseInterface;
+use oat\generis\test\GenerisPhpUnitTestRunner;
 
+/**
+ * Class RestTestRunner
+ *
+ * @package oat\tao\test\integration
+ */
 abstract class RestTestRunner extends GenerisPhpUnitTestRunner
 {
+    /** @var Client */
+    protected $client;
+
+    /** @var string */
     protected $host = '';
 
-    protected $userUri = "";
+    /** @var string */
+    protected $userUri = '';
 
-    protected $login = "";
+    /** @var string */
+    protected $login = '';
 
-    protected $password = "";
-    
+    /** @var string */
+    protected $password = '';
+
+    /**
+     * @return array
+     */
     protected function getUserData()
     {
         return [
             GenerisRdf::PROPERTY_USER_LOGIN => 'tjdoe',
-            GenerisRdf::PROPERTY_USER_PASSWORD => 'test123',
             GenerisRdf::PROPERTY_USER_LASTNAME => 'Doe',
             GenerisRdf::PROPERTY_USER_FIRSTNAME => 'John',
             GenerisRdf::PROPERTY_USER_MAIL => 'jdoe@tao.lu',
-            GenerisRdf::PROPERTY_USER_UILG => \tao_models_classes_LanguageService::singleton()->getLanguageByCode(DEFAULT_LANG)->getUri(),
-            GenerisRdf::PROPERTY_USER_PASSWORD => 'test' . rand(),
+            GenerisRdf::PROPERTY_USER_UILG => \tao_models_classes_LanguageService::singleton()
+                ->getLanguageByCode(DEFAULT_LANG)
+                ->getUri(),
+            GenerisRdf::PROPERTY_USER_PASSWORD => 'Test' . rand() . '!!',
             GenerisRdf::PROPERTY_USER_ROLES => [
-                TaoRoles::GLOBAL_MANAGER
-            ]
+                TaoRoles::GLOBAL_MANAGER,
+            ],
         ];
     }
-    
+
+    /**
+     * @throws \common_exception_Error
+     * @throws \oat\generis\model\user\PasswordConstraintsException
+     */
     public function setUp()
     {
         parent::setUp();
@@ -40,16 +62,19 @@ abstract class RestTestRunner extends GenerisPhpUnitTestRunner
         $this->host = ROOT_URL;
         $this->disableCache();
         
-        // creates a user using remote script from joel
-        $userdata = $this->getUserData();
-        $password = $userdata[GenerisRdf::PROPERTY_USER_PASSWORD];
-        $userdata[GenerisRdf::PROPERTY_USER_PASSWORD] = \core_kernel_users_Service::getPasswordHash()->encrypt($userdata[GenerisRdf::PROPERTY_USER_PASSWORD]);
+        // Creates a user using remote script from joel
+        $userData = $this->getUserData();
+
+        $this->password = $userData[GenerisRdf::PROPERTY_USER_PASSWORD];
+        $this->login = $userData[GenerisRdf::PROPERTY_USER_LOGIN];
+
+        $userData[GenerisRdf::PROPERTY_USER_PASSWORD] = \core_kernel_users_Service::getPasswordHash()->encrypt(
+            $userData[GenerisRdf::PROPERTY_USER_PASSWORD]
+        );
+
         $tmclass = new \core_kernel_classes_Class(TaoOntology::CLASS_URI_TAO_USER);
-        $user = $tmclass->createInstanceWithProperties($userdata);
+        $user = $tmclass->createInstanceWithProperties($userData);
         \common_Logger::i('Created user ' . $user->getUri());
-        
-        $this->login = $userdata[GenerisRdf::PROPERTY_USER_LOGIN];
-        $this->password = $password;
         $this->userUri = $user->getUri();
     }
 
@@ -127,4 +152,42 @@ abstract class RestTestRunner extends GenerisPhpUnitTestRunner
     {
         // just to avoid stopping tests with error "Call to undefined method restoreCache()"
     }
+
+    /**
+     * @param string $method
+     * @param string $uri
+     * @param array $options
+     *
+     * @return ResponseInterface
+     */
+    protected function send($method, $uri, array $options = [])
+    {
+        if (!isset($this->client)) {
+            $this->client = new Client();
+        }
+
+        return $this->client->request($method, $uri, $this->processOptions($options));
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return array
+     */
+    private function processOptions(array $options)
+    {
+        if (
+            array_key_exists('headers', $options)
+            && !array_key_exists('Accept', $options['headers'])
+            && !array_key_exists('accept', $options['headers'])
+        ) {
+            $options['headers']['Accept'] = 'application/json';
+        }
+
+        return array_merge([
+            'http_errors' => false,
+            'auth' => [$this->login, $this->password],
+        ], $options);
+    }
 }
+

--- a/test/integration/RestTestRunner.php
+++ b/test/integration/RestTestRunner.php
@@ -176,11 +176,7 @@ abstract class RestTestRunner extends GenerisPhpUnitTestRunner
      */
     private function processOptions(array $options)
     {
-        if (
-            array_key_exists('headers', $options)
-            && !array_key_exists('Accept', $options['headers'])
-            && !array_key_exists('accept', $options['headers'])
-        ) {
+        if (!isset($options['headers']['Accept'], $options['headers']['accept'])) {
             $options['headers']['Accept'] = 'application/json';
         }
 


### PR DESCRIPTION
Added Guzzle support for Rest API Test Runner.

Related to: [https://oat-sa.atlassian.net/browse/ACTP-295](https://oat-sa.atlassian.net/browse/ACTP-295)

#### Changes
- Fixed user data: user password was changed to valid (Uppercase letter, lowercase letter, number, character);
- Removed duplicated key (password) from user data;
- Added guzzle support. 

#### Dependencies
 
Requires :
 - [ ] [https://github.com/oat-sa/generis/pull/740](https://github.com/oat-sa/generis/pull/740)