### PR TITLE
Feature/nex 1094/backoffice user metrics

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -59,7 +59,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '44.11.0   ',
+    'version' => '44.11.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.31.0',

--- a/manifest.php
+++ b/manifest.php
@@ -59,7 +59,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '44.10.1',
+    'version' => '44.11.0   ',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=12.31.0',

--- a/models/classes/event/UserCreatedEvent.php
+++ b/models/classes/event/UserCreatedEvent.php
@@ -30,7 +30,7 @@ use oat\tao\model\webhooks\WebhookSerializableEventInterface;
 
 class UserCreatedEvent implements Event, JsonSerializable, WebhookSerializableEventInterface
 {
-    private const WEBHOOK_EVENT_NAME = 'UserCreated';
+    private const WEBHOOK_EVENT_NAME = 'user-created';
 
     /** @var  string */
     protected $user;

--- a/models/classes/event/UserCreatedEvent.php
+++ b/models/classes/event/UserCreatedEvent.php
@@ -30,7 +30,7 @@ use oat\tao\model\webhooks\WebhookSerializableEventInterface;
 
 class UserCreatedEvent implements Event, JsonSerializable, WebhookSerializableEventInterface
 {
-    public const WEBHOOK_EVENT_NAME = 'UserCreated';
+    private const WEBHOOK_EVENT_NAME = 'UserCreated';
 
     /** @var  string */
     protected $user;

--- a/models/classes/event/UserCreatedEvent.php
+++ b/models/classes/event/UserCreatedEvent.php
@@ -15,19 +15,22 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2015-2020 (original work) Open Assessment Technologies SA
  *
  */
+
+declare(strict_types=1);
 
 namespace oat\tao\model\event;
 
 use core_kernel_classes_Resource;
 use JsonSerializable;
-use oat\generis\model\GenerisRdf;
 use oat\oatbox\event\Event;
+use oat\tao\model\webhooks\WebhookSerializableEventInterface;
 
-class UserCreatedEvent implements Event, JsonSerializable
+class UserCreatedEvent implements Event, JsonSerializable, WebhookSerializableEventInterface
 {
+    public const WEBHOOK_EVENT_NAME = 'UserCreated';
 
     /** @var  string */
     protected $user;
@@ -61,7 +64,18 @@ class UserCreatedEvent implements Event, JsonSerializable
     {
         return [
             'uri' => $this->user->getUri(),
-        //            'login' => $this->user->getOnePropertyValue(new core_kernel_classes_Property(GenerisRdf::PROPERTY_USER_LOGIN)),
+        ];
+    }
+
+    public function getWebhookEventName()
+    {
+        return self::WEBHOOK_EVENT_NAME;
+    }
+
+    public function serializeForWebhook()
+    {
+        return [
+            'userId' => $this->user->getUri(),
         ];
     }
 }

--- a/models/classes/event/UserRemovedEvent.php
+++ b/models/classes/event/UserRemovedEvent.php
@@ -15,20 +15,23 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2015-2020 (original work) Open Assessment Technologies SA
  *
  */
 
+declare(strict_types=1);
+
 namespace oat\tao\model\event;
 
-use core_kernel_classes_Resource;
 use JsonSerializable;
 use oat\oatbox\event\Event;
+use oat\tao\model\webhooks\WebhookSerializableEventInterface;
 
-class UserRemovedEvent implements Event, JsonSerializable
+class UserRemovedEvent implements Event, JsonSerializable, WebhookSerializableEventInterface
 {
-
     const EVENT_NAME = __CLASS__;
+    public const WEBHOOK_EVENT_NAME = 'UserRemoved';
+
 
     /** @var  string */
     private $userUri;
@@ -62,6 +65,18 @@ class UserRemovedEvent implements Event, JsonSerializable
     {
         return [
             'uri' => $this->userUri,
+        ];
+    }
+
+    public function getWebhookEventName()
+    {
+        return self::WEBHOOK_EVENT_NAME;
+    }
+
+    public function serializeForWebhook()
+    {
+        return [
+            'userId' => $this->userUri,
         ];
     }
 }

--- a/models/classes/event/UserRemovedEvent.php
+++ b/models/classes/event/UserRemovedEvent.php
@@ -29,9 +29,9 @@ use oat\tao\model\webhooks\WebhookSerializableEventInterface;
 
 class UserRemovedEvent implements Event, JsonSerializable, WebhookSerializableEventInterface
 {
-    const EVENT_NAME = __CLASS__;
-    private const WEBHOOK_EVENT_NAME = 'user-removed';
+    public const EVENT_NAME = __CLASS__;
 
+    private const WEBHOOK_EVENT_NAME = 'user-removed';
 
     /** @var  string */
     private $userUri;

--- a/models/classes/event/UserRemovedEvent.php
+++ b/models/classes/event/UserRemovedEvent.php
@@ -30,7 +30,7 @@ use oat\tao\model\webhooks\WebhookSerializableEventInterface;
 class UserRemovedEvent implements Event, JsonSerializable, WebhookSerializableEventInterface
 {
     const EVENT_NAME = __CLASS__;
-    private const WEBHOOK_EVENT_NAME = 'UserRemoved';
+    private const WEBHOOK_EVENT_NAME = 'user-removed';
 
 
     /** @var  string */

--- a/models/classes/event/UserRemovedEvent.php
+++ b/models/classes/event/UserRemovedEvent.php
@@ -30,7 +30,7 @@ use oat\tao\model\webhooks\WebhookSerializableEventInterface;
 class UserRemovedEvent implements Event, JsonSerializable, WebhookSerializableEventInterface
 {
     const EVENT_NAME = __CLASS__;
-    public const WEBHOOK_EVENT_NAME = 'UserRemoved';
+    private const WEBHOOK_EVENT_NAME = 'UserRemoved';
 
 
     /** @var  string */

--- a/models/classes/event/UserUpdatedEvent.php
+++ b/models/classes/event/UserUpdatedEvent.php
@@ -15,22 +15,18 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015-2020 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2015 (original work) Open Assessment Technologies SA
  *
  */
-
-declare(strict_types=1);
 
 namespace oat\tao\model\event;
 
 use core_kernel_classes_Resource;
 use JsonSerializable;
 use oat\oatbox\event\Event;
-use oat\tao\model\webhooks\WebhookSerializableEventInterface;
 
-class UserUpdatedEvent implements Event, JsonSerializable, WebhookSerializableEventInterface
+class UserUpdatedEvent implements Event, JsonSerializable
 {
-    public const WEBHOOK_EVENT_NAME = 'UserUpdated';
 
     /** @var  string */
     protected $user;
@@ -68,18 +64,6 @@ class UserUpdatedEvent implements Event, JsonSerializable, WebhookSerializableEv
         return [
             'uri' => $this->user->getUri(),
             'data' => $this->data,
-        ];
-    }
-
-    public function getWebhookEventName()
-    {
-        return self::WEBHOOK_EVENT_NAME;
-    }
-
-    public function serializeForWebhook()
-    {
-        return [
-            'userId' => $this->user->getUri(),
         ];
     }
 }

--- a/models/classes/event/UserUpdatedEvent.php
+++ b/models/classes/event/UserUpdatedEvent.php
@@ -15,19 +15,22 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2015-2020 (original work) Open Assessment Technologies SA
  *
  */
 
+declare(strict_types=1);
+
 namespace oat\tao\model\event;
 
-use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
 use JsonSerializable;
 use oat\oatbox\event\Event;
+use oat\tao\model\webhooks\WebhookSerializableEventInterface;
 
-class UserUpdatedEvent implements Event, JsonSerializable
+class UserUpdatedEvent implements Event, JsonSerializable, WebhookSerializableEventInterface
 {
+    public const WEBHOOK_EVENT_NAME = 'UserUpdated';
 
     /** @var  string */
     protected $user;
@@ -65,6 +68,18 @@ class UserUpdatedEvent implements Event, JsonSerializable
         return [
             'uri' => $this->user->getUri(),
             'data' => $this->data,
+        ];
+    }
+
+    public function getWebhookEventName()
+    {
+        return self::WEBHOOK_EVENT_NAME;
+    }
+
+    public function serializeForWebhook()
+    {
+        return [
+            'userId' => $this->user->getUri(),
         ];
     }
 }

--- a/test/unit/models/classes/event/UserCreatedEventTest.php
+++ b/test/unit/models/classes/event/UserCreatedEventTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace oat\tao\test\unit\model\event;
+
+use oat\generis\test\TestCase;
+use oat\tao\model\event\UserCreatedEvent;
+use core_kernel_classes_Resource as RdfResource;
+
+class UserCreatedEventTest extends TestCase
+{
+    /** @var UserCreatedEvent */
+    private $subject;
+
+    /** @var string */
+    private $userUriFixture;
+
+    protected function setUp(): void
+    {
+        $this->userUriFixture = 'test';
+        $this->subject = new UserCreatedEvent(
+            $this->createConfiguredMock(
+                RdfResource::class,
+                ['getUri' => $this->userUriFixture]
+            )
+        );
+    }
+
+    public function testSerializeForWebhook(): void
+    {
+        $this->assertSame(
+            [
+                'userId' => $this->userUriFixture,
+            ],
+            $this->subject->serializeForWebhook()
+        );
+    }
+
+    public function testGetWebhookEventName(): void
+    {
+        $this->assertSame(
+            'user-created',
+            $this->subject->getWebhookEventName()
+        );
+    }
+}

--- a/test/unit/models/classes/event/UserRemovedEventTest.php
+++ b/test/unit/models/classes/event/UserRemovedEventTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\model\event;
+
+use oat\generis\test\TestCase;
+use oat\tao\model\event\UserRemovedEvent;
+
+class UserRemovedEventTest extends TestCase
+{
+    /** @var UserRemovedEvent */
+    private $subject;
+
+    /** @var string */
+    private $userUriFixture;
+
+    protected function setUp(): void
+    {
+        $this->userUriFixture= 'test';
+        $this->subject = new UserRemovedEvent($this->userUriFixture);
+    }
+
+    public function testSerializeForWebhook(): void
+    {
+        $this->assertSame(
+            [
+                'userId' => $this->userUriFixture,
+            ],
+            $this->subject->serializeForWebhook()
+        );
+    }
+
+    public function testGetWebhookEventName(): void
+    {
+        $this->assertSame(
+            'user-removed',
+            $this->subject->getWebhookEventName()
+        );
+    }
+}


### PR DESCRIPTION
This PR aims to add webhook for user creation and deletion.
It covers: 
- From UI user manager, create and delete
- From TAO cli, user import is triggering userCreatedEvent (except test taker)

*NB:*
In user management we can add testtaker role to a user. In reality, this is not used like that and this testtaker cannot be assigned to any test. Business is considering all users created in this section as backoffice user
