### PR TITLE
move post update scripts call to tao-core

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -59,7 +59,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '44.6.0',
+    'version' => '44.7.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.27.0',

--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'version' => '44.7.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
-        'generis' => '>=12.27.0',
+        'generis' => '>=12.31.0',
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAO.rdf',

--- a/models/classes/extension/UpdateExtensions.php
+++ b/models/classes/extension/UpdateExtensions.php
@@ -69,9 +69,7 @@ class UpdateExtensions extends \common_ext_UpdateExtensions
         $this->updateCacheBuster($report, $updateId);
 
         $postUpdateReport = $this->runPostUpdateScripts();
-        if ($postUpdateReport->hasChildren()) {
-            $report->add($postUpdateReport);
-        }
+        $report->add($postUpdateReport);
 
         $report->add(new common_report_Report(common_report_Report::TYPE_INFO, __('Update ID : %s', $updateId)));
 
@@ -121,6 +119,9 @@ class UpdateExtensions extends \common_ext_UpdateExtensions
             } catch (\common_ext_ManifestException $e) {
                 $report->add(new common_report_Report(common_report_Report::TYPE_WARNING, $e->getMessage()));
             }
+        }
+        if (!$report->hasChildren()) {
+            $report->add(new common_report_Report(common_report_Report::TYPE_INFO, 'No actions to be executed'));
         }
         return $report;
     }

--- a/models/classes/extension/UpdateExtensions.php
+++ b/models/classes/extension/UpdateExtensions.php
@@ -26,7 +26,7 @@ use oat\oatbox\log\LoggerAggregator;
 use oat\oatbox\service\ServiceNotFoundException;
 use oat\tao\model\asset\AssetService;
 use oat\tao\model\migrations\MigrationsService;
-use common_ext_ExtensionsManager as ExtensionsManager;
+use common_ext_ExtensionsManager as ExtensionManager;
 use common_ext_Extension as Extension;
 
 /**
@@ -108,7 +108,7 @@ class UpdateExtensions extends \common_ext_UpdateExtensions
     private function runPostUpdateScripts()
     {
         $report = new common_report_Report(common_report_Report::TYPE_INFO, 'Post update actions:');
-        $extManager = $this->getServiceLocator()->get(ExtensionsManager::SERVICE_ID);
+        $extManager = $this->getServiceLocator()->get(ExtensionManager::SERVICE_ID);
         $sorted = \helpers_ExtensionHelper::sortByDependencies($extManager->getInstalledExtensions());
         foreach ($sorted as $ext) {
             $postUpdateExtensionReport = $this->runPostUpdateScript($ext);

--- a/test/unit/extension/UpdateExtensionsTest.php
+++ b/test/unit/extension/UpdateExtensionsTest.php
@@ -69,7 +69,7 @@ class UpdateExtensionsTest extends TestCase
 
         $this->assertInstanceOf(Report::class, $report);
         $reports = $report->getChildren();
-        $this->assertCount(5, $reports);
+        $this->assertCount(6, $reports);
         $this->assertEquals('foo already up to date', $reports[0]->getMessage());
         $this->assertEquals('bar already up to date', $reports[1]->getMessage());
         $this->assertEquals('Migrations applied', $reports[2]->getMessage());


### PR DESCRIPTION
Post update scripts have to be run after migrations applied.
Execution of migrations done in the `tao-core` extension so post update script must be run in the very end of tao update process. 