### PR TITLE
NFER-66:  Implement a key-value storage for the OAuth lockout service

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '41.10.1',
+    'version' => '41.11.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/models/classes/oauth/lockout/storage/KvLockoutStorage.php
+++ b/models/classes/oauth/lockout/storage/KvLockoutStorage.php
@@ -22,15 +22,37 @@ declare(strict_types=1);
 
 namespace oat\tao\model\oauth\lockout\storage;
 
-class KvLockoutStorage extends LockoutStorageAbstract
+use common_persistence_KeyValuePersistence as Persistence;
+
+/**
+ * @method Persistence getPersistence()
+ */
+final class KvLockoutStorage extends LockoutStorageAbstract
 {
-    public function store(string $ip, int $ttl = 0)
+    /**
+     * @inheritDoc
+     */
+    public function store(string $ip, int $ttl = 0): void
     {
-        return true;
+        $this->getPersistence()->set(
+            $this->createKey($ip),
+            $this->getFailedAttempts($ip, $ttl) + 1,
+            $ttl
+        );
     }
 
+    /**
+     * @inheritDoc
+     */
     public function getFailedAttempts(string $ip, int $timeout): int
     {
-        return 0;
+        return (int)$this->getPersistence()->get(
+            $this->createKey($ip)
+        );
+    }
+
+    private function createKey(string $ip): string
+    {
+        return sprintf('%s_%u', self::class, ip2long($ip));
     }
 }

--- a/models/classes/oauth/lockout/storage/KvLockoutStorage.php
+++ b/models/classes/oauth/lockout/storage/KvLockoutStorage.php
@@ -27,7 +27,7 @@ use common_persistence_KeyValuePersistence as Persistence;
 /**
  * @method Persistence getPersistence()
  */
-final class KvLockoutStorage extends LockoutStorageAbstract
+class KvLockoutStorage extends LockoutStorageAbstract
 {
     /**
      * @inheritDoc

--- a/models/classes/oauth/lockout/storage/LockoutStorageAbstract.php
+++ b/models/classes/oauth/lockout/storage/LockoutStorageAbstract.php
@@ -15,22 +15,35 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) (update and modification) Open Assessment Technologies SA (under the project TAO-PRODUCT)
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
 
 namespace oat\tao\model\oauth\lockout\storage;
 
-class KvLockoutStorage extends LockoutStorageAbstract
+use common_persistence_Persistence as Persistence;
+use oat\generis\persistence\PersistenceManager;
+use oat\oatbox\service\ConfigurableService;
+
+abstract class LockoutStorageAbstract extends ConfigurableService implements LockoutStorageInterface
 {
-    public function store(string $ip, int $ttl = 0)
+    /** @var Persistence */
+    private $persistence;
+
+    public function getPersistenceId(): string
     {
-        return true;
+        return $this->getOption(self::OPTION_PERSISTENCE);
     }
 
-    public function getFailedAttempts(string $ip, int $timeout): int
+    protected function getPersistence(): Persistence
     {
-        return 0;
+        if ($this->persistence === null) {
+            $this->persistence = $this->getServiceLocator()
+                ->get(PersistenceManager::SERVICE_ID)
+                ->getPersistenceById($this->getPersistenceId());
+        }
+
+        return $this->persistence;
     }
 }

--- a/models/classes/oauth/lockout/storage/LockoutStorageInterface.php
+++ b/models/classes/oauth/lockout/storage/LockoutStorageInterface.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace oat\tao\model\oauth\lockout\storage;
 
+use Exception;
+
 /**
  * Describe how should be implemented storage of failed OAuth sessions
  *
@@ -39,9 +41,9 @@ interface LockoutStorageInterface
      * @param string $ip Client IP address
      * @param int $ttl How long entry will be valid
      *
-     * @return mixed
+     * @throws Exception
      */
-    public function store(string $ip, int $ttl = 0);
+    public function store(string $ip, int $ttl = 0): void;
 
     /**
      * Returns amount of failed attempts for requested IP

--- a/models/classes/oauth/lockout/storage/RdsLockoutStorage.php
+++ b/models/classes/oauth/lockout/storage/RdsLockoutStorage.php
@@ -27,16 +27,16 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\Schema;
 use Exception;
-use oat\generis\persistence\PersistenceManager;
-use oat\oatbox\service\ConfigurableService;
 
 /**
  * Class RdsLockoutStorage
  *
- * @author Ivan Klimchuk <ivan@taotesting.com>
+ * @author  Ivan Klimchuk <ivan@taotesting.com>
  * @package oat\tao\model\oauth\lockout\storage
+ *
+ * @method SqlPersistence getPersistence()
  */
-class RdsLockoutStorage extends ConfigurableService implements LockoutStorageInterface
+class RdsLockoutStorage extends LockoutStorageAbstract
 {
     public const TABLE_NAME = 'oauth_lti_failures';
 
@@ -44,9 +44,6 @@ class RdsLockoutStorage extends ConfigurableService implements LockoutStorageInt
     public const FIELD_ADDRESS = 'address';
     public const FIELD_EXPIRE_AT = 'expire_at';
     public const FIELD_ATTEMPTS = 'attempts';
-
-    /** @var SqlPersistence */
-    private $persistence;
 
     /**
      * @param string $ip
@@ -152,14 +149,6 @@ class RdsLockoutStorage extends ConfigurableService implements LockoutStorageInt
     }
 
     /**
-     * @return string
-     */
-    public function getPersistenceId(): string
-    {
-        return $this->getOption(self::OPTION_PERSISTENCE);
-    }
-
-    /**
      * @param Schema $schema
      *
      * @return mixed
@@ -175,19 +164,5 @@ class RdsLockoutStorage extends ConfigurableService implements LockoutStorageInt
     protected function getQueryBuilder(): QueryBuilder
     {
         return $this->getPersistence()->getPlatForm()->getQueryBuilder();
-    }
-
-    /**
-     * @return SqlPersistence
-     */
-    protected function getPersistence()
-    {
-        if ($this->persistence === null) {
-            $this->persistence = $this->getServiceLocator()
-                ->get(PersistenceManager::SERVICE_ID)
-                ->getPersistenceById($this->getPersistenceId());
-        }
-
-        return $this->persistence;
     }
 }

--- a/models/classes/oauth/lockout/storage/RdsLockoutStorage.php
+++ b/models/classes/oauth/lockout/storage/RdsLockoutStorage.php
@@ -35,7 +35,7 @@ use Doctrine\DBAL\Schema\Schema;
  *
  * @method Persistence getPersistence()
  */
-final class RdsLockoutStorage extends LockoutStorageAbstract
+class RdsLockoutStorage extends LockoutStorageAbstract
 {
     public const TABLE_NAME = 'oauth_lti_failures';
 

--- a/scripts/install/SetUpOAuthLockoutService.php
+++ b/scripts/install/SetUpOAuthLockoutService.php
@@ -29,7 +29,6 @@ use oat\tao\model\oauth\lockout\IPLockout;
 use oat\tao\model\oauth\lockout\LockoutInterface;
 use oat\tao\model\oauth\lockout\NoLockout;
 use oat\tao\model\oauth\lockout\storage\KvLockoutStorage;
-use oat\tao\model\oauth\lockout\storage\LockoutStorageInterface;
 use oat\tao\model\oauth\lockout\storage\RdsLockoutStorage;
 use oat\tao\model\oauth\OauthService;
 
@@ -154,7 +153,7 @@ class SetUpOAuthLockoutService extends ScriptAction
         $options[IPLockout::OPTION_IP_FACTORY] = new IPFactory();
         switch ($this->getOption(self::OPT_STORAGE)) {
             case self::STORAGE_KV:
-                $options[IPLockout::OPTION_LOCKOUT_STORAGE] = new KvLockoutStorage();
+                $options[IPLockout::OPTION_LOCKOUT_STORAGE] = new KvLockoutStorage([RdsLockoutStorage::OPTION_PERSISTENCE => 'default_kv']);
                 break;
             case self::STORAGE_RDS:
                 $options[IPLockout::OPTION_LOCKOUT_STORAGE] = new RdsLockoutStorage([RdsLockoutStorage::OPTION_PERSISTENCE => 'default']);

--- a/scripts/install/SetUpOAuthLockoutService.php
+++ b/scripts/install/SetUpOAuthLockoutService.php
@@ -120,7 +120,7 @@ class SetUpOAuthLockoutService extends ScriptAction
                 ->get(OauthService::SERVICE_ID)
                 ->getSubService(OauthService::OPTION_LOCKOUT_SERVICE)
                 ->getSubService(IPLockout::OPTION_LOCKOUT_STORAGE);
-            if ($storageService instanceof LockoutStorageInterface) {
+            if ($storageService instanceof RdsLockoutStorage) {
                 $persistenceId = $storageService->getPersistenceId();
                 $persistence = $this->getServiceLocator()
                     ->get(PersistenceManager::SERVICE_ID)

--- a/scripts/install/SetUpOAuthLockoutService.php
+++ b/scripts/install/SetUpOAuthLockoutService.php
@@ -153,7 +153,7 @@ class SetUpOAuthLockoutService extends ScriptAction
         $options[IPLockout::OPTION_IP_FACTORY] = new IPFactory();
         switch ($this->getOption(self::OPT_STORAGE)) {
             case self::STORAGE_KV:
-                $options[IPLockout::OPTION_LOCKOUT_STORAGE] = new KvLockoutStorage([RdsLockoutStorage::OPTION_PERSISTENCE => 'default_kv']);
+                $options[IPLockout::OPTION_LOCKOUT_STORAGE] = new KvLockoutStorage([KvLockoutStorage::OPTION_PERSISTENCE => 'default_kv']);
                 break;
             case self::STORAGE_RDS:
                 $options[IPLockout::OPTION_LOCKOUT_STORAGE] = new RdsLockoutStorage([RdsLockoutStorage::OPTION_PERSISTENCE => 'default']);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1352,6 +1352,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('41.8.0');
         }
 
-        $this->skip('41.8.0', '41.10.1');
+        $this->skip('41.8.0', '41.11.0');
     }
 }

--- a/test/unit/oauth/lockout/IPLockoutTest.php
+++ b/test/unit/oauth/lockout/IPLockoutTest.php
@@ -7,6 +7,7 @@ use oat\oatbox\log\LoggerService;
 use oat\tao\model\oauth\lockout\IPFactory;
 use oat\tao\model\oauth\lockout\IPLockout;
 use oat\tao\model\oauth\lockout\storage\LockoutStorageInterface;
+use oat\tao\model\oauth\lockout\storage\RdsLockoutStorage;
 use oat\generis\test\MockObject;
 
 class IPLockoutTest extends TestCase
@@ -22,7 +23,7 @@ class IPLockoutTest extends TestCase
 
     public function setUp(): void
     {
-        $this->lockStorageMock = $this->createMock(LockoutStorageInterface::class);
+        $this->lockStorageMock = $this->createMock(RdsLockoutStorage::class);
 
         $ipFactoryMock = $this->createMock(IPFactory::class);
         $ipFactoryMock->method('create')->willReturn('127.0.0.1');

--- a/test/unit/oauth/lockout/IPLockoutTest.php
+++ b/test/unit/oauth/lockout/IPLockoutTest.php
@@ -7,7 +7,6 @@ use oat\oatbox\log\LoggerService;
 use oat\tao\model\oauth\lockout\IPFactory;
 use oat\tao\model\oauth\lockout\IPLockout;
 use oat\tao\model\oauth\lockout\storage\LockoutStorageInterface;
-use oat\tao\model\oauth\lockout\storage\RdsLockoutStorage;
 use oat\generis\test\MockObject;
 
 class IPLockoutTest extends TestCase
@@ -23,7 +22,7 @@ class IPLockoutTest extends TestCase
 
     public function setUp(): void
     {
-        $this->lockStorageMock = $this->createMock(RdsLockoutStorage::class);
+        $this->lockStorageMock = $this->createMock(LockoutStorageInterface::class);
 
         $ipFactoryMock = $this->createMock(IPFactory::class);
         $ipFactoryMock->method('create')->willReturn('127.0.0.1');


### PR DESCRIPTION
- NFER-66 fix(setup): run migrations during `OAuthLockoutService` installation only in case of `RdsLockoutStorage`
- NFER-66 chore: extract a lockout persistence layer location from a storage implementation into `LockoutStorageAbstract`
- NFER-66 chore: inject a key-value persistence ID into `KvLockoutStorage` during the service installation
- NFER-66 feat: implement `KvLockoutStorage`
- NFER-66 chore: change `LockoutStorageInterface::store()` return type to `void`
- NFER-66 chore(version): bump a minor one