### PR TITLE
Fix NEX-1191 don't show error if HEAD request failed because of CORS

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -57,7 +57,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '42.12.2',
+    'version' => '42.12.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.21.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -1361,6 +1361,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('42.11.0');
         }
 
-        $this->skip('42.11.0', '42.12.2');
+        $this->skip('42.11.0', '42.12.3');
     }
 }

--- a/views/js/controller/backoffice.js
+++ b/views/js/controller/backoffice.js
@@ -20,7 +20,16 @@
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
 define([
-    'jquery', 'lodash', 'i18n', 'context', 'helpers', 'core/router', 'uikitLoader', 'core/history', 'ui/feedback', 'layout/logout-event'
+    'jquery',
+    'lodash',
+    'i18n',
+    'context',
+    'helpers',
+    'core/router',
+    'uikitLoader',
+    'core/history',
+    'ui/feedback',
+    'layout/logout-event'
 ], function ($, _, __, context, helpers, router, uikitLoader, history, feedback, logoutEvent) {
     'use strict';
 
@@ -29,12 +38,10 @@ define([
      * Starts the ajax based router, the automated error reporting and the UI listeners.
      */
     return {
-
         /**
          * Controller entry point
          */
-        start: function start(){
-
+        start: function start() {
             var $doc = $(document);
             var $container = $('body > .content-wrap');
 
@@ -42,17 +49,17 @@ define([
             history.fixBrokenBrowsers();
 
             //contextual loading, do a dispatch each time an ajax request loads an HTML page
-            $doc.ajaxComplete(function(event, request, settings){
+            $doc.ajaxComplete(function (event, request, settings) {
                 var urls;
                 var forward;
-                if(_.contains(settings.dataTypes, 'html')){
+                if (_.contains(settings.dataTypes, 'html')) {
                     urls = [settings.url];
                     forward = request.getResponseHeader('X-Tao-Forward');
-                    if(forward){
+                    if (forward) {
                         urls.push(forward);
                     }
 
-                    router.dispatch(urls, function(){
+                    router.dispatch(urls, function () {
                         uikitLoader.startDomComponent($container);
                     });
                 }
@@ -64,36 +71,32 @@ define([
             //intercept errors
             //TODO this should belongs to the Router
             $doc.ajaxError(function (event, request, settings, thrownError) {
+                var ajaxResponse;
+                var errorMessage = __('Unknown Error');
                 // Request was manually aborted, isn't a error
                 if (thrownError === 'abort') return;
 
-                var ajaxResponse;
-                var errorMessage = __('Unknown Error');
-
-                if (request.status === 404 && settings.type === 'HEAD') {
+                if ((request.status === 404 || request.status === 0) && settings.type === 'HEAD') {
                     //consider it as a "test" to check if resource exists
                     return;
-
                 } else if (request.status === 404 || request.status === 500) {
                     try {
                         // is it a common_AjaxResponse? Let's "duck type"
                         ajaxResponse = $.parseJSON(request.responseText);
-                        if (ajaxResponse !== null &&
+                        if (
+                            ajaxResponse !== null &&
                             typeof ajaxResponse.success !== 'undefined' &&
                             typeof ajaxResponse.type !== 'undefined' &&
                             typeof ajaxResponse.message !== 'undefined' &&
-                            typeof ajaxResponse.data !== 'undefined') {
-
-                            errorMessage = request.status + ': ' + ajaxResponse.message;
+                            typeof ajaxResponse.data !== 'undefined'
+                        ) {
+                            errorMessage = `${request.status}: ${ajaxResponse.message}`;
+                        } else {
+                            errorMessage = `${request.status}: ${request.responseText}`;
                         }
-                        else {
-                            errorMessage = request.status + ': ' + request.responseText;
-                        }
-
-                    }
-                    catch (err) {
+                    } catch (err) {
                         // It does not seem to be valid JSON.
-                        errorMessage = request.status + ': ' + request.responseText;
+                        errorMessage = `${request.status}: ${request.responseText}`;
                     }
                 }
 


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEX-1191

When user try to add an image by URL function getResourceType called
`getResourceType: function getResourceType(url, callback) {`
https://github.com/oat-sa/tao-core-sdk-fe/blob/d222ef0a28298b76eb1e5718a63a466a2a21356b/src/core/mimetype.js#L41-L61

Sometimes ajax request failed because of CORS policy in this case `request.status === 0`
In `views/js/controller/backoffice.js` we listen to all ajax errors.
No need to show a popup with error in this case because it will be handled in proper Widgets

Steps to reproduce:

1. Go to 'Items' tab.
2. Create a new item and go to Authoring.
3. Put inline bock and insert an image.
4. Put the image's URL into 'File' field in Image Properties.