### PR TITLE
Fix/tao 10285 error removing property

### DIFF
--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -33,6 +33,7 @@ use oat\tao\model\event\ClassFormUpdatedEvent;
 use oat\tao\model\event\ClassPropertiesChangedEvent;
 use oat\tao\model\search\index\OntologyIndex;
 use oat\tao\model\search\index\OntologyIndexService;
+use oat\tao\model\search\tasks\IndexTrait;
 use oat\tao\model\validator\PropertyChangedValidator;
 use oat\tao\model\search\Search;
 
@@ -44,6 +45,7 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
 {
     use OntologyAwareTrait;
     use LoggerAwareTrait;
+    use IndexTrait;
 
     /**
      * @return EventManager
@@ -128,8 +130,12 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
 
         $class = $this->getClass($this->getRequestParameter('classUri'));
         $property = $this->getProperty($this->getRequestParameter('uri'));
+        $propertyType = $this->getPropertyType($property);
 
-        $this->getEventManager()->trigger(new ClassPropertyRemovedEvent($class, $property));
+        if ($propertyType !== null) {
+            $propertyName = $this->getPropertyRealName($property->getLabel(), $propertyType->getUri());
+            $this->getEventManager()->trigger(new ClassPropertyRemovedEvent($class, $propertyName));
+        }
 
         //delete property mode
         foreach ($class->getProperties() as $classProperty) {

--- a/models/classes/event/ClassPropertyRemovedEvent.php
+++ b/models/classes/event/ClassPropertyRemovedEvent.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 namespace oat\tao\model\event;
 
 use core_kernel_classes_Class;
-use core_kernel_classes_Property;
 use JsonSerializable;
 use oat\oatbox\event\Event;
 
@@ -31,13 +30,13 @@ class ClassPropertyRemovedEvent implements Event, JsonSerializable
     /** @var core_kernel_classes_Class */
     private $class;
 
-    /** @var core_kernel_classes_Property */
-    private $property;
+    /** @var string */
+    private $propertyName;
 
-    public function __construct(core_kernel_classes_Class $class, core_kernel_classes_Property $property)
+    public function __construct(core_kernel_classes_Class $class, string $propertyName)
     {
         $this->class = $class;
-        $this->property = $property;
+        $this->propertyName = $propertyName;
     }
 
     public function getName(): string
@@ -50,9 +49,9 @@ class ClassPropertyRemovedEvent implements Event, JsonSerializable
         return $this->class;
     }
 
-    public function getProperty(): core_kernel_classes_Property
+    public function getPropertyName(): string
     {
-        return $this->property;
+        return $this->propertyName;
     }
 
     public function jsonSerialize(): array
@@ -60,8 +59,7 @@ class ClassPropertyRemovedEvent implements Event, JsonSerializable
         return [
             'class_uri' => $this->class->getUri(),
             'class_label' => $this->class->getLabel(),
-            'property_uri' => $this->property->getUri(),
-            'property_label' => $this->property->getLabel()
+            'property_name' => $this->propertyName,
         ];
     }
 }

--- a/models/classes/event/ClassPropertyRemovedEvent.php
+++ b/models/classes/event/ClassPropertyRemovedEvent.php
@@ -22,10 +22,9 @@ declare(strict_types=1);
 namespace oat\tao\model\event;
 
 use core_kernel_classes_Class;
-use JsonSerializable;
 use oat\oatbox\event\Event;
 
-class ClassPropertyRemovedEvent implements Event, JsonSerializable
+class ClassPropertyRemovedEvent implements Event
 {
     /** @var core_kernel_classes_Class */
     private $class;
@@ -52,14 +51,5 @@ class ClassPropertyRemovedEvent implements Event, JsonSerializable
     public function getPropertyName(): string
     {
         return $this->propertyName;
-    }
-
-    public function jsonSerialize(): array
-    {
-        return [
-            'class_uri' => $this->class->getUri(),
-            'class_label' => $this->class->getLabel(),
-            'property_name' => $this->propertyName,
-        ];
     }
 }

--- a/models/classes/listener/ClassPropertyRemovedListener.php
+++ b/models/classes/listener/ClassPropertyRemovedListener.php
@@ -41,7 +41,7 @@ class ClassPropertyRemovedListener extends ConfigurableService
             new DeleteIndexProperty(),
             [
                 $event->getClass(),
-                $event->getProperty()
+                $event->getPropertyName()
             ],
             $taskMessage
         );

--- a/models/classes/search/tasks/DeleteIndexProperty.php
+++ b/models/classes/search/tasks/DeleteIndexProperty.php
@@ -24,7 +24,6 @@ namespace oat\tao\model\search\tasks;
 
 use common_report_Report;
 use core_kernel_classes_Class;
-use core_kernel_classes_Property;
 use oat\oatbox\action\Action;
 use oat\oatbox\log\LoggerAwareTrait;
 use oat\tao\model\search\index\IndexUpdaterInterface;

--- a/models/classes/search/tasks/DeleteIndexProperty.php
+++ b/models/classes/search/tasks/DeleteIndexProperty.php
@@ -43,16 +43,11 @@ class DeleteIndexProperty implements Action, ServiceLocatorAwareInterface, TaskA
 
     public function __invoke($params): common_report_Report
     {
-        [$class, $property] = $params;
+        [$class, $propertyName] = $params;
 
         $class = new core_kernel_classes_Class($class['uriResource']);
-        $property = new core_kernel_classes_Property($property['uriResource']);
-        $propertyType = $this->getPropertyType($property);
-
-        $this->logDebug(get_class($propertyType));
-
         $propertyData = [
-            'name' => $this->getPropertyRealName($property->getLabel(), $propertyType->getUri()),
+            'name' => $propertyName,
             'type' => $class->getUri(),
             'parentClasses' => $this->getParentClasses($class)
         ];

--- a/test/unit/model/listener/ClassPropertyRemovedListenerTest.php
+++ b/test/unit/model/listener/ClassPropertyRemovedListenerTest.php
@@ -54,7 +54,6 @@ class ClassPropertyRemovedListenerTest extends TestCase
     public function testRemoveClassProperty(): void
     {
         $class = $this->createMock(core_kernel_classes_Class::class);
-        $property = $this->createMock(core_kernel_classes_Property::class);
 
         $this->queueDispatcher->expects($this->once())
             ->method('createTask')
@@ -62,13 +61,13 @@ class ClassPropertyRemovedListenerTest extends TestCase
                 new DeleteIndexProperty(),
                 [
                     $class,
-                    $property
+                    'property-name'
                 ],
                 'Updating search index',
                 null,
                 false
             );
 
-        $this->sut->removeClassProperty(new ClassPropertyRemovedEvent($class, $property));
+        $this->sut->removeClassProperty(new ClassPropertyRemovedEvent($class, 'property-name'));
     }
 }


### PR DESCRIPTION
With this fix we are passing the property real name (like `TextBox_prop`) instead of the property object. This was needed since when the event was captured, the property was not available on database anymore for further operations