### PR TITLE
TAO-10365 Changed IndexDocumentBuilder.php to not rely on Extension Manager

### DIFF
--- a/models/classes/search/index/DocumentBuilder/IndexDocumentBuilder.php
+++ b/models/classes/search/index/DocumentBuilder/IndexDocumentBuilder.php
@@ -261,7 +261,7 @@ class IndexDocumentBuilder extends InjectionAwareService implements IndexDocumen
             return null;
         }
 
-        $accessRights = $permissionProvider->getResourceAccessData($resource);
+        $accessRights = $permissionProvider->getResourceAccessData($resource->getUri());
         $accessRightsURIs = ['read_access' => array_keys($accessRights)];
 
         return new ArrayIterator($accessRightsURIs);


### PR DESCRIPTION
On previous implementation we were checking if the `taoSimpleDac` extension was enabled, what isn't really a reliable way to check. Instead, we are now checking if the PermissionProvider implements an interface