### PR TITLE
Feature/uno 267/enable oauth for pasp event

### DIFF
--- a/actions/class.RestController.php
+++ b/actions/class.RestController.php
@@ -20,9 +20,10 @@
  */
 
 use oat\generis\model\OntologyAwareTrait;
+use oat\tao\model\action\RestControllerInterface;
 use oat\tao\model\routing\AnnotationReader\security;
 
-abstract class tao_actions_RestController extends \tao_actions_CommonModule
+abstract class tao_actions_RestController extends \tao_actions_CommonModule implements RestControllerInterface
 {
     use OntologyAwareTrait;
     use \tao_actions_RestTrait;

--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '42.7.1',
+    'version' => '42.8.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.21.0',

--- a/models/classes/action/RestControllerInterface.php
+++ b/models/classes/action/RestControllerInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\action;
+
+interface RestControllerInterface
+{
+
+}

--- a/models/classes/routing/ActionEnforcer.php
+++ b/models/classes/routing/ActionEnforcer.php
@@ -25,9 +25,7 @@ namespace oat\tao\model\routing;
 use Context;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
-
 use ReflectionException;
-
 use IExecutable;
 use ActionEnforcingException;
 use oat\tao\model\http\ResponseEmitter;
@@ -104,7 +102,9 @@ class ActionEnforcer implements IExecutable, ServiceManagerAwareInterface, TaoLo
         if (!class_exists($controllerClass)) {
             throw new ActionEnforcingException('Controller "' . $controllerClass . '" could not be loaded.', $controllerClass, $this->getAction());
         }
-        $controller = new $controllerClass();
+
+        $controller = $this->getClassInstance($controllerClass);
+
         $this->propagate($controller);
         if ($controller instanceof Controller) {
             $controller->setRequest($this->getRequest());

--- a/models/classes/routing/ActionEnforcer.php
+++ b/models/classes/routing/ActionEnforcer.php
@@ -22,10 +22,11 @@
 
 namespace oat\tao\model\routing;
 
+use Context;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
 
-use function GuzzleHttp\Psr7\stream_for;
+use ReflectionException;
 
 use IExecutable;
 use ActionEnforcingException;
@@ -115,6 +116,17 @@ class ActionEnforcer implements IExecutable, ServiceManagerAwareInterface, TaoLo
         return $controller;
     }
 
+    private function getClassInstance(string $className): object
+    {
+        $serviceId = defined("$className::SERVICE_ID")
+            ? $className::SERVICE_ID
+            : $className;
+
+        return $this->getServiceLocator()->has($serviceId)
+            ? $this->getServiceLocator()->get($serviceId)
+            : new $className;
+    }
+
     protected function getRequest()
     {
         if (!$this->request) {
@@ -165,7 +177,7 @@ class ActionEnforcer implements IExecutable, ServiceManagerAwareInterface, TaoLo
 
     /**
      * @throws ActionEnforcingException
-     * @throws \ReflectionException
+     * @throws ReflectionException
      * @throws \common_exception_Error
      * @throws \common_exception_MissingParameter
      * @throws tao_models_classes_AccessDeniedException
@@ -177,7 +189,7 @@ class ActionEnforcer implements IExecutable, ServiceManagerAwareInterface, TaoLo
             $this->verifyAuthorization();
         } catch (PermissionException $pe) {
             //forward the action (yes it's an awful hack, but far better than adding a step in Bootstrap's dispatch error).
-            \Context::getInstance()->setExtensionName('tao');
+            Context::getInstance()->setExtensionName('tao');
             $this->action       = 'denied';
             $this->controllerClass   = 'tao_actions_Permission';
             $this->extension    = 'tao';
@@ -193,7 +205,7 @@ class ActionEnforcer implements IExecutable, ServiceManagerAwareInterface, TaoLo
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      * @throws ActionEnforcingException
-     * @throws \ReflectionException
+     * @throws ReflectionException
      * @throws \common_exception_Error
      */
     public function resolve(ServerRequestInterface $request)
@@ -219,18 +231,7 @@ class ActionEnforcer implements IExecutable, ServiceManagerAwareInterface, TaoLo
             );
         }
 
-        // search parameters method
-        $reflect    = new ReflectionMethod($controller, $action);
-        $parameters = $this->getParameters();
-
-        $tabParam   = [];
-        foreach ($reflect->getParameters() as $param) {
-            if (isset($parameters[$param->getName()])) {
-                $tabParam[$param->getName()] = $parameters[$param->getName()];
-            } elseif (!$param->isDefaultValueAvailable()) {
-                $this->logWarning('Missing parameter ' . $param->getName() . ' for ' . $this->getControllerClass() . '@' . $action);
-            }
-        }
+        $actionParameters = $this->resolveParameters($request, $controller, $action);
 
         // Action method is invoked, passing request parameters as method parameters.
         $user = common_session_SessionManager::getSession()->getUser();
@@ -239,8 +240,42 @@ class ActionEnforcer implements IExecutable, ServiceManagerAwareInterface, TaoLo
         $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
         $eventManager->trigger(new BeforeAction());
 
-        $response = call_user_func_array([$controller, $action], $tabParam);
+        $response = call_user_func_array([$controller, $action], $actionParameters);
 
         return $response instanceof ResponseInterface ? $response : $controller->getPsrResponse();
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param                        $controller
+     * @param string                 $action
+     *
+     * @return array
+     * @throws ReflectionException
+     */
+    private function resolveParameters(ServerRequestInterface $request, $controller, string $action): array
+    {
+        // search parameters method
+        $reflect    = new ReflectionMethod($controller, $action);
+        $parameters = $this->getParameters();
+
+        $actionParameters   = [];
+        foreach ($reflect->getParameters() as $param) {
+            $paramName = $param->getName();
+            $paramType = $param->getType();
+            $paramTypeName = $paramType !== null ? $paramType->getName() : null;
+
+            if (isset($parameters[$paramName])) {
+                $actionParameters[$paramName] = $parameters[$paramName];
+            } elseif($paramTypeName === ServerRequest::class) {
+                $actionParameters[$paramName] = $request;
+            } elseif (class_exists($paramTypeName)) {
+                $actionParameters[$paramName] = $this->getClassInstance($paramTypeName);
+            } elseif (!$param->isDefaultValueAvailable()) {
+                $this->logWarning('Missing parameter ' . $paramName . ' for ' . $this->getControllerClass() . '@' . $action);
+            }
+        }
+
+        return $actionParameters;
     }
 }

--- a/models/classes/session/restSessionFactory/RestSessionFactory.php
+++ b/models/classes/session/restSessionFactory/RestSessionFactory.php
@@ -21,9 +21,13 @@
 
 namespace oat\tao\model\session\restSessionFactory;
 
+use common_exception_InconsistentData;
+use common_ext_ManifestNotFoundException;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\user\LoginFailedException;
+use oat\tao\model\action\RestControllerInterface;
 use oat\tao\model\routing\Resolver;
+use ResolverException;
 
 /**
  * Class RestSessionFactory
@@ -95,10 +99,14 @@ class RestSessionFactory extends ConfigurableService
      * Check if the requested controller is a RestController
      *
      * @param Resolver $resolver
+     *
      * @return bool
+     * @throws ResolverException
+     * @throws common_exception_InconsistentData
+     * @throws common_ext_ManifestNotFoundException
      */
-    protected function isRestController(Resolver $resolver)
+    protected function isRestController(Resolver $resolver): bool
     {
-        return is_subclass_of($resolver->getControllerClass(), \tao_actions_RestController::class);
+        return is_subclass_of($resolver->getControllerClass(), RestControllerInterface::class, true);
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1343,6 +1343,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('42.0.4');
         }
 
-        $this->skip('42.0.4', '42.7.1');
+        $this->skip('42.0.4', '42.8.0');
     }
 }

--- a/test/unit/session/RestSessionFactoryTest.php
+++ b/test/unit/session/RestSessionFactoryTest.php
@@ -176,7 +176,7 @@ class SubTestRest extends TestRest
 
 class RestSessionFactoryTester extends RestSessionFactory
 {
-    public function isRestController(Resolver $resolver)
+    public function isRestController(Resolver $resolver): bool
     {
         return parent::isRestController($resolver);
     }


### PR DESCRIPTION
This improvement allows using controllers as services.

Improvements:
1. Added an attempt to fetch service from the service locator
2. Is not mandatory to extend controllers from tao_actions_RestController or any other so a controller can be a `ConfigureableService` or `InjectionAwareService` or any other
3. Action parameters resolving using the service locator
4. To use facilities of Rest controllers `\oat\tao\model\action\RestControllerInterface` implemented
5. Controllers are more unittestable.
6. You can pass a Request as a parameter by just specifying it.

example of the controller

```php
class Controller implements RestControllerInterface
{
    public function event(
        ServerRequest $request,
        NotificationService $notificationService,
        LoggerService $logger
    ): Response {
        $notificationService->notify();
        $logger->debug('debug');

        return new Response(202);
    }
```

If you want to use a constructor you need to register controller as a service and then

```php
class Controller extends InjectionAwareService implements RestControllerInterface
{
    public const SERVICE_ID = 'tmp/controller';

    /** @var SessionService */
    private $sessionService;

    public function __construct(SessionService $sessionService)
    {
        $this->sessionService = $sessionService;
    }

    public function event(
        ServerRequest $request,
        NotificationService $notificationService,
        LoggerService $logger
    ): Response {
        $notificationService->notify();
        $logger->debug($this->sessionService->getCurrentUser()->getIdentifier());

        return new Response(202);
    }
```