### PR TITLE
Fix deprecated in cleanup

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '42.7.2',
+    'version' => '42.7.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.21.0',

--- a/scripts/tools/CleanClass.php
+++ b/scripts/tools/CleanClass.php
@@ -22,6 +22,7 @@
 namespace oat\tao\scripts\tools;
 
 use oat\oatbox\extension\AbstractAction;
+use oat\tao\model\OntologyClassService;
 
 /**
  * This post-installation script creates a new local file source for services
@@ -81,7 +82,7 @@ class CleanClass extends AbstractAction
 
         if (isset($params[0])) {
             $serviceName = $params[0];
-            if (is_a($serviceName, \tao_models_classes_ClassService::class, true)) {
+            if (is_a($serviceName, OntologyClassService::class, true)) {
                 $this->service = call_user_func([$serviceName, 'singleton'], []);
             } else {
                 return new \common_report_Report(\common_report_Report::TYPE_ERROR, __('USAGE: please provide a valid service name as first parameter'));

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1343,6 +1343,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('42.0.4');
         }
 
-        $this->skip('42.0.4', '42.7.2');
+        $this->skip('42.0.4', '42.7.3');
     }
 }


### PR DESCRIPTION
Related to: BSA-119
Fixed deprecated class in cleanup script
How to test(example): `php index.php  '\oat\tao\scripts\tools\CleanClass' 'taoItems_models_classes_ItemsService' 'taoItems' 'http://sample/bosa.rdf#i5e284568c573919336809f37f03c7c0c9'`
