### PR TITLE
BOSA-82: Last selected tree item doesn't retain focus after performing an action on it

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '41.11.1',
+    'version' => '41.11.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1352,6 +1352,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('41.8.0');
         }
 
-        $this->skip('41.8.0', '41.11.1');
+        $this->skip('41.8.0', '41.11.2');
     }
 }

--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -371,13 +371,13 @@ define([
                         var treeState       = $container.data('tree-state') || {};
                         var selectNode      = treeState.selectNode || options.selectNode;
                         var nodeSelection   = function nodeSelection() {
-                            //after refreshing tree previously node will be already selected.
-                            if(!selectNode && typeof tree.selected !== 'undefined') {
-                                return tree.selected;
-                            }
-
                             //the node to select is given
                             if (selectNodeById(selectNode, tree)) {
+                                return;
+                            }
+
+                            //after refreshing tree previously node will be already selected.
+                            if (tree.selected) {
                                 return;
                             }
 
@@ -392,8 +392,9 @@ define([
                             if ($firstInstance.length) {
                                 return tree.select_branch($firstInstance);
                             }
+
                             //or something
-                            return tree.select_branch($('.node-class,.node-instance', $container).get(0));
+                            tree.select_branch($('.node-class,.node-instance', $container).get(0));
                         };
 
                         if($firstClass.hasClass('leaf')){

--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -455,7 +455,7 @@ define([
                             signature: $node.data('signature')
                         };
 
-                        lastSelected = $node.attr('id');
+                        lastSelected = nodeId;
 
                         //mark all unselected
                         $('a.clicked', $container)

--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -331,7 +331,6 @@ define([
                      * Used to modify them before building the tree.
                      *
                      * @param {Object} data - the received data
-                     * @param {Object} tree - the tree instance
                      * @returns {Object} data the modified data
                      */
                     ondata: function ondata(data) {
@@ -391,7 +390,6 @@ define([
                             if(lastSelected){
                                 $lastSelected = $('#' +  lastSelected, $container);
                                 if($lastSelected.length && !$lastSelected.hasClass('private')){
-                                    lastSelected = null;
                                     return tree.select_branch($lastSelected);
                                 }
                             }
@@ -460,6 +458,8 @@ define([
                             rootClassUri:  options.rootClassUri,
                             signature: $node.data('signature')
                         };
+
+                        lastSelected = $node.attr('id');
 
                         //mark all unselected
                         $('a.clicked', $container)
@@ -591,9 +591,6 @@ define([
 
                         store('taotree').then(function(treeStore){
                             treeStore.getItem(context.section).then(function(node){
-                                if(node){
-                                    lastSelected = node;
-                                }
                                 //create the tree
                                 setTreeState({ loadNode: options.loadNode });
                                 $container.tree(treeOptions);

--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -445,12 +445,11 @@ define([
                      */
                     onselect: function onselect(node, tree) {
 
-                        var $node           = $(node);
+                        var $node        = $(node);
                         var classActions = [];
-                        var nodeId          = $node.attr('id');
-                        var nodeUri         = $node.data('uri');
-                        var $parentNode     = tree.parent($node);
-                        var nodeContext     =  {
+                        var nodeUri      = $node.data('uri');
+                        var $parentNode  = tree.parent($node);
+                        var nodeContext  =  {
                             rootClassUri:  options.rootClassUri,
                             signature: $node.data('signature')
                         };
@@ -460,7 +459,7 @@ define([
                         //mark all unselected
                         $('a.clicked', $container)
                             .parent('li')
-                            .not('[id="' + nodeId + '"]')
+                            .not('[id="' + lastSelected + '"]')
                             .removeClass('clicked');
 
                         //the more node makes you load more resources
@@ -474,7 +473,7 @@ define([
                             if ($node.hasClass('closed')) {
                                 tree.open_branch($node);
                             }
-                            nodeContext.classUri = nodeId;
+                            nodeContext.classUri = lastSelected;
                             nodeContext.classSignature = $node.data('signature');
                             nodeContext.id = nodeUri;
                             nodeContext.context = ['class', 'resource'];
@@ -489,7 +488,7 @@ define([
 
                         //exec the  selectInstance action
                         if ($node.hasClass('node-instance')){
-                            nodeContext.uri = nodeId;
+                            nodeContext.uri = lastSelected;
                             nodeContext.classUri = $parentNode.attr('id');
                             nodeContext.classSignature = $parentNode.data('signature');
                             nodeContext.id = nodeUri;
@@ -497,7 +496,7 @@ define([
 
                             //the last selected node is stored
                             store('taotree').then(function(treeStore){
-                                treeStore.setItem(context.section, nodeId).then(function(){
+                                treeStore.setItem(context.section, lastSelected).then(function(){
                                     generisRouter.pushNodeState(location.href, uri.decode(nodeContext.uri));
                                     executePossibleAction(options.actions, nodeContext, ['moveInstance', 'delete']);
                                 });

--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -445,11 +445,12 @@ define([
                      */
                     onselect: function onselect(node, tree) {
 
-                        var $node        = $(node);
+                        var $node           = $(node);
                         var classActions = [];
-                        var nodeUri      = $node.data('uri');
-                        var $parentNode  = tree.parent($node);
-                        var nodeContext  =  {
+                        var nodeId          = $node.attr('id');
+                        var nodeUri         = $node.data('uri');
+                        var $parentNode     = tree.parent($node);
+                        var nodeContext     =  {
                             rootClassUri:  options.rootClassUri,
                             signature: $node.data('signature')
                         };
@@ -459,7 +460,7 @@ define([
                         //mark all unselected
                         $('a.clicked', $container)
                             .parent('li')
-                            .not('[id="' + lastSelected + '"]')
+                            .not('[id="' + nodeId + '"]')
                             .removeClass('clicked');
 
                         //the more node makes you load more resources
@@ -473,7 +474,7 @@ define([
                             if ($node.hasClass('closed')) {
                                 tree.open_branch($node);
                             }
-                            nodeContext.classUri = lastSelected;
+                            nodeContext.classUri = nodeId;
                             nodeContext.classSignature = $node.data('signature');
                             nodeContext.id = nodeUri;
                             nodeContext.context = ['class', 'resource'];
@@ -488,7 +489,7 @@ define([
 
                         //exec the  selectInstance action
                         if ($node.hasClass('node-instance')){
-                            nodeContext.uri = lastSelected;
+                            nodeContext.uri = nodeId;
                             nodeContext.classUri = $parentNode.attr('id');
                             nodeContext.classSignature = $parentNode.data('signature');
                             nodeContext.id = nodeUri;
@@ -496,7 +497,7 @@ define([
 
                             //the last selected node is stored
                             store('taotree').then(function(treeStore){
-                                treeStore.setItem(context.section, lastSelected).then(function(){
+                                treeStore.setItem(context.section, nodeId).then(function(){
                                     generisRouter.pushNodeState(location.href, uri.decode(nodeContext.uri));
                                     executePossibleAction(options.actions, nodeContext, ['moveInstance', 'delete']);
                                 });

--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -366,33 +366,28 @@ define([
                      * @fires layout/tree#ready.taotree
                      */
                     onload: function onload(tree){
-
-                        var $lastSelected, $selectNode;
                         var $firstClass     = $(".node-class:not(.private):first", $container);
                         var $firstInstance  = $(".node-instance:not(.private):first", $container);
                         var treeState       = $container.data('tree-state') || {};
                         var selectNode      = treeState.selectNode || options.selectNode;
-                        var nodeSelection   = function nodeSelection(){
+                        var nodeSelection   = function nodeSelection() {
+                            //after refreshing tree previously node will be already selected.
+                            if(!selectNode && typeof tree.selected !== 'undefined') {
+                                return tree.selected;
+                            }
 
                             //the node to select is given
-                            if(selectNode){
-                                $selectNode = $('#' + selectNode, $container);
-                                if($selectNode.length && !$selectNode.hasClass('private')){
-                                    return tree.select_branch($selectNode);
-                                }
-                            } else if(typeof tree.selected !== 'undefined') {//after refreshing tree previously node will be already selected.
-                                return tree.selected;
+                            if (selectNodeById(selectNode, tree)) {
+                                return;
                             }
 
                             //if selectNode was not given and there is no selected node on the tree then try to find node to select:
 
                             //try to select the last one
-                            if(lastSelected){
-                                $lastSelected = $('#' +  lastSelected, $container);
-                                if($lastSelected.length && !$lastSelected.hasClass('private')){
-                                    return tree.select_branch($lastSelected);
-                                }
+                            if (selectNodeById(lastSelected, tree)) {
+                                return;
                             }
+
                             //or the 1st instance
                             if ($firstInstance.length) {
                                 return tree.select_branch($firstInstance);
@@ -827,6 +822,30 @@ define([
                     }
                 }
                 return treeData;
+            }
+
+            /**
+             * @param {String} id
+             * @param {Object} tree
+             *
+             * @returns {Boolean} Whether or not the selection succeed
+             */
+            function selectNodeById(id, tree) {
+                var $node;
+
+                if (!id) {
+                    return false;
+                }
+
+                $node = $('#' + id, $container);
+
+                if(!$node.length || $node.hasClass('private')){
+                    return false;
+                }
+
+                tree.select_branch($node);
+
+                return true;
             }
 
             return setUpTree();


### PR DESCRIPTION
- BOSA-82 fix(tree): retain `lastSelected` item identifier
- BOSA-82 chore(tree): extract repeating node selection by ID into a method
- BOSA-82 chore(tree): reorganize and simplify `jstree.init.treeOptions.callback.onload.nodeSelection()` method
- BOSA-82 chore(version): bump a fix version

One way to reproduce the issue is to open a list of Tests, select a not-selected-by-default-test and publish it. The focus will jump back to the selected-on-render item.
This PR fixes it, and retains the focus on an item, selected last.