### PR TITLE
UNO-205: Allow variadic arguments in InjectionAwareService implementations

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '42.0.5',
+    'version' => '42.1.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.19.0',

--- a/models/classes/service/InjectionAwareService.php
+++ b/models/classes/service/InjectionAwareService.php
@@ -113,7 +113,7 @@ FACTORY;
 
             $parameter->isVariadic()
                 ? yield from $value
-                : yield;
+                : yield $value;
         }
     }
 

--- a/models/classes/service/InjectionAwareService.php
+++ b/models/classes/service/InjectionAwareService.php
@@ -21,7 +21,6 @@
 namespace oat\tao\model\service;
 
 use common_Utils;
-use oat\oatbox\Configurable;
 use oat\oatbox\service\ConfigurableService;
 use ReflectionClass;
 use ReflectionException;
@@ -31,6 +30,12 @@ abstract class InjectionAwareService extends ConfigurableService
 {
     /** @var bool */
     private $isChildItem = false;
+
+    // to skip checking parent's constructor parameters inherited from Configurable::class
+    public function __construct()
+    {
+        parent::__construct([]);
+    }
 
     /**
      * @noinspection MagicMethodsValidityInspection
@@ -82,11 +87,6 @@ FACTORY;
     {
         $class = new ReflectionClass($service);
         $constructor = $class->getMethod('__construct');
-
-        // do not check parent constructor inherited from Configurable::class
-        if ($constructor->class === Configurable::class) {
-            return;
-        }
 
         $parameters = $constructor->getParameters();
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1343,6 +1343,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('42.0.4');
         }
 
-        $this->skip('42.0.4', '42.0.5');
+        $this->skip('42.0.4', '42.1.0');
     }
 }

--- a/test/unit/models/classes/service/InjectionAwareServiceTest.php
+++ b/test/unit/models/classes/service/InjectionAwareServiceTest.php
@@ -31,6 +31,10 @@ namespace oat\tao\model\service;
 use oat\generis\test\TestCase;
 use oat\oatbox\service\ConfigurableService;
 
+class EmptyConstructorInjectionAwareService extends InjectionAwareService
+{
+}
+
 class PureInjectionAwareService extends InjectionAwareService
 {
     private $var;
@@ -38,6 +42,18 @@ class PureInjectionAwareService extends InjectionAwareService
     public function __construct(string $var)
     {
         $this->var = $var;
+    }
+}
+
+class InjectionAwareServiceWithVariadicParameters extends InjectionAwareService
+{
+    private $strings;
+    private $int;
+
+    public function __construct(int $int, string ...$strings)
+    {
+        $this->strings = $strings;
+        $this->int = $int;
     }
 }
 
@@ -225,6 +241,29 @@ new class implements \oat\oatbox\service\ServiceFactoryInterface {
     }
 }
 EXPECTED;
+        $this->assertEquals($expected, $instance->__toPhpCode());
+    }
+
+    public function testEmptyConstructor(): void
+    {
+        $instance = new EmptyConstructorInjectionAwareService();
+
+        $expected = 'new oat\tao\model\service\EmptyConstructorInjectionAwareService()';
+
+        $this->assertEquals($expected, $instance->__toPhpCode());
+    }
+
+    public function testConstructorWithVariadicParameters(): void
+    {
+        $instance = new InjectionAwareServiceWithVariadicParameters(10, 'one', 'two', 'tree');
+
+        $expected = <<<'EXPECTED'
+new oat\tao\model\service\InjectionAwareServiceWithVariadicParameters(10,
+'one',
+'two',
+'tree')
+EXPECTED;
+
         $this->assertEquals($expected, $instance->__toPhpCode());
     }
 }


### PR DESCRIPTION
skip checking parent constructor inherited from Configurable
added support of variadic parameters