### PR TITLE
Fix VFV-15 misplaced test element action separators

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -59,7 +59,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '44.5.0',
+    'version' => '44.5.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.27.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,9 +39,9 @@
             "integrity": "sha512-K1g2SLt4VOVHXY+8SCQeOIBeqLIDV4VZoifoDq1PYZzMwr3OqXbalAtMPT7B7qdT2NYVvz0CFXLkQTVE+d7YMg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.4.1.tgz",
-            "integrity": "sha512-xVlq8nu9l+SkRxnphjviw5GL5vEmjZzWCijuNt6DppiZy9o92H4q+iP0+U1V4a81CybYhEFawqcgJZdz6KqqLw=="
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.4.2.tgz",
+            "integrity": "sha512-No908aaOVIyTMVwnHwxq3st20Nph+tnagQroqGpXdR3oMTMGP5kz9WQFAKyBueNcthp9yNxJNzVb/M+HJHMdyA=="
         },
         "amdefine": {
             "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^0.4.2",
         "@oat-sa/tao-core-sdk": "1.3.0",
         "@oat-sa/tao-core-shared-libs": "1.0.0",
-        "@oat-sa/tao-core-ui": "1.4.1",
+        "@oat-sa/tao-core-ui": "1.4.2",
         "async": "0.2.10",
         "decimal.js": "10.1.1",
         "dompurify": "1.0.11",


### PR DESCRIPTION
- [VFV-15](https://oat-sa.atlassian.net/browse/VFV-15) fix: upgrade `@oat-sa/tao-core-ui` to version `1.4.2`, which contains a fixed stylesheet, correcting the placement of test element action separators
- [VFV-15](https://oat-sa.atlassian.net/browse/VFV-15) chore(version): bump a fix one