### PR TITLE
Verify each resource before add new task on the queue

### DIFF
--- a/models/classes/resources/ResourceWatcher.php
+++ b/models/classes/resources/ResourceWatcher.php
@@ -29,7 +29,7 @@ use oat\generis\model\data\event\ResourceUpdated;
 use oat\generis\model\OntologyAwareTrait;
 use oat\generis\model\OntologyRdfs;
 use oat\oatbox\service\ConfigurableService;
-use oat\tao\elasticsearch\IndexUpdater;
+use oat\tao\model\search\index\IndexUpdaterInterface;
 use oat\tao\model\search\Search;
 use oat\tao\model\search\tasks\UpdateResourceInIndex;
 use oat\tao\model\TaoOntology;
@@ -163,7 +163,7 @@ class ResourceWatcher extends ConfigurableService
             $classUri = array_pop($resourceTypeIds);
 
             $hasClassSupport = $this->getServiceLocator()
-                ->get(IndexUpdater::SERVICE_ID)
+                ->get(IndexUpdaterInterface::SERVICE_ID)
                 ->hasClassSupport(
                     $classUri
                 );

--- a/models/classes/resources/ResourceWatcher.php
+++ b/models/classes/resources/ResourceWatcher.php
@@ -21,14 +21,18 @@
 
 namespace oat\tao\model\resources;
 
+use core_kernel_classes_Class;
+use core_kernel_classes_Resource;
 use oat\generis\model\data\event\ResourceCreated;
 use oat\generis\model\data\event\ResourceDeleted;
 use oat\generis\model\data\event\ResourceUpdated;
 use oat\generis\model\OntologyAwareTrait;
+use oat\generis\model\OntologyRdfs;
 use oat\oatbox\service\ConfigurableService;
+use oat\tao\elasticsearch\IndexUpdater;
+use oat\tao\model\search\Search;
 use oat\tao\model\search\tasks\UpdateResourceInIndex;
 use oat\tao\model\TaoOntology;
-use oat\tao\model\search\Search;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
 
 /**
@@ -51,9 +55,9 @@ class ResourceWatcher extends ConfigurableService
     /**
      * @param ResourceCreated $event
      */
-    public function catchCreatedResourceEvent(ResourceCreated $event)
+    public function catchCreatedResourceEvent(ResourceCreated $event): void
     {
-        /** @var \core_kernel_classes_Resource $resource */
+        /** @var core_kernel_classes_Resource $resource */
         $resource = $event->getResource();
         $property = $this->getProperty(TaoOntology::PROPERTY_UPDATED_AT);
         $now = microtime(true);
@@ -71,7 +75,7 @@ class ResourceWatcher extends ConfigurableService
      * @param ResourceUpdated $event
      * @throws \core_kernel_persistence_Exception
      */
-    public function catchUpdatedResourceEvent(ResourceUpdated $event)
+    public function catchUpdatedResourceEvent(ResourceUpdated $event): void
     {
         $resource = $event->getResource();
         $updatedAt = $this->getUpdatedAt($resource);
@@ -95,20 +99,9 @@ class ResourceWatcher extends ConfigurableService
     }
 
     /**
-     * Create a task in the task queue to index/re-index created/updated resource
-     * @param \core_kernel_classes_Resource $resource
-     * @param string $message
-     */
-    private function createResourceIndexingTask(\core_kernel_classes_Resource $resource, string $message)
-    {
-        $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
-        $queueDispatcher->createTask(new UpdateResourceInIndex(), [$resource->getUri()], $message);
-    }
-
-    /**
      * @param ResourceDeleted $event
      */
-    public function catchDeletedResourceEvent(ResourceDeleted $event)
+    public function catchDeletedResourceEvent(ResourceDeleted $event): void
     {
         $searchService = $this->getServiceLocator()->get(Search::SERVICE_ID);
         try {
@@ -120,11 +113,11 @@ class ResourceWatcher extends ConfigurableService
     }
 
      /**
-     * @param \core_kernel_classes_Resource $resource
+     * @param core_kernel_classes_Resource $resource
      * @return \core_kernel_classes_Container
      * @throws \core_kernel_persistence_Exception
      */
-    public function getUpdatedAt(\core_kernel_classes_Resource $resource)
+    public function getUpdatedAt(core_kernel_classes_Resource $resource)
     {
         if (isset($this->updatedAtCache[$resource->getUri()])) {
             $updatedAt = $this->updatedAtCache[$resource->getUri()];
@@ -137,5 +130,58 @@ class ResourceWatcher extends ConfigurableService
             $this->updatedAtCache[$resource->getUri()] = $updatedAt;
         }
         return $updatedAt;
+    }
+
+    /**
+     * Create a task in the task queue to index/re-index created/updated resource
+     * @param core_kernel_classes_Resource $resource
+     * @param string $message
+     */
+    private function createResourceIndexingTask(core_kernel_classes_Resource $resource, string $message): void
+    {
+        if ($this->hasResourceSupport($resource)) {
+            $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
+            $queueDispatcher->createTask(new UpdateResourceInIndex(), [$resource->getUri()], $message);
+
+            return;
+        }
+    }
+
+    private function hasResourceSupport(core_kernel_classes_Resource $resource): bool
+    {
+        $resourceTypeIds = array_map(
+            function (core_kernel_classes_Class $resourceType): string {
+                return $resourceType->getUri();
+            },
+            $resource->getTypes()
+        );
+
+        $checkedResourceTypes = [OntologyRdfs::RDFS_RESOURCE, TaoOntology::CLASS_URI_OBJECT];
+        $resourceTypeIds = array_diff($resourceTypeIds, [OntologyRdfs::RDFS_RESOURCE, TaoOntology::CLASS_URI_OBJECT]);
+
+        while (!empty($resourceTypeIds)) {
+            $classUri = array_pop($resourceTypeIds);
+
+            $hasClassSupport = $this->getServiceLocator()
+                ->get(IndexUpdater::SERVICE_ID)
+                ->hasClassSupport(
+                    $classUri
+                );
+
+            if ($hasClassSupport) {
+                return true;
+            }
+
+            $class = $this->getClass($classUri);
+
+            foreach ($class->getParentClasses() as $parent) {
+                if (!in_array($parent->getUri(), $checkedResourceTypes)) {
+                    $resourceTypeIds[] = $parent->getUri();
+                }
+            }
+            $checkedResourceTypes[] = $class->getUri();
+        }
+
+        return false;
     }
 }

--- a/models/classes/resources/ResourceWatcher.php
+++ b/models/classes/resources/ResourceWatcher.php
@@ -67,7 +67,7 @@ class ResourceWatcher extends ConfigurableService
 
         $this->getLogger()->debug('triggering index update on resourceCreated event');
 
-        $taskMessage = __('Adding search index for created resource ', $resource->getUri());
+        $taskMessage = __('Adding search index for created resource');
         $this->createResourceIndexingTask($resource, $taskMessage);
     }
 
@@ -89,7 +89,7 @@ class ResourceWatcher extends ConfigurableService
         if ($updatedAt === null || ($now - $updatedAt) > $threshold) {
             $this->getLogger()->debug('triggering index update on resourceUpdated event');
 
-            $taskMessage = __('Adding/updating search index for updated resource ', $resource->getUri());
+            $taskMessage = __('Adding/updating search index for updated resource');
             $this->createResourceIndexingTask($resource, $taskMessage);
 
             $property = $this->getProperty(TaoOntology::PROPERTY_UPDATED_AT);
@@ -108,7 +108,7 @@ class ResourceWatcher extends ConfigurableService
             $searchService->remove($event->getId());
         } catch (\Exception $e) {
             $message = $e->getMessage();
-            \common_Logger::e("Error delete index document for {$event->getId()} with message $message");
+            $this->getLogger()->error("Error delete index document for {$event->getId()} with message $message");
         }
     }
 

--- a/models/classes/search/index/DocumentBuilder/IndexDocumentBuilderInterface.php
+++ b/models/classes/search/index/DocumentBuilder/IndexDocumentBuilderInterface.php
@@ -22,14 +22,9 @@ declare(strict_types=1);
 namespace oat\tao\model\search\index\DocumentBuilder;
 
 use oat\tao\model\search\index\IndexDocument;
-use oat\tao\model\search\index\IndexProperty;
-use oat\tao\model\search\index\OntologyIndex;
-use core_kernel_classes_Resource;
 
 interface IndexDocumentBuilderInterface
 {
-    const TYPE_PROPERTY = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
-
     /**
      * Creates IndexDocument object from the \core_kernel_classes_Resource data
      * @param \core_kernel_classes_Resource $resource

--- a/models/classes/search/index/IndexUpdaterInterface.php
+++ b/models/classes/search/index/IndexUpdaterInterface.php
@@ -40,4 +40,11 @@ interface IndexUpdaterInterface
      * @throws Throwable
      */
     public function deleteProperty(array $property): void;
+
+    /**
+     * @param string $class
+     *
+     * @return bool
+     */
+    public function hasClassSupport(string $class): bool;
 }

--- a/models/classes/search/strategy/GenerisIndexUpdater.php
+++ b/models/classes/search/strategy/GenerisIndexUpdater.php
@@ -35,4 +35,9 @@ class GenerisIndexUpdater extends ConfigurableService implements IndexUpdaterInt
     {
         return;
     }
+
+    public function hasClassSupport(string $class): bool
+    {
+        return true;
+    }
 }

--- a/models/classes/search/tasks/UpdateResourceInIndex.php
+++ b/models/classes/search/tasks/UpdateResourceInIndex.php
@@ -54,7 +54,7 @@ class UpdateResourceInIndex implements Action, ServiceLocatorAwareInterface, Tas
 
         /** @var IndexService $indexService */
         $indexService = $this->getServiceLocator()->get(IndexService::SERVICE_ID);
-    
+
         $documentBuilder = $indexService->getDocumentBuilder();
 
         $indexDocument = $documentBuilder->createDocumentFromResource($createdResource);
@@ -76,24 +76,5 @@ class UpdateResourceInIndex implements Action, ServiceLocatorAwareInterface, Tas
         }
 
         return new Report($type, $message);
-    }
-    
-    private function getResourceRootType(\core_kernel_classes_Resource $resource): string
-    {
-        if ($resource->isInstanceOf($this->getClass(TaoOntology::CLASS_URI_ITEM))) {
-            $rootClass = $this->getClass(TaoOntology::CLASS_URI_ITEM)->getUri();
-        } elseif ($resource->isInstanceOf($this->getClass(TaoOntology::CLASS_URI_TEST))) {
-            $rootClass = $this->getClass(TaoOntology::CLASS_URI_TEST)->getUri();
-        } elseif ($resource->isInstanceOf($this->getClass(TaoOntology::CLASS_URI_SUBJECT))) {
-            $rootClass = $this->getClass(TaoOntology::CLASS_URI_SUBJECT)->getUri();
-        } elseif ($resource->isInstanceOf($this->getClass(TaoOntology::CLASS_URI_GROUP))) {
-            $rootClass = $this->getClass(TaoOntology::CLASS_URI_GROUP)->getUri();
-        } elseif ($resource->isInstanceOf($this->getClass(TaoOntology::CLASS_URI_DELIVERY))) {
-            $rootClass = $this->getClass(TaoOntology::CLASS_URI_DELIVERY)->getUri();
-        } else {
-            $rootClass = current(array_keys($resource->getTypes()));
-        }
-        
-        return $rootClass;
     }
 }

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\resources;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use Exception;
+use oat\generis\model\data\event\ResourceCreated;
+use oat\generis\model\data\event\ResourceDeleted;
+use oat\generis\model\data\event\ResourceUpdated;
+use oat\generis\model\data\Ontology;
+use oat\generis\test\TestCase;
+use oat\oatbox\log\LoggerService;
+use oat\tao\model\resources\ResourceWatcher;
+use oat\tao\model\search\index\IndexUpdaterInterface;
+use oat\tao\model\search\Search;
+use oat\tao\model\search\tasks\UpdateResourceInIndex;
+use oat\tao\model\taskQueue\QueueDispatcherInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
+use Psr\Log\LoggerInterface;
+
+class ResourceWatcherTest extends TestCase
+{
+    /** @var ResourceWatcher|MockObject */
+    private $sut;
+
+    /** @var IndexUpdaterInterface|MockObject */
+    private $indexUpdater;
+
+    /** @var LoggerInterface|MockObject */
+    private $logger;
+
+    /**  @var Ontology|MockObject */
+    private $ontology;
+
+    /** @var QueueDispatcherInterface|MockObject */
+    private $queueDispatcher;
+
+    /** @var core_kernel_classes_Resource|MockObject */
+    private $resource;
+
+    /** @var MockObject|Search */
+    private $search;
+
+    protected function setUp(): void
+    {
+        $this->sut = new ResourceWatcher();
+
+        $this->indexUpdater = $this->createMock(IndexUpdaterInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->ontology = $this->createMock(Ontology::class);
+        $this->queueDispatcher = $this->createMock(QueueDispatcherInterface::class);
+        $this->resource = $this->createMock(core_kernel_classes_Resource::class);
+        $this->search = $this->createMock(Search::class);
+
+        $serviceLocator = $this->getServiceLocatorMock(
+            [
+                IndexUpdaterInterface::SERVICE_ID => $this->indexUpdater,
+                QueueDispatcherInterface::SERVICE_ID => $this->queueDispatcher,
+                Ontology::SERVICE_ID => $this->ontology,
+                LoggerService::SERVICE_ID => $this->logger,
+                Search::SERVICE_ID => $this->search
+            ]
+        );
+        $this->sut->setServiceLocator($serviceLocator);
+    }
+
+    public function testCatchCreatedResourceEvent_mustCreateIndexTaskInCaseResourceIsSupportedByIndex(): void
+    {
+        $classUri = 'https://tao.docker.localhost/ontologies/tao.rdf#Item';
+        $this->mockHasClassSupportIndexUpdater($classUri);
+
+        $this->mockGetTypesResource($classUri);
+
+        $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+        $this->mockCreateTaskQueueDispatcher($resourceUri, 'Adding search index for created resource');
+
+        $this->mockGetPropertyOntology($this->once());
+
+        $this->mockGetUriResource($resourceUri);
+
+        $this->mockDebugLogger('triggering index update on resourceCreated event');
+
+        $this->sut->catchCreatedResourceEvent(
+            new ResourceCreated($this->resource)
+        );
+    }
+
+    public function testCatchCreatedResourceEvent_mustCreateIndexTaskInCaseResourceIsSupportedByIndexWhenRootClassBelongsToParent(): void
+    {
+        $classUri = 'https://tao.docker.localhost/ontologies/tao.rdf#Item';
+        $this->indexUpdater->expects($this->at(0))
+            ->method('hasClassSupport')
+            ->with($classUri)
+            ->willReturn(
+                false
+            );
+        $this->indexUpdater->expects($this->at(1))
+            ->method('hasClassSupport')
+            ->with($classUri)
+            ->willReturn(
+                true
+            );
+
+        $this->mockGetTypesResource($classUri);
+
+        $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+        $this->mockCreateTaskQueueDispatcher($resourceUri, 'Adding search index for created resource');
+
+        $this->mockGetPropertyOntology($this->once());
+
+        $parentClass = $this->createMock(
+            core_kernel_classes_Class::class
+        );
+
+        $class = $this->createMock(
+            core_kernel_classes_Class::class
+        );
+
+        $parentClass->expects($this->any())->method('getUri')->willReturn(
+            $classUri
+        );
+
+        $class->expects($this->once())->method('getParentClasses')->willReturn(
+            [
+                $parentClass
+            ]
+        );
+        $this->ontology->expects($this->once())
+            ->method('getClass')
+            ->willReturn(
+                $class
+            );
+
+        $this->mockGetUriResource($resourceUri);
+
+        $this->mockDebugLogger('triggering index update on resourceCreated event');
+
+        $this->sut->catchCreatedResourceEvent(
+            new ResourceCreated($this->resource)
+        );
+    }
+
+    public function testCatchCreatedResourceEvent_mustNotCreateIndexTaskInCaseResourceIsNotSupported(): void
+    {
+        $classUri = 'https://tao.docker.localhost/ontologies/tao.rdf#Item';
+        $this->indexUpdater->expects($this->any())
+            ->method('hasClassSupport')
+            ->with($classUri)
+            ->willReturn(false);
+
+        $this->mockGetTypesResource($classUri);
+
+        $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+        $this->queueDispatcher->expects($this->never())->method('createTask');
+
+        $this->mockGetPropertyOntology($this->once());
+
+        $class = $this->createMock(
+            core_kernel_classes_Class::class
+        );
+
+        $class->expects($this->once())->method('getParentClasses')
+            ->willReturn([]);
+
+        $this->ontology->expects($this->once())
+            ->method('getClass')
+            ->willReturn($class);
+
+        $this->mockGetUriResource($resourceUri);
+
+        $this->mockDebugLogger('triggering index update on resourceCreated event');
+
+        $this->sut->catchCreatedResourceEvent(
+            new ResourceCreated($this->resource)
+        );
+    }
+
+    public function testCatchUpdatedResourceEvent_mustCreateIndexTaskInCaseResourceIsSupportedByIndex(): void
+    {
+        $classUri = 'https://tao.docker.localhost/ontologies/tao.rdf#Item';
+        $this->mockHasClassSupportIndexUpdater($classUri);
+
+        $this->mockGetTypesResource($classUri);
+
+        $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+        $this->mockCreateTaskQueueDispatcher($resourceUri, 'Adding/updating search index for updated resource');
+
+        $this->mockGetPropertyOntology($this->atLeast(2));
+
+        $this->mockGetUriResource($resourceUri);
+
+        $this->mockDebugLogger('triggering index update on resourceUpdated event');
+
+        $this->resource->expects($this->once())->method('editPropertyValues');
+
+        $this->sut->catchUpdatedResourceEvent(
+            new ResourceUpdated($this->resource)
+        );
+    }
+
+    public function testCatchDeletedResourceEventSuccess(): void
+    {
+        $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+
+        $this->search->expects($this->once())->method('remove');
+
+        $this->sut->catchDeletedResourceEvent(
+            new ResourceDeleted($resourceUri)
+        );
+    }
+
+    public function testCatchDeletedResourceEventFail(): void
+    {
+        $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+
+        $this->search->expects($this->once())
+            ->method('remove')
+            ->willThrowException(new Exception());
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with(
+                'Error delete index document for https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec with message '
+            );
+
+        $this->sut->catchDeletedResourceEvent(
+            new ResourceDeleted($resourceUri)
+        );
+    }
+
+    private function mockGetTypesResource(string $classUri): void
+    {
+        $class = $this->createMock(core_kernel_classes_Class::class);
+        $class->expects($this->once())
+            ->method('getUri')
+            ->willReturn($classUri);
+
+        $this->resource->expects($this->once())
+            ->method('getTypes')
+            ->willReturn(
+                [
+                    $class
+                ]
+            );
+    }
+
+    private function mockHasClassSupportIndexUpdater(string $classUri): void
+    {
+        $this->indexUpdater->expects($this->once())
+            ->method('hasClassSupport')
+            ->with($classUri)
+            ->willReturn(
+                true
+            );
+    }
+
+    private function mockCreateTaskQueueDispatcher(string $resourceUri, string $taskMessage): void
+    {
+        $this->queueDispatcher->expects($this->once())
+            ->method('createTask')
+            ->with(
+                new UpdateResourceInIndex(),
+                [$resourceUri],
+                $taskMessage,
+                null,
+                false
+            );
+    }
+
+    private function mockGetPropertyOntology(InvocationOrder $expectation): void
+    {
+        $this->ontology->expects($expectation)->method('getProperty')->willReturn(
+            $this->createMock(core_kernel_classes_Property::class)
+        );
+    }
+
+    private function mockGetUriResource(string $resourceUri): void
+    {
+        $this->resource->expects($this->any())
+            ->method('getUri')
+            ->willReturn($resourceUri);
+    }
+
+    private function mockDebugLogger(string $message): void
+    {
+        $this->logger->expects($this->once())
+            ->method('debug')
+            ->with($message);
+    }
+}

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -15,8 +15,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
- *
- *
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
- Do not add resources to the task queue that are not supported by the search.
- Removed 'getResourceRootType' method that is not being used.
- Added some return type hints in ResourceWatcher methods
- We moved the private methods of the ResourceWatcher class to the end
- Useless constant removed and classes imports from IndexDocumentBuilderInterface

Before these changes:
    We are creating tasks in the queue for all events created / updated by the Resource. To play it, just go to the items page and refresh the page. You will see that a new task has been created in the queue.

After these changes:
  Only known resources will create jobs in the queue.
 