### PR TITLE
remove funcAcl dependency

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '41.9.5',
+    'version' => '41.9.6',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -26,7 +26,6 @@ use common_cache_Cache;
 use common_Exception;
 use common_report_Report as Report;
 use core_kernel_persistence_smoothsql_SmoothModel;
-use oat\funcAcl\models\ModuleAccessService;
 use oat\generis\model\data\event\ResourceCreated;
 use oat\generis\model\data\event\ResourceDeleted;
 use oat\generis\model\data\event\ResourceUpdated;
@@ -589,11 +588,11 @@ class Updater extends \common_ext_ExtensionUpdater
         $this->skip('14.4.1', '14.8.0');
 
         if ($this->isVersion('14.8.0')) {
-            $moduleService = ModuleAccessService::singleton();
-            $moduleService->remove(
+            AclProxy::revokeRule(new AccessRule(
+                AccessRule::GRANT,
                 'http://www.tao.lu/Ontologies/TAO.rdf#TaoManagerRole',
-                'http://www.tao.lu/Ontologies/taoFuncACL.rdf#m_tao_ExtensionsManager'
-            );
+                ['ext' => 'tao']
+            ));
 
             AclProxy::applyRule(new AccessRule('grant', 'http://www.tao.lu/Ontologies/TAO.rdf#SysAdminRole', ['ext' => 'tao','mod' => 'ExtensionsManager']));
             AclProxy::applyRule(new AccessRule('grant', 'http://www.tao.lu/Ontologies/TAO.rdf#TaoManagerRole', ['ext' => 'tao','mod' => 'Api']));
@@ -1353,6 +1352,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('41.8.0');
         }
 
-        $this->skip('41.8.0', '41.9.5');
+        $this->skip('41.8.0', '41.9.6');
     }
 }


### PR DESCRIPTION
This PR add dependency of tao-code on funcAcl extension without mentioning it in manifest.php:
https://github.com/oat-sa/tao-core/pull/1568/files

This adds cyclic dependency (tao-code and funcAcl depends on each other).

Current PR removes this cyclic dependency.