### PR TITLE
UNO-229: Add alias to schema form

### DIFF
--- a/actions/form/class.SimpleProperty.php
+++ b/actions/form/class.SimpleProperty.php
@@ -46,25 +46,27 @@ class tao_actions_form_SimpleProperty extends tao_actions_form_AbstractProperty
      */
     protected function initElements()
     {
-        
+
         $property = $this->getPropertyInstance();
 
         $index = $this->getIndex();
 
         $propertyProperties = array_merge(
             tao_helpers_form_GenerisFormFactory::getDefaultProperties(),
-            [new core_kernel_classes_Property(GenerisRdf::PROPERTY_IS_LG_DEPENDENT),
+            [
+                new core_kernel_classes_Property(GenerisRdf::PROPERTY_ALIAS),
+                new core_kernel_classes_Property(GenerisRdf::PROPERTY_IS_LG_DEPENDENT),
                 new core_kernel_classes_Property(TaoOntology::PROPERTY_GUI_ORDER),
                 $this->getProperty(ValidationRuleRegistry::PROPERTY_VALIDATION_RULE)
             ]
         );
         $values = $property->getPropertiesValues($propertyProperties);
-        
+
         $elementNames = [];
         foreach ($propertyProperties as $propertyProperty) {
             //map properties widgets to form elements
             $element = tao_helpers_form_GenerisFormFactory::elementMap($propertyProperty);
-            
+
             if (!is_null($element)) {
                 //take property values to populate the form
                 if (isset($values[$propertyProperty->getUri()])) {
@@ -93,7 +95,7 @@ class tao_actions_form_SimpleProperty extends tao_actions_form_AbstractProperty
                 $elementNames[] = $element->getName();
             }
         }
-        
+
         //build the type list from the "widget/range to type" map
         $typeElt = tao_helpers_form_FormFactory::getElement("{$index}_type", 'Combobox');
         $typeElt->setDescription(__('Type'));
@@ -140,7 +142,7 @@ class tao_actions_form_SimpleProperty extends tao_actions_form_AbstractProperty
         $elementNames[] = $treeElt->getName();
 
         //index part
-        $indexes = $property->getPropertyValues(new \core_kernel_classes_Property(OntologyIndex::PROPERTY_INDEX));
+        $indexes = $property->getPropertyValues(new core_kernel_classes_Property(OntologyIndex::PROPERTY_INDEX));
         foreach ($indexes as $i => $indexUri) {
             $indexProperty = new OntologyIndex($indexUri);
             $indexFormContainer = new tao_actions_form_IndexProperty($indexProperty, $index . $i);

--- a/manifest.php
+++ b/manifest.php
@@ -56,10 +56,10 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '42.5.0',
+    'version' => '42.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
-        'generis' => '>=12.19.0',
+        'generis' => '>=12.21.0',
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAO.rdf',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1343,6 +1343,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('42.0.4');
         }
 
-        $this->skip('42.0.4', '42.5.0');
+        $this->skip('42.0.4', '42.6.0');
     }
 }


### PR DESCRIPTION
Requires [`generis`](https://github.com/oat-sa/generis/pull/784).
This PR doesn't do much, except for adding the `Alias` property to schema management form, and required for [`taoDeliverConnect`](https://github.com/oat-sa/extension-tao-deliver-connect/pull/58).

- [UNO-229](https://oat-sa.atlassian.net/browse/UNO-229) feature: add `GenerisRdf::PROPERTY_ALIAS` to the schema form
- [UNO-229](https://oat-sa.atlassian.net/browse/UNO-229) chore(dependency): depend on `generis` `12.21.0`, which introduced `GenerisRdf::PROPERTY_ALIAS`