### PR TITLE
Feature TBD-48 configurable csrf token pool store

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -1,7 +1,5 @@
 <?php
 
-use oat\tao\scripts\update\Updater;
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -37,8 +35,8 @@ use oat\tao\scripts\install\CreateRdsListStore;
 use oat\tao\scripts\install\CreateWebhookEventLogTable;
 use oat\tao\scripts\install\InstallNotificationTable;
 use oat\tao\scripts\install\RegisterActionService;
-use oat\tao\scripts\install\RegisterResourceEvents;
 use oat\tao\scripts\install\RegisterEvents;
+use oat\tao\scripts\install\RegisterResourceEvents;
 use oat\tao\scripts\install\RegisterResourceWatcherService;
 use oat\tao\scripts\install\RegisterSignatureGenerator;
 use oat\tao\scripts\install\RegisterTaskQueueServices;
@@ -54,6 +52,7 @@ use oat\tao\scripts\install\SetServiceFileStorage;
 use oat\tao\scripts\install\SetServiceState;
 use oat\tao\scripts\install\SetupMaintenanceService;
 use oat\tao\scripts\install\SetUpQueueTasks;
+use oat\tao\scripts\update\Updater;
 
 $extpath = __DIR__ . DIRECTORY_SEPARATOR;
 
@@ -62,7 +61,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.5.0',
+    'version' => '45.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/models/classes/security/xsrf/TokenService.php
+++ b/models/classes/security/xsrf/TokenService.php
@@ -165,9 +165,7 @@ class TokenService extends ConfigurableService
             throw new common_exception_Unauthorized();
         }
 
-        $this->revokeToken($token);
-
-        return $isValid;
+        return $this->revokeToken($token);
     }
 
     /**

--- a/models/classes/security/xsrf/TokenService.php
+++ b/models/classes/security/xsrf/TokenService.php
@@ -47,27 +47,34 @@ class TokenService extends ConfigurableService
     public const SERVICE_ID = 'tao/security-xsrf-token';
 
     // options keys
-    public const POOL_SIZE_OPT = 'poolSize';
-    public const TIME_LIMIT_OPT = 'timeLimit';
+    public const POOL_SIZE_OPT       = 'poolSize';
+    public const TIME_LIMIT_OPT      = 'timeLimit';
     public const VALIDATE_TOKENS_OPT = 'validateTokens';
-    public const OPTION_STORE = 'store';
+    public const OPTION_STORE        = 'store';
     public const OPTION_CLIENT_STORE = 'clientStore';
 
-    public const OPTION_CLIENT_STORE_LOCAL_STORAGE = 'localStorage';
-    public const OPTION_CLIENT_STORE_LOCAL_SESSION_STORAGE = 'sessionStorage';
+    public const OPTION_CLIENT_STORE_LOCAL_STORAGE            = 'localStorage';
+    public const OPTION_CLIENT_STORE_LOCAL_SESSION_STORAGE    = 'sessionStorage';
     public const OPTION_CLIENT_STORE_LOCAL_SESSION_INDEXED_DB = 'indexedDB';
-    public const OPTION_CLIENT_STORE_MEMORY = 'memory';
+    public const OPTION_CLIENT_STORE_MEMORY                   = 'memory';
 
-    public const CSRF_TOKEN_HEADER = 'X-CSRF-Token';
-    public const FORM_POOL = 'form_pool';
-    public const JS_DATA_KEY = 'tokenHandler';
-    public const JS_TOKEN_KEY = 'tokens';
-    public const JS_TOKEN_POOL_SIZE_KEY = 'maxSize';
+    public const CLIENT_STORE_OPTION_VALUES = [
+        self::OPTION_CLIENT_STORE_LOCAL_STORAGE,
+        self::OPTION_CLIENT_STORE_LOCAL_SESSION_STORAGE,
+        self::OPTION_CLIENT_STORE_LOCAL_SESSION_INDEXED_DB,
+        self::OPTION_CLIENT_STORE_MEMORY,
+    ];
+
+    public const CSRF_TOKEN_HEADER       = 'X-CSRF-Token';
+    public const FORM_POOL               = 'form_pool';
+    public const JS_DATA_KEY             = 'tokenHandler';
+    public const JS_TOKEN_KEY            = 'tokens';
+    public const JS_TOKEN_POOL_SIZE_KEY  = 'maxSize';
     public const JS_TOKEN_TIME_LIMIT_KEY = 'tokenTimeLimit';
-    public const JS_TOKEN_STORE = 'store';
+    public const JS_TOKEN_STORE          = 'store';
 
-    private const DEFAULT_POOL_SIZE = 6;
-    private const DEFAULT_TIME_LIMIT = 0;
+    private const DEFAULT_POOL_SIZE    = 6;
+    private const DEFAULT_TIME_LIMIT   = 0;
     private const DEFAULT_CLIENT_STORE = self::OPTION_CLIENT_STORE_MEMORY;
 
     /**
@@ -426,14 +433,7 @@ class TokenService extends ConfigurableService
     {
         $store = $this->getOption(self::OPTION_CLIENT_STORE, self::DEFAULT_CLIENT_STORE);
 
-        static $validStoreOptions = [
-            self::OPTION_CLIENT_STORE_LOCAL_STORAGE,
-            self::OPTION_CLIENT_STORE_LOCAL_SESSION_STORAGE,
-            self::OPTION_CLIENT_STORE_LOCAL_SESSION_INDEXED_DB,
-            self::OPTION_CLIENT_STORE_MEMORY,
-        ];
-
-        return in_array($store, $validStoreOptions, true)
+        return in_array($store, self::CLIENT_STORE_OPTION_VALUES, true)
             ? $store
             : self::DEFAULT_CLIENT_STORE;
     }

--- a/models/classes/security/xsrf/TokenService.php
+++ b/models/classes/security/xsrf/TokenService.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * This program is free software; you can redistribute it and/or
@@ -15,16 +15,18 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2019 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2020 (original work) Open Assessment Technologies SA ;
  */
 
 namespace oat\tao\model\security\xsrf;
 
+use common_Exception;
 use common_exception_Unauthorized;
 use oat\oatbox\log\LoggerAwareTrait;
 use oat\oatbox\service\ConfigurableService;
-use oat\tao\model\security\TokenGenerator;
 use oat\oatbox\service\exception\InvalidService;
+use oat\tao\model\security\TokenGenerator;
+use PHPSession;
 
 /**
  * This service let's you manage tokens to protect against XSRF.
@@ -42,32 +44,32 @@ class TokenService extends ConfigurableService
     use TokenGenerator;
     use LoggerAwareTrait;
 
-    const SERVICE_ID = 'tao/security-xsrf-token';
+    public const SERVICE_ID = 'tao/security-xsrf-token';
 
     // options keys
-    const POOL_SIZE_OPT = 'poolSize';
-    const TIME_LIMIT_OPT = 'timeLimit';
-    const VALIDATE_TOKENS_OPT = 'validateTokens';
-    const OPTION_STORE = 'store';
+    public const POOL_SIZE_OPT = 'poolSize';
+    public const TIME_LIMIT_OPT = 'timeLimit';
+    public const VALIDATE_TOKENS_OPT = 'validateTokens';
+    public const OPTION_STORE = 'store';
 
-    const DEFAULT_POOL_SIZE = 6;
-    const DEFAULT_TIME_LIMIT = 0;
+    public const CSRF_TOKEN_HEADER = 'X-CSRF-Token';
+    public const FORM_POOL = 'form_pool';
+    public const JS_DATA_KEY = 'tokenHandler';
+    public const JS_TOKEN_KEY = 'tokens';
+    public const JS_TOKEN_POOL_SIZE_KEY = 'maxSize';
+    public const JS_TOKEN_TIME_LIMIT_KEY = 'tokenTimeLimit';
 
-    const CSRF_TOKEN_HEADER = 'X-CSRF-Token';
-    const FORM_POOL = 'form_pool';
-    const JS_DATA_KEY = 'tokenHandler';
-    const JS_TOKEN_KEY = 'tokens';
-    const JS_TOKEN_POOL_SIZE_KEY = 'maxSize';
-    const JS_TOKEN_TIME_LIMIT_KEY = 'tokenTimeLimit';
+    private const DEFAULT_POOL_SIZE = 6;
+    private const DEFAULT_TIME_LIMIT = 0;
 
     /**
      * Generates, stores and return a brand new token
      * Triggers the pool invalidation.
      *
      * @return Token
-     * @throws \common_Exception
+     * @throws common_Exception
      */
-    public function createToken()
+    public function createToken(): Token
     {
         $store = $this->getStore();
         $pool = $this->invalidate($store->getTokens());
@@ -84,9 +86,11 @@ class TokenService extends ConfigurableService
      * (does not revoke)
      *
      * @param string|Token $token The given token to validate
+     *
      * @return boolean
+     * @throws InvalidService
      */
-    public function checkToken($token)
+    public function checkToken($token): bool
     {
         $valid = false;
         $pool = $this->getStore()->getTokens();
@@ -112,10 +116,10 @@ class TokenService extends ConfigurableService
      *
      * @param string |Token $token
      * @return boolean
-     * @throws \common_Exception`
+     * @throws common_Exception
      * @throws common_exception_Unauthorized
      */
-    public function validateToken($token)
+    public function validateToken($token): bool
     {
         $isValid = false;
         $expired = false;
@@ -157,7 +161,7 @@ class TokenService extends ConfigurableService
      * @param Token $token
      * @return bool
      */
-    private function isExpired(Token $token)
+    private function isExpired(Token $token): bool
     {
         $expired = false;
         $actualTime = microtime(true);
@@ -174,9 +178,12 @@ class TokenService extends ConfigurableService
      * Revokes the given token
      *
      * @param string|Token $token
+     *
      * @return true
+     *
+     * @throws InvalidService
      */
-    public function revokeToken($token)
+    public function revokeToken($token): bool
     {
         $revoked = false;
         $store = $this->getStore();
@@ -205,14 +212,15 @@ class TokenService extends ConfigurableService
      * Gets this session's name for token
      * @return string
      */
-    public function getTokenName()
+    public function getTokenName(): string
     {
-        $session = \PHPSession::singleton();
+        /** @var PHPSession $session */
+        $session = PHPSession::singleton();
 
         if ($session->hasAttribute(TokenStore::TOKEN_NAME)) {
             $name = $session->getAttribute(TokenStore::TOKEN_NAME);
         } else {
-            $name = 'tao_' . substr(md5(microtime()), rand(0, 25), 7);
+            $name = 'tao_' . substr(md5(microtime()), mt_rand(0, 25), 7);
             $session->setAttribute(TokenStore::TOKEN_NAME, $name);
         }
 
@@ -223,16 +231,20 @@ class TokenService extends ConfigurableService
      * Invalidate the tokens in the pool :
      *  - remove the oldest if the pool raises it's size limit
      *  - remove the expired tokens
+     *
      * @param Token[] $pool
+     *
      * @return array the invalidated pool
+     *
+     * @throws InvalidService
      */
-    protected function invalidate($pool)
+    protected function invalidate(array $pool): array
     {
         $actualTime = microtime(true);
         $timeLimit = $this->getTimeLimit();
         $poolSize = $this->getPoolSize();
 
-        $reduced = array_filter($pool, function ($token) use ($actualTime, $timeLimit) {
+        $reduced = array_filter($pool, static function (Token $token) use ($actualTime, $timeLimit) {
             if ($timeLimit > 0) {
                 return $token->getCreatedAt() + $timeLimit > $actualTime;
             }
@@ -240,7 +252,7 @@ class TokenService extends ConfigurableService
         });
 
         if ($poolSize > 0 && count($reduced) > 0) {
-            uasort($reduced, function ($a, $b) {
+            uasort($reduced, static function (Token $a, Token $b) {
                 if ($a->getCreatedAt() === $b->getCreatedAt()) {
                     return 0;
                 }
@@ -258,11 +270,14 @@ class TokenService extends ConfigurableService
 
     /**
      * Get the configured pool size
+     *
      * @param bool $withForm - Takes care of the FORM_POOL
+     *
      * @return int the pool size, 10 by default
+     *
      * @throws InvalidService
      */
-    public function getPoolSize($withForm = true)
+    public function getPoolSize(bool $withForm = true): int
     {
         $poolSize = self::DEFAULT_POOL_SIZE;
         if ($this->hasOption(self::POOL_SIZE_OPT)) {
@@ -282,9 +297,10 @@ class TokenService extends ConfigurableService
 
     /**
      * Get the configured time limit in seconds
+     *
      * @return int the limit
      */
-    protected function getTimeLimit()
+    protected function getTimeLimit(): int
     {
         $timeLimit = self::DEFAULT_TIME_LIMIT;
         if ($this->hasOption(self::TIME_LIMIT_OPT)) {
@@ -295,9 +311,12 @@ class TokenService extends ConfigurableService
 
     /**
      * Get the configured store
+     *
      * @return TokenStore the store
+     *
+     * @throws InvalidService
      */
-    protected function getStore()
+    protected function getStore(): TokenStore
     {
         $store = $this->getOption(self::OPTION_STORE);
         if (!$store instanceof TokenStore) {
@@ -310,9 +329,9 @@ class TokenService extends ConfigurableService
      * Generate a token pool, and return it.
      *
      * @return Token[]
-     * @throws \common_Exception
+     * @throws common_Exception
      */
-    public function generateTokenPool()
+    public function generateTokenPool(): array
     {
         $store = $this->getStore();
         $pool = $store->getTokens();
@@ -339,10 +358,12 @@ class TokenService extends ConfigurableService
 
     /**
      * Gets the client configuration
+     *
      * @return array
-     * @throws \common_Exception
+     *
+     * @throws common_Exception
      */
-    public function getClientConfig()
+    public function getClientConfig(): array
     {
         $tokenPool = $this->generateTokenPool();
         $jsTokenPool = [];
@@ -362,9 +383,9 @@ class TokenService extends ConfigurableService
 
     /**
      * Add a token that can be used for forms.
-     * @throws \common_Exception
+     * @throws common_Exception
      */
-    public function addFormToken()
+    public function addFormToken(): void
     {
         $store = $this->getStore();
         $tokenPool = $store->getTokens();
@@ -377,9 +398,9 @@ class TokenService extends ConfigurableService
     /**
      * Get a token from the pool, which can be used for forms.
      * @return Token
-     * @throws \common_Exception
+     * @throws common_Exception
      */
-    public function getFormToken()
+    public function getFormToken(): Token
     {
         $store = $this->getStore();
         $tokenPool = $store->getTokens();

--- a/models/classes/security/xsrf/TokenService.php
+++ b/models/classes/security/xsrf/TokenService.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 /**
  * This program is free software; you can redistribute it and/or
@@ -17,6 +17,8 @@
  *
  * Copyright (c) 2017-2020 (original work) Open Assessment Technologies SA ;
  */
+
+declare(strict_types=1);
 
 namespace oat\tao\model\security\xsrf;
 

--- a/models/classes/security/xsrf/TokenService.php
+++ b/models/classes/security/xsrf/TokenService.php
@@ -51,6 +51,12 @@ class TokenService extends ConfigurableService
     public const TIME_LIMIT_OPT = 'timeLimit';
     public const VALIDATE_TOKENS_OPT = 'validateTokens';
     public const OPTION_STORE = 'store';
+    public const OPTION_CLIENT_STORE = 'clientStore';
+
+    public const OPTION_CLIENT_STORE_LOCAL_STORAGE = 'localStorage';
+    public const OPTION_CLIENT_STORE_LOCAL_SESSION_STORAGE = 'sessionStorage';
+    public const OPTION_CLIENT_STORE_LOCAL_SESSION_INDEXED_DB = 'indexedDB';
+    public const OPTION_CLIENT_STORE_MEMORY = 'memory';
 
     public const CSRF_TOKEN_HEADER = 'X-CSRF-Token';
     public const FORM_POOL = 'form_pool';
@@ -58,9 +64,11 @@ class TokenService extends ConfigurableService
     public const JS_TOKEN_KEY = 'tokens';
     public const JS_TOKEN_POOL_SIZE_KEY = 'maxSize';
     public const JS_TOKEN_TIME_LIMIT_KEY = 'tokenTimeLimit';
+    public const JS_TOKEN_STORE = 'store';
 
     private const DEFAULT_POOL_SIZE = 6;
     private const DEFAULT_TIME_LIMIT = 0;
+    private const DEFAULT_CLIENT_STORE = self::OPTION_CLIENT_STORE_MEMORY;
 
     /**
      * Generates, stores and return a brand new token
@@ -377,7 +385,8 @@ class TokenService extends ConfigurableService
             self::JS_TOKEN_TIME_LIMIT_KEY => $this->getTimeLimit() * 1000,
             self::JS_TOKEN_POOL_SIZE_KEY => $this->getPoolSize(false),
             self::JS_TOKEN_KEY => $jsTokenPool,
-            self::VALIDATE_TOKENS_OPT => $this->getOption(self::VALIDATE_TOKENS_OPT)
+            self::VALIDATE_TOKENS_OPT => $this->getOption(self::VALIDATE_TOKENS_OPT),
+            self::JS_TOKEN_STORE => $this->getClientStore(),
         ];
     }
 
@@ -411,5 +420,21 @@ class TokenService extends ConfigurableService
         }
 
         return $tokenPool[self::FORM_POOL];
+    }
+
+    private function getClientStore(): string
+    {
+        $store = $this->getOption(self::OPTION_CLIENT_STORE, self::DEFAULT_CLIENT_STORE);
+
+        static $validStoreOptions = [
+            self::OPTION_CLIENT_STORE_LOCAL_STORAGE,
+            self::OPTION_CLIENT_STORE_LOCAL_SESSION_STORAGE,
+            self::OPTION_CLIENT_STORE_LOCAL_SESSION_INDEXED_DB,
+            self::OPTION_CLIENT_STORE_MEMORY,
+        ];
+
+        return in_array($store, $validStoreOptions, true)
+            ? $store
+            : self::DEFAULT_CLIENT_STORE;
     }
 }

--- a/scripts/tools/SetupClientCsrfTokenPoolStore.php
+++ b/scripts/tools/SetupClientCsrfTokenPoolStore.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\scripts\tools;
+
+use common_report_Report as Report;
+use Exception;
+use InvalidArgumentException;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\tao\model\security\xsrf\TokenService;
+
+class SetupClientCsrfTokenPoolStore extends ScriptAction
+{
+    private const OPTION_STORE = 'store';
+
+    protected function provideOptions(): array
+    {
+        return [
+            self::OPTION_STORE => [
+                'prefix'      => 's',
+                'longPrefix'  => self::OPTION_STORE,
+                'required'    => true,
+                'description' => "One of {$this->createFormattedStoreOptionValues()}",
+            ],
+        ];
+    }
+
+    protected function provideDescription(): string
+    {
+        return 'Set a client-side CSRF token pool store preference.';
+    }
+
+    protected function run(): Report
+    {
+        try {
+            /** @var TokenService $tokenService */
+            $tokenService = $this->getServiceLocator()->get(TokenService::class);
+
+            $storeOption = $this->getStoreOption();
+
+            $tokenService->setOptions(
+                array_replace(
+                    $tokenService->getOptions(),
+                    [
+                        TokenService::OPTION_CLIENT_STORE => $storeOption,
+                    ]
+                )
+            );
+
+            $this->getServiceManager()->register(TokenService::SERVICE_ID, $tokenService);
+        } catch (Exception $exception) {
+            return Report::createFailure($exception->getMessage());
+        }
+
+        return Report::createSuccess(
+            sprintf(
+                'Set "%s"\'s "%s" option to "%s"',
+                TokenService::class,
+                TokenService::OPTION_CLIENT_STORE,
+                $storeOption
+            )
+        );
+    }
+
+    private function getStoreOption(): string
+    {
+        $value = $this->getOption(self::OPTION_STORE);
+
+        if (!in_array($value, TokenService::CLIENT_STORE_OPTION_VALUES, true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    '"%s" must be one of %s, "%s" given.',
+                    self::OPTION_STORE,
+                    $this->createFormattedStoreOptionValues(),
+                    $value
+                )
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return string
+     */
+    private function createFormattedStoreOptionValues(): string
+    {
+        return sprintf('"%s"', implode('", "', TokenService::CLIENT_STORE_OPTION_VALUES));
+    }
+}

--- a/test/unit/model/security/xsrf/TokenServiceTest.php
+++ b/test/unit/model/security/xsrf/TokenServiceTest.php
@@ -385,7 +385,7 @@ class TokenServiceTest extends TestCase
         $storeMock = $this->prophesize(TokenStore::class);
         $storeMock->getTokens()->willReturn([]);
         $storeMock->setTokens(Argument::any())->will(
-            static function ($args) use ($storeMock) {
+            function ($args) use ($storeMock) {
                 $storeMock->getTokens()->willReturn($args[0]);
             }
         );

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -24,9 +24,8 @@
             "integrity": "sha512-XZhhEtGsrEctcr4ZEuTop1N96IRV8iWNTA2Ffvk83n7GDqSYZpLePkFK1VFxPKc1HlLEoXzx+YLQotq4UJQjvQ=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.5.0.tgz",
-            "integrity": "sha512-f2kg//lksuQjAk+w/qFXocRja5/LWJ4D6yWNfb+NXb4eyom4bediIr7+rQJxFD2NvVPclM0xyPwjuVxF4rHIBg==",
+            "version": "github:oat-sa/tao-core-sdk-fe#42b44ac08998b3180bb616ecca65319f754602a3",
+            "from": "github:oat-sa/tao-core-sdk-fe#feature/TBD-48/configurable-csrf-token-pool-store",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "^1.0.14",
                 "idb-wrapper": "1.7.0",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -24,8 +24,9 @@
             "integrity": "sha512-XZhhEtGsrEctcr4ZEuTop1N96IRV8iWNTA2Ffvk83n7GDqSYZpLePkFK1VFxPKc1HlLEoXzx+YLQotq4UJQjvQ=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "github:oat-sa/tao-core-sdk-fe#eafcdd3ee7ea81e935596564c354a79bdb97f440",
-            "from": "github:oat-sa/tao-core-sdk-fe#fix/TBD-48/initialize-token-pool-by-configuration-values-on-first-access",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.6.2.tgz",
+            "integrity": "sha512-7o3TELgVLKI4/sZOxGr3D5UBAB5dEtMpPoqVRPO/m6Oypip7QYPGL1I4L7WKUfgTTUXthntUUT/svGJPYyUKng==",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "^1.0.14",
                 "idb-wrapper": "1.7.0",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -24,9 +24,8 @@
             "integrity": "sha512-XZhhEtGsrEctcr4ZEuTop1N96IRV8iWNTA2Ffvk83n7GDqSYZpLePkFK1VFxPKc1HlLEoXzx+YLQotq4UJQjvQ=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.6.0.tgz",
-            "integrity": "sha512-j57sZhj/oEVPEcLj5ZPplkbhjnPcNG3dR9+b3VcEbcxMUT53mWphb1UQYSA+0yyKeBruTYmI35xxCZSnbMz7NQ==",
+            "version": "github:oat-sa/tao-core-sdk-fe#eafcdd3ee7ea81e935596564c354a79bdb97f440",
+            "from": "github:oat-sa/tao-core-sdk-fe#fix/TBD-48/initialize-token-pool-by-configuration-values-on-first-access",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "^1.0.14",
                 "idb-wrapper": "1.7.0",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -24,8 +24,9 @@
             "integrity": "sha512-XZhhEtGsrEctcr4ZEuTop1N96IRV8iWNTA2Ffvk83n7GDqSYZpLePkFK1VFxPKc1HlLEoXzx+YLQotq4UJQjvQ=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "github:oat-sa/tao-core-sdk-fe#42b44ac08998b3180bb616ecca65319f754602a3",
-            "from": "github:oat-sa/tao-core-sdk-fe#feature/TBD-48/configurable-csrf-token-pool-store",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.6.0.tgz",
+            "integrity": "sha512-j57sZhj/oEVPEcLj5ZPplkbhjnPcNG3dR9+b3VcEbcxMUT53mWphb1UQYSA+0yyKeBruTYmI35xxCZSnbMz7NQ==",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "^1.0.14",
                 "idb-wrapper": "1.7.0",

--- a/views/package.json
+++ b/views/package.json
@@ -11,7 +11,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/tao-core-libs": "^0.4.2",
-        "@oat-sa/tao-core-sdk": "1.5.0",
+        "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#feature/TBD-48/configurable-csrf-token-pool-store",
         "@oat-sa/tao-core-shared-libs": "1.0.2",
         "@oat-sa/tao-core-ui": "1.6.0",
         "async": "0.2.10",

--- a/views/package.json
+++ b/views/package.json
@@ -11,7 +11,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/tao-core-libs": "^0.4.2",
-        "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#fix/TBD-48/initialize-token-pool-by-configuration-values-on-first-access",
+        "@oat-sa/tao-core-sdk": "1.6.2",
         "@oat-sa/tao-core-shared-libs": "1.0.2",
         "@oat-sa/tao-core-ui": "1.6.0",
         "async": "0.2.10",

--- a/views/package.json
+++ b/views/package.json
@@ -11,7 +11,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/tao-core-libs": "^0.4.2",
-        "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#feature/TBD-48/configurable-csrf-token-pool-store",
+        "@oat-sa/tao-core-sdk": "1.6.0",
         "@oat-sa/tao-core-shared-libs": "1.0.2",
         "@oat-sa/tao-core-ui": "1.6.0",
         "async": "0.2.10",

--- a/views/package.json
+++ b/views/package.json
@@ -11,7 +11,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/tao-core-libs": "^0.4.2",
-        "@oat-sa/tao-core-sdk": "1.6.0",
+        "@oat-sa/tao-core-sdk": "oat-sa/tao-core-sdk-fe#fix/TBD-48/initialize-token-pool-by-configuration-values-on-first-access",
         "@oat-sa/tao-core-shared-libs": "1.0.2",
         "@oat-sa/tao-core-ui": "1.6.0",
         "async": "0.2.10",


### PR DESCRIPTION
- [TBD-48](https://oat-sa.atlassian.net/browse/TBD-48) chore: apply strict types and define return and argument types in `TokenService`
- [TBD-48](https://oat-sa.atlassian.net/browse/TBD-48) feat: add `TokenService::OPTION_CLIENT_STORE` option support, defining a client-side store for the token pool
- [TBD-48](https://oat-sa.atlassian.net/browse/TBD-48) feat: add `SetupClientCsrfTokenPoolStore` script action, allowing to redefine `TokenService`'s `clientStore` option value
- [TBD-48](https://oat-sa.atlassian.net/browse/TBD-48) chore(version): bump a minor one
- [TBD-48](https://oat-sa.atlassian.net/browse/TBD-48) chore(dependency): add a dependency on `@oat-sa/tao-test-runner-qti` `1.6.2`, fixing a client-side CSRF token pool initialization

ℹ️ Run `php index.php 'oat\tao\scripts\tools\SetupClientCsrfTokenPoolStore' -s localStorage` in order to enable `LocalStorage` client token pool store.
ℹ️ Required by `extension-tao-udir`[#88](https://github.com/oat-sa/extension-tao-udir/pull/88).

⚠️ Depends on `tao-core-sdk-fe` [#70](https://github.com/oat-sa/tao-core-sdk-fe/pull/70).
⚠️ Depends on `tao-core-sdk-fe` [#73](https://github.com/oat-sa/tao-core-sdk-fe/pull/73).