### PR TITLE
Fix TAO-10108 apply ACL to search results

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -61,7 +61,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.6.0',
+    'version' => '45.6.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/views/js/layout/search.js
+++ b/views/js/layout/search.js
@@ -48,16 +48,18 @@ function($, _, __, section, actionManager, feedback){
         //create a datatable
         $tableContainer.datatable({
             url: data.url,
-            model : _.values(data.model),
-            actions : {
-                open : function openResource(id){
+            model: _.values(data.model),
+            actions: [{
+                id: 'open',
+                label: 'Open',
+                action: function openResource(id) {
                     actionManager.trigger('refresh', {
-                        uri : id
+                        uri: id
                     });
                 }
-            },
-            params : {
-                params : data.params,
+            }],
+            params: {
+                params: data.params,
                 filters: data.filters,
                 rows: 20
             }


### PR DESCRIPTION
- [TAO-10108](https://oat-sa.atlassian.net/browse/TAO-10108) chore: apply `strict_types` to `class.Search.php`
- [TAO-10108](https://oat-sa.atlassian.net/browse/TAO-10108) chore: declare return types of `tao_actions_Search` methods
- [TAO-10108](https://oat-sa.atlassian.net/browse/TAO-10108) chore: inject services into methods of `tao_actions_Search` instead of fetching them directly from a service locator
- [TAO-10108](https://oat-sa.atlassian.net/browse/TAO-10108) fix: remove a catch of never-thrown `SyntaxException` from `tao_actions_Search::search()`
- [TAO-10108](https://oat-sa.atlassian.net/browse/TAO-10108) feat: display `Access Denied` instead of a search result element in cases a current user has no `READ` permission on the element
- [TAO-10108](https://oat-sa.atlassian.net/browse/TAO-10108) feat: add `readonly` property to a `search` response, blocking any action on a search result element
- [TAO-10108](https://oat-sa.atlassian.net/browse/TAO-10108) fix: remove a non-existent icon from search result `open` action button
- [TAO-10108](https://oat-sa.atlassian.net/browse/TAO-10108) chore(version): bump a fix one