### PR TITLE
PUT under the REST

### DIFF
--- a/actions/class.CommonRestModule.php
+++ b/actions/class.CommonRestModule.php
@@ -221,6 +221,31 @@ abstract class tao_actions_CommonRestModule extends tao_actions_RestController
         }
     }
 
+    private function getPostData(): array
+    {
+        if (!is_array($parameters = $this->getPsrRequest()->getParsedBody())) {
+            $parameters = [];
+        }
+
+        return $parameters;
+    }
+
+    private function getBodyData(): array
+    {
+        $data = null;
+        $json = $this->getPsrRequest()->getBody()->getContents();
+        if ($json) {
+            $data = @json_decode($json, true);
+        }
+
+        return is_array($data) ? $data : [];
+    }
+
+    private function getRequestData(): array
+    {
+        return array_merge($this->getPostData(), $this->getBodyData());
+    }
+
     /**
      * Returns all parameters that are URIs or Aliased with values
      *
@@ -228,14 +253,12 @@ abstract class tao_actions_CommonRestModule extends tao_actions_RestController
      *
      * @return array
      */
-    protected function getParameters()
+    protected function getParameters(): array
     {
         $effectiveParameters = [];
         $missedAliases = [];
 
-        if (!is_array($parameters = $this->getPsrRequest()->getParsedBody())) {
-            $parameters = [];
-        }
+        $parameters = $this->getRequestData();
 
         foreach ($this->getParametersAliases() as $checkParameterShort => $checkParameterUri) {
             if (array_key_exists($checkParameterUri, $parameters)) {

--- a/manifest.php
+++ b/manifest.php
@@ -59,7 +59,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '44.6.3',
+    'version' => '44.6.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.27.0',


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/TCA-678
 
REST API doesn't allow us to use a data from the body, that required with PUT action.
 
#### Steps to reproduce  (for bugs)
 - send PUT with the data that has to be updated in the resource
 - nothing changed
  
#### How to test
 
```
curl --location --request PUT 'http://tao-act.loc/taoLti/RestService/index?uri=http%3A%2F%2Fsample%2Fact.rdf%23i5ef44f33c222b694e6664782566e0038' \
--header 'Accept: application/json' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--header 'Authorization: Basic ###' \
--data-raw '{
    "oauth_consumer_key": "valfromput2",
    "oauth-key": "valfromput2_oauth",
    "label": "labelfromput2",
    "oauth-secret": "secretfromput2",
    "oauth-callback-url": "callbackfromput2"
}'
```

**uri** - ID of the LTI consumer
 
or use any other tools like a Storm's REST tool or Postman.