### PR TITLE
TBD-13: Support custom copy-to-clipboard form fields

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '41.4.0',
+    'version' => '41.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1345,6 +1345,6 @@ class Updater extends \common_ext_ExtensionUpdater
 
             $this->setVersion('41.2.0');
         }
-        $this->skip('41.2.0', '41.4.0');
+        $this->skip('41.2.0', '41.5.0');
     }
 }

--- a/views/js/form/post-render-props.js
+++ b/views/js/form/post-render-props.js
@@ -23,7 +23,7 @@ define([
 ], function ($, __, feedback) {
     'use strict';
 
-    function createCopyToClipboardHandler($field) {
+    function _createCopyToClipboardHandler($field) {
         var
             successFeedback = $field.data('copy-success-feedback')
                 || __('Resource Identifier has been copied to the clipboard'),
@@ -47,36 +47,32 @@ define([
         }
     }
 
+    function _cloneField($field) {
+        return $field.clone()
+            // To make MS browsers happy, value needs to be removed and re-added
+            .val('')
+            .attr({readonly: true, type: 'text'});
+    }
+
     /**
      * Add a field with URI of an item etc and a button to copy it to the clipboard
      * @param $container
      * @private
      */
     function _initializeCopyToClipboard($container) {
-        // Note: isInstanceForm will not work with jquery|querySelector
-        var isInstanceForm = document.getElementById('tao.forms.instance'),
-            $fields = $container.find('#id, .copy-to-clipboard');
+        var $fields = $container.find('#id, .copy-to-clipboard');
 
-        // if the field has already been added
-        if ($('.uri-container').length) {
-            return;
-        }
-
-        if (!isInstanceForm) {
-            return;
-        }
-
-        if (!$fields.length) {
+        // Early return in case:
+        // 1. isInstanceForm that will not work with jquery|querySelector
+        // 2. The field has already been added
+        // 3. There is nothing to initialize
+        if (!document.getElementById('tao.forms.instance') || $('.uri-container').length || !$fields.length) {
             return;
         }
 
         $fields.each(function () {
-            var
-                $field = $(this),
-                $fieldCopy = $field.clone()
-                    // To make MS browsers happy, value needs to be removed and re-added
-                    .val('')
-                    .attr({readonly: true, type: 'text'}),
+            var $field = $(this),
+                $fieldCopy = _cloneField($field),
                 $button = $('<span>', {class: 'icon-clipboard clipboard-command', title: __('Copy to clipboard')}),
                 $label = $('<span>', {class: 'form_desc', text: __('Resource Identifier')}),
                 $fieldBox = $('<span>', {class: 'uri-container'}),
@@ -90,19 +86,15 @@ define([
 
                 $container.find('div')
                     .first()
-                    .after($('<div>')
-                        .append([$label, $fieldBox]));
+                    .after($('<div>').append([$label, $fieldBox]));
                 $fieldBox.height($field.outerHeight());
             } else {
                 $fieldBox.height($field.outerHeight());
-                $field.wrap($fieldBox);
-                $field.parent().append($button);
+                $field.wrap($fieldBox).parent().append($button);
             }
 
-            $button.on('click', createCopyToClipboardHandler($field));
-            $field.addClass('final')
-                // re-add value
-                .val(value);
+            $button.on('click', _createCopyToClipboardHandler($field));
+            $field.addClass('final').val(value);
         });
     }
 

--- a/views/js/form/post-render-props.js
+++ b/views/js/form/post-render-props.js
@@ -60,17 +60,14 @@ define([
      * @private
      */
     function _initializeCopyToClipboard($container) {
-        var $fields = $container.find('#id, .copy-to-clipboard');
-
         // Early return in case:
         // 1. isInstanceForm that will not work with jquery|querySelector
         // 2. The field has already been added
-        // 3. There is nothing to initialize
-        if (!document.getElementById('tao.forms.instance') || $('.uri-container').length || !$fields.length) {
+        if (!document.getElementById('tao.forms.instance') || $('.uri-container').length) {
             return;
         }
 
-        $fields.each(function () {
+        $container.find('#id, .copy-to-clipboard').each(function () {
             var $field = $(this),
                 $fieldCopy = _cloneField($field),
                 $button = $('<span>', {class: 'icon-clipboard clipboard-command', title: __('Copy to clipboard')}),

--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -173,6 +173,7 @@ define([
 
             $('.form-submitter').off('click').on('click', function (e) {
                 e.preventDefault();
+                $(this).addClass('current-submitter');
                 $(e.target).closest('.xhtml_form form').trigger('submit');
             });
 
@@ -929,6 +930,11 @@ define([
                         });
 
                         serialize = typeof serialize !== 'undefined' ? serialize : myForm.serializeArray();
+
+                        $('.current-submitter', myForm).each(function () {
+                            $(this).removeClass('current-submitter');
+                            serialize.push({ name: this.name, value: this.value });
+                        });
                         $container.load(myForm.prop('action'), serialize);
                     }
                 }


### PR DESCRIPTION
- TBD-13 feat: support `copy-to-clipboard` action on any form field with `copy-to-clipboard` class

Required by [taoLti extension](https://github.com/oat-sa/extension-tao-lti/pull/232).