### PR TITLE
Feature/nsup 27/disable validation tokens

### DIFF
--- a/config/default/security-xsrf-token.conf.php
+++ b/config/default/security-xsrf-token.conf.php
@@ -2,5 +2,6 @@
 return new oat\tao\model\security\xsrf\TokenService([
     'store' => new oat\tao\model\security\xsrf\TokenStoreSession(),
     'poolSize' => 10,
-    'timeLimit' => 0
+    'timeLimit' => 0,
+    'validateTokens' => true
 ]);

--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.2.1',
+    'version' => '45.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/migrations/Version202008030748582234_tao.php
+++ b/migrations/Version202008030748582234_tao.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\security\xsrf\TokenService;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202008030748582234_tao extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Set new option `validateTokens` to `true`. This option can disable validation tokens on FE side.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $service = $this->getServiceLocator()->get(TokenService::SERVICE_ID);
+        if (!$service->hasOption(TokenService::VALIDATE_TOKENS_OPT)) {
+            $service->setOption(TokenService::VALIDATE_TOKENS_OPT, true);
+            $this->getServiceManager()->register(TokenService::SERVICE_ID, $service);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $service = $this->getServiceLocator()->get(TokenService::SERVICE_ID);
+        if ($service->hasOption(TokenService::VALIDATE_TOKENS_OPT)) {
+            $options = $service->getOptions();
+            unset($options[TokenService::VALIDATE_TOKENS_OPT]);
+            $service->setOptions($options);
+            $this->getServiceManager()->register(TokenService::SERVICE_ID, $service);
+        }
+    }
+}

--- a/models/classes/security/xsrf/TokenService.php
+++ b/models/classes/security/xsrf/TokenService.php
@@ -47,6 +47,7 @@ class TokenService extends ConfigurableService
     // options keys
     const POOL_SIZE_OPT = 'poolSize';
     const TIME_LIMIT_OPT = 'timeLimit';
+    const VALIDATE_TOKENS_OPT = 'validateTokens';
     const OPTION_STORE = 'store';
 
     const DEFAULT_POOL_SIZE = 6;
@@ -354,7 +355,8 @@ class TokenService extends ConfigurableService
         return [
             self::JS_TOKEN_TIME_LIMIT_KEY => $this->getTimeLimit() * 1000,
             self::JS_TOKEN_POOL_SIZE_KEY => $this->getPoolSize(false),
-            self::JS_TOKEN_KEY => $jsTokenPool
+            self::JS_TOKEN_KEY => $jsTokenPool,
+            self::VALIDATE_TOKENS_OPT => $this->getOption(self::VALIDATE_TOKENS_OPT)
         ];
     }
 

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -24,9 +24,9 @@
             "integrity": "sha512-XZhhEtGsrEctcr4ZEuTop1N96IRV8iWNTA2Ffvk83n7GDqSYZpLePkFK1VFxPKc1HlLEoXzx+YLQotq4UJQjvQ=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.3.0.tgz",
-            "integrity": "sha512-WWqPPukRMDjGMaxQHtc0fGLghaHTBT69EU0OH5Tkc3KdG0NmVrycweL6w+9K+cIcU+46wMMOnK1h8pM/+B7QvQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.5.0.tgz",
+            "integrity": "sha512-f2kg//lksuQjAk+w/qFXocRja5/LWJ4D6yWNfb+NXb4eyom4bediIr7+rQJxFD2NvVPclM0xyPwjuVxF4rHIBg==",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "^1.0.14",
                 "idb-wrapper": "1.7.0",

--- a/views/package.json
+++ b/views/package.json
@@ -11,7 +11,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/tao-core-libs": "^0.4.2",
-        "@oat-sa/tao-core-sdk": "1.3.0",
+        "@oat-sa/tao-core-sdk": "1.5.0",
         "@oat-sa/tao-core-shared-libs": "1.0.2",
         "@oat-sa/tao-core-ui": "1.6.0",
         "async": "0.2.10",


### PR DESCRIPTION
NSUP-28 and NSUP-27

Depends on https://github.com/oat-sa/tao-core-sdk-fe/pull/68

For one of the our clients, we need to disable xsrf tokens. By default, we can disable only validation on the server-side, but on FE side we will still try to get a token from the queue.
Because of that we added a new option which allows to reuse tokens from the queue again and send it to the server. 

How to reproduce that issue:
1. `config/taoQtiTest/testRunner.conf.php` set: `'csrf-token' => false`
2. `config/tao/security-xsrf-token.conf.php` set `poolSize' => 5`
3. Run a test with more than 5 items
4.  While in passing the test you will see the next error: `No tokens available. Please refresh the page.`

How to check the fix:
1. Update tao-core with tao-core-sdk-fe.
2. `config/taoQtiTest/testRunner.conf.php` set: `'csrf-token' => false`
3. `config/tao/security-xsrf-token.conf.php` set `poolSize' => 5` and `validateTokens => false`
4. Run a test with more than 5 items
5. You will finish the test without any issues