### PR TITLE
UNO-195: Support unicode display name

### DIFF
--- a/helpers/class.Display.php
+++ b/helpers/class.Display.php
@@ -33,6 +33,7 @@ use oat\tao\model\service\ApplicationService;
  */
 class tao_helpers_Display
 {
+    private static $replacement = '_';
 
     /**
      * Enables you to cut a long string and end it with [...] and add an hover
@@ -43,21 +44,19 @@ class tao_helpers_Display
      * @param  int maxLength (optional, default = 75) The maximum length for the result string.
      * @return string The cut string, enclosed in a <span> html tag. This tag received the 'cutted' CSS class.
      */
-    public static function textCutter($input, $maxLength = 75)
+    public static function textCutter(string $input, int $maxLength = 75): string
     {
-        $encoding = self::getApplicationService()->getDefaultEncoding();
-        if (mb_strlen($input, $encoding) > $maxLength) {
-            $input = "<span title='$input' class='cutted' style='cursor:pointer;'>" . mb_substr($input, 0, $maxLength, $encoding) . "[...]</span>";
+        $encoding = self::getEncoding();
+
+        if (mb_strlen($input, $encoding) <= $maxLength) {
+            return $input;
         }
 
-        $returnValue = $input;
-
-        return (string) $returnValue;
+        return "<span title='$input' class='cutted' style='cursor:pointer;'>" . mb_substr($input, 0, $maxLength, $encoding) . '[...]</span>';
     }
 
     /**
-     * Clean a text with a joker character to replace any characters that is
-     * alphanumeric.
+     * Clean a text with a joker character to replace any characters that is not alphanumeric.
      *
      * @author Bertrand Chevrier, <bertrand.chevrier@tudor.lu>
      * @param  string input The string input.
@@ -65,31 +64,20 @@ class tao_helpers_Display
      * @param  int maxLength (optional, default = -1) output maximum length
      * @return string The result string.
      */
-    public static function textCleaner($input, $joker = '_', $maxLength = -1)
+    public static function textCleaner(string $input, string $joker = '_', int $maxLength = -1): string
     {
-        $returnValue = '';
-
-        $randJoker = ($joker == '*');
-        $length =  ((defined('TAO_DEFAULT_ENCODING')) ? mb_strlen($input, TAO_DEFAULT_ENCODING) : mb_strlen($input));
         if ($maxLength > -1) {
-            $length = min($length, $maxLength);
+            $input = mb_substr($input, 0, $maxLength, self::getEncoding());
         }
 
-        $i = 0;
-        while ($i < $length) {
-            if (preg_match("/^[a-zA-Z0-9_-]{1}$/u", $input[$i])) {
-                $returnValue .= $input[$i];
-            } else {
-                if ($input[$i] == ' ') {
-                    $returnValue .= '_';
-                } else {
-                    $returnValue .= ((true === $randJoker) ? chr(rand(97, 122)) : $joker);
-                }
-            }
-            $i++;
-        }
+        $patternMaps = [
+            '/\s+/u' => [self::class, 'replaceWithUnderscore'],
+            '/[^a-z0-9-_]+/ui' => [self::class, 'replace'],
+        ];
 
-        return (string) $returnValue;
+        self::$replacement = $joker;
+
+        return preg_replace_callback_array($patternMaps, $input);
     }
 
     /**
@@ -100,11 +88,9 @@ class tao_helpers_Display
      * @param  string input The input string.
      * @return string The htmlized string.
      */
-    public static function htmlize($input)
+    public static function htmlize(string $input): string
     {
-        $returnValue = htmlentities($input, ENT_COMPAT, self::getApplicationService()->getDefaultEncoding());
-
-        return (string) $returnValue;
+        return htmlentities($input, ENT_COMPAT, self::getEncoding());
     }
 
 
@@ -112,7 +98,7 @@ class tao_helpers_Display
     /**
      *  Convert special characters to HTML entities
      */
-    public static function htmlEscape($string)
+    public static function htmlEscape(string $string): string
     {
         return htmlspecialchars($string);
     }
@@ -123,7 +109,7 @@ class tao_helpers_Display
      * @param string $string
      * @return string
      */
-    public static function encodeAttrValue($string)
+    public static function encodeAttrValue(string $string): string
     {
         return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
     }
@@ -137,7 +123,7 @@ class tao_helpers_Display
      * @param string $input the input HTML
      * @return string the sanitized HTML
      */
-    public static function sanitizeXssHtml($input)
+    public static function sanitizeXssHtml(string $input): string
     {
         $config = HTMLPurifier_Config::createDefault();
 
@@ -153,11 +139,57 @@ class tao_helpers_Display
         return  $purifier->purify($input);
     }
 
-    /**
-     * @return ApplicationService
-     */
-    private static function getApplicationService()
+    /** @noinspection PhpUnusedPrivateMethodInspection */
+    private static function replace(array $matches): string
     {
+        return '*' === self::$replacement
+            ? self::replaceWithRandom($matches)
+            : self::replaceWith($matches, self::$replacement);
+    }
+
+    /** @noinspection PhpUnusedPrivateMethodInspection */
+    private static function replaceWithUnderscore(array $matches): string
+    {
+        return self::replaceWith($matches, '_');
+    }
+
+    private static function replaceWithRandom(array $matches): string
+    {
+        $result = [];
+
+        $length = mb_strlen(reset($matches), self::getEncoding());
+
+        for ($i = 0; $i < $length; $i++) {
+            /** @noinspection RandomApiMigrationInspection */
+            $result[] = chr(mt_rand(97, 122));
+        }
+
+        return implode('', $result);
+    }
+
+    private static function replaceWith(array $matches, string $replacement): string
+    {
+        return str_repeat($replacement, mb_strlen(reset($matches), self::getEncoding()));
+    }
+
+    private static function getEncoding(): string
+    {
+        static $encoding;
+
+        if (null === $encoding) {
+            try {
+                $encoding = self::getApplicationService()->getDefaultEncoding();
+            } catch (common_Exception $exception) {
+                $encoding = mb_internal_encoding();
+            }
+        }
+
+        return $encoding;
+    }
+
+    private static function getApplicationService(): ApplicationService
+    {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return ServiceManager::getServiceManager()->get(ApplicationService::SERVICE_ID);
     }
 }

--- a/helpers/class.Display.php
+++ b/helpers/class.Display.php
@@ -44,7 +44,7 @@ class tao_helpers_Display
      * @param  int maxLength (optional, default = 75) The maximum length for the result string.
      * @return string The cut string, enclosed in a <span> html tag. This tag received the 'cutted' CSS class.
      */
-    public static function textCutter(string $input, int $maxLength = 75): string
+    public static function textCutter($input, int $maxLength = 75): string
     {
         $encoding = self::getEncoding();
 
@@ -64,7 +64,7 @@ class tao_helpers_Display
      * @param  int maxLength (optional, default = -1) output maximum length
      * @return string The result string.
      */
-    public static function textCleaner(string $input, string $joker = '_', int $maxLength = -1): string
+    public static function textCleaner($input, string $joker = '_', int $maxLength = -1): string
     {
         $encoding = self::getEncoding();
 
@@ -94,7 +94,7 @@ class tao_helpers_Display
      * @param  string input The input string.
      * @return string The htmlized string.
      */
-    public static function htmlize(string $input): string
+    public static function htmlize($input): string
     {
         return htmlentities($input, ENT_COMPAT, self::getEncoding());
     }
@@ -104,7 +104,7 @@ class tao_helpers_Display
     /**
      *  Convert special characters to HTML entities
      */
-    public static function htmlEscape(string $string): string
+    public static function htmlEscape($string): string
     {
         return htmlspecialchars($string);
     }
@@ -115,7 +115,7 @@ class tao_helpers_Display
      * @param string $string
      * @return string
      */
-    public static function encodeAttrValue(string $string): string
+    public static function encodeAttrValue($string): string
     {
         return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
     }
@@ -129,7 +129,7 @@ class tao_helpers_Display
      * @param string $input the input HTML
      * @return string the sanitized HTML
      */
-    public static function sanitizeXssHtml(string $input): string
+    public static function sanitizeXssHtml($input): string
     {
         $config = HTMLPurifier_Config::createDefault();
 

--- a/helpers/class.Display.php
+++ b/helpers/class.Display.php
@@ -66,13 +66,19 @@ class tao_helpers_Display
      */
     public static function textCleaner(string $input, string $joker = '_', int $maxLength = -1): string
     {
+        $encoding = self::getEncoding();
+
         if ($maxLength > -1) {
-            $input = mb_substr($input, 0, $maxLength, self::getEncoding());
+            $input = mb_substr($input, 0, $maxLength, $encoding);
         }
 
+        $replacingPattern = strpos($encoding, 'UTF') === 0
+            ? '/[^\p{L}0-9-_]+/u'
+            : '/[^a-z0-9-_]+/ui';
+
         $patternMaps = [
-            '/\s+/u' => [self::class, 'replaceWithUnderscore'],
-            '/[^a-z0-9-_]+/ui' => [self::class, 'replace'],
+            '/\s+/u'          => [self::class, 'replaceWithUnderscore'],
+            $replacingPattern => [self::class, 'replace'],
         ];
 
         self::$replacement = $joker;

--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '42.0.2',
+    'version' => '42.0.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.19.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -22,7 +22,6 @@
 
 namespace oat\tao\scripts\update;
 
-use common_cache_Cache;
 use common_Exception;
 use common_report_Report as Report;
 use core_kernel_persistence_smoothsql_SmoothModel;
@@ -78,19 +77,16 @@ use oat\tao\model\notification\implementation\NotificationServiceAggregator;
 use oat\tao\model\notification\implementation\RdsNotification;
 use oat\tao\model\notification\NotificationServiceInterface;
 use oat\tao\model\oauth\DataStore;
+use oat\tao\model\oauth\lockout\NoLockout;
 use oat\tao\model\oauth\nonce\NoNonce;
 use oat\tao\model\oauth\OauthService;
 use oat\tao\model\OperatedByService;
-use oat\tao\model\resources\GetAllChildrenCacheKeyFactory;
 use oat\tao\model\resources\ListResourceLookup;
 use oat\tao\model\resources\ResourceService;
-use oat\tao\model\oauth\lockout\NoLockout;
 use oat\tao\model\resources\ResourceWatcher;
-use oat\tao\model\resources\SecureResourceCachedService;
 use oat\tao\model\resources\SecureResourceService;
 use oat\tao\model\resources\SecureResourceServiceInterface;
 use oat\tao\model\resources\TreeResourceLookup;
-use oat\tao\model\resources\ValidatePermissionsCacheKeyFactory;
 use oat\tao\model\routing\AnnotationReaderService;
 use oat\tao\model\routing\ControllerService;
 use oat\tao\model\routing\RouteAnnotationService;
@@ -1352,6 +1348,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('41.8.0');
         }
 
-        $this->skip('41.8.0', '42.0.2');
+        $this->skip('41.8.0', '42.0.3');
     }
 }

--- a/test/unit/DisplayHelperTest.php
+++ b/test/unit/DisplayHelperTest.php
@@ -19,37 +19,68 @@
  *
  */
 
+declare(strict_types=1);
+
 /**
  * PHPUnit test of the {@link tao_helpers_Duration} helper
+ *
  * @package tao
-
  */
+
 use oat\generis\test\TestCase;
+use oat\oatbox\service\ServiceManager;
+use oat\tao\model\service\ApplicationService;
 
 class DisplayHelperTest extends TestCase
 {
-    
+    private $defaultEncoding = 'UTF-8';
+
+    /**
+     * @before
+     * @noinspection PhpUnhandledExceptionInspection
+     */
+    protected function init(): void
+    {
+        $config = new common_persistence_KeyValuePersistence([], new common_persistence_InMemoryKvDriver());
+        $config->set(ApplicationService::SERVICE_ID, $this->createApplicationServiceMock());
+
+        ServiceManager::setServiceManager(new ServiceManager($config));
+    }
+
     /**
      * Data provider for the testTimetoDuration method
+     *
      * @return array[] the parameters
      */
-    public function stringToCleanProvider()
+    public function stringToCleanProvider(): array
     {
         return [
-            ['This is a simple text',          '_', -1, 'This_is_a_simple_text'],
-            ['This is a simple text',          '-', 10, 'This_is_a_'],
-            ['@à|`',                           '-', -1, '----'],
-            ['@à|`',                           '-',  2, '--'],
-            ['This 4s @ \'stronger\' tèxte',   '',  -1, 'This_4s__stronger_txt']
+            ['This is a simple text', '_', -1, 'This_is_a_simple_text'],
+            ['This is a simple text', '-', 10, 'This_is_a_'],
+            ['@à|`', '-', -1, '----'],
+            ['@à|`', '-', 2, '--'],
+            ['This 4s @ \'stronger\' tèxte', '', -1, 'This_4s__stronger_txte'],
         ];
     }
-    
+
     /**
      * Test {@link tao_helpers_Display::}
+     *
      * @dataProvider stringToCleanProvider
      */
-    public function testCleaner($input, $joker, $maxLength, $output)
+    public function testCleaner(string $input, string $joker, int $maxLength, string $expected): void
     {
-        $this->assertEquals(tao_helpers_Display::textCleaner($input, $joker, $maxLength), $output);
+        $this->assertEquals($expected, tao_helpers_Display::textCleaner($input, $joker, $maxLength));
+    }
+
+    private function createApplicationServiceMock(): ApplicationService
+    {
+        $applicationServiceMock = $this->createMock(ApplicationService::class);
+
+        $applicationServiceMock
+            ->method('getDefaultEncoding')
+            ->willReturn($this->defaultEncoding);
+
+        return $applicationServiceMock;
     }
 }

--- a/test/unit/DisplayHelperTest.php
+++ b/test/unit/DisplayHelperTest.php
@@ -57,9 +57,9 @@ class DisplayHelperTest extends TestCase
         return [
             ['This is a simple text', '_', -1, 'This_is_a_simple_text'],
             ['This is a simple text', '-', 10, 'This_is_a_'],
-            ['@à|`', '-', -1, '----'],
-            ['@à|`', '-', 2, '--'],
-            ['This 4s @ \'stronger\' tèxte', '', -1, 'This_4s__stronger_txte'],
+            ['@à|`', '-', -1, '-à--'],
+            ['@à|`', '-', 2, '-à'],
+            ['This 4s @ \'stronger\' tèxte', '', -1, 'This_4s__stronger_tèxte'],
         ];
     }
 


### PR DESCRIPTION
- UNO-195 fix(sanitization): respect unicode string length in `tao_helpers_Display::textCleaner()` method
- UNO-195 feat(sanitization): allow unicode characters for `UTF*` encodings in `tao_helpers_Display::textCleaner()` method
- UNO-195 chore(version): bump a fix one

One way to reproduce the issue is to try and export any item/test/delivery with a multibyte unicode symbol in its label. The suggested file name name would be distorted.