### PR TITLE
UDI-190: Allow rendering of theme based head elements

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '41.9.5',
+    'version' => '41.10.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/models/classes/theme/ConfigurableTheme.php
+++ b/models/classes/theme/ConfigurableTheme.php
@@ -142,6 +142,9 @@ class ConfigurableTheme extends Configurable implements Theme
     public function getTemplate($id, $context = Theme::CONTEXT_BACKOFFICE)
     {
         switch ($id) {
+            case 'head':
+                $template = Template::getTemplate('blocks/head.tpl', 'tao');
+                break;
             case 'header-logo':
                 $template = Template::getTemplate('blocks/header-logo.tpl', 'tao');
                 break;

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1353,6 +1353,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('41.8.0');
         }
 
-        $this->skip('41.8.0', '41.9.5');
+        $this->skip('41.8.0', '41.10.0');
     }
 }

--- a/views/templates/blocks/head.tpl
+++ b/views/templates/blocks/head.tpl
@@ -1,0 +1,4 @@
+<?php
+use oat\tao\helpers\Template;
+?>
+<link rel="shortcut icon" href="<?= Template::img('favicon.ico', 'tao') ?>"/>

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -22,7 +22,7 @@ $hasVersionWarning = empty($_COOKIE['versionWarning'])
     <meta name="google" content="notranslate" />
     <title><?= Layout::getTitle() ?></title>
 
-    <link rel="shortcut icon" href="<?= Template::img('favicon.ico', 'tao') ?>"/>
+    <?= Layout::renderThemeTemplate(Theme::CONTEXT_BACKOFFICE, 'head') ?>
 
     <?= tao_helpers_Scriptloader::render() ?>
 

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -20,9 +20,10 @@ $hasVersionWarning = empty($_COOKIE['versionWarning'])
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="google" content="notranslate" />
-    <title><?= Layout::getTitle() ?></title>
 
     <?= Layout::renderThemeTemplate(Theme::CONTEXT_BACKOFFICE, 'head') ?>
+
+    <title><?= Layout::getTitle() ?></title>
 
     <?= tao_helpers_Scriptloader::render() ?>
 


### PR DESCRIPTION
- UDI-190 feat(layout): allow rendering `<head>`-nested elements via `head` template
- UDI-190 chore(layout): render a favicon `<link>` via `head` template
- UDI-190 chore(version): bump a minor one
- UDI-190 feat(layout): allow overriding a `title` tag via a themed `head` template

Is a dependency for [taoUdir PR #49](https://github.com/oat-sa/extension-tao-udir/pull/49)