### PR TITLE
BSA 144 - Fix missing translations

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -57,7 +57,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '42.12.0',
+    'version' => '42.12.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.21.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1361,6 +1361,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('42.11.0');
         }
 
-        $this->skip('42.11.0', '42.12.0');
+        $this->skip('42.11.0', '42.12.1');
     }
 }

--- a/test/unit/http/formatter/ResponseFormatterTest.php
+++ b/test/unit/http/formatter/ResponseFormatterTest.php
@@ -20,8 +20,8 @@
 
 namespace oat\tao\test\unit\http;
 
+use DateTime;
 use GuzzleHttp\Psr7\Response;
-use oat\dtms\DateTime;
 use oat\generis\test\TestCase;
 use oat\tao\model\http\formatter\ResponseFormatter;
 use oat\tao\model\http\response\SuccessJsonResponse;

--- a/views/templates/blocks/header-main-navi.tpl
+++ b/views/templates/blocks/header-main-navi.tpl
@@ -72,7 +72,7 @@ $userLabel    = get_data('userLabel');
                                     <?php foreach ($item['children'] as $child): ?>
                                         <?php if(!$child->getDisabled()) : ?>
                                             <li<?=$child->getId() === get_data('current-section') ? ' class="active"' : '' ?>>
-                                                <a href="<?= $entry->getUrl() ?>&section=<?= $child->getId() ?>"><?php echo $child->getName() ?></a>
+                                                <a href="<?= $entry->getUrl() ?>&section=<?= $child->getId() ?>"><?php echo __($child->getName()) ?></a>
                                             </li>
                                         <?php endif; ?>
                                     <?php endforeach; ?>


### PR DESCRIPTION
**Related to**

https://oat-sa.atlassian.net/browse/BSA-144

**Title**

Items in drop-down menus are not translated

**Description**

As a user.
I want drop-down menus to be translated.
So I can better understand the meaning of menu items.

Translations are mostly present, but still, all items are in English

![imagen](https://user-images.githubusercontent.com/34692207/83856460-e4086d80-a719-11ea-99c4-33c7a64b1208.png)
![imagen](https://user-images.githubusercontent.com/34692207/83856480-ec60a880-a719-11ea-8228-63f849747d9e.png)
![imagen](https://user-images.githubusercontent.com/34692207/83856486-ef5b9900-a719-11ea-8685-0ba3b655ab2a.png)




**Acceptance criteria**

The menus shown in the attached images have translated values