### PR TITLE
Fix/UNO-235/config copy remove plugins

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -56,7 +56,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '42.10.1',
+    'version' => '42.10.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.21.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1343,6 +1343,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('42.0.4');
         }
 
-        $this->skip('42.0.4', '42.10.1');
+        $this->skip('42.0.4', '42.10.2');
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,9 +39,9 @@
             "integrity": "sha512-tE8KCTS/zVcmUomg/dFjHVjinpbu8w1/tx5XJD0w4pNjQ7BJduLL3rQr/Twz8c/KKv232LpxwLxv+T8A5jIDMg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.1.1.tgz",
-            "integrity": "sha512-/HoE9g/6wjVrNhXful533cLr7yvea9OE6bunOzlv49pKNhgp47Dt3elKcb4rCPz+wUcZoeAdeJudhS2sxYN3Yw=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.1.2.tgz",
+            "integrity": "sha512-fn4n9tauPGOgLNUBLP14KxJddLH8raufM/n9YtSTzMBbThNz8PnPF/ff8+GC5PPIxH2v3WKYumoVs5OyZSnx0g=="
         },
         "amdefine": {
             "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^0.4.2",
         "@oat-sa/tao-core-sdk": "1.3.0",
         "@oat-sa/tao-core-shared-libs": "^0.1.0",
-        "@oat-sa/tao-core-ui": "^1.1.1",
+        "@oat-sa/tao-core-ui": "^1.1.2",
         "async": "0.2.10",
         "decimal.js": "10.1.1",
         "dompurify": "1.0.11",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/UNO-235

Fixed: copy options.removePlugins to CKEditor config
update "@oat-sa/tao-core-ui": "^1.1.2"
Related to: https://github.com/oat-sa/tao-core-ui-fe/pull/129