### PR TITLE
Fix TAO 10464 - Uncaught type error upon dragging the Media Interaction on canvas

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -61,7 +61,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.6.3',
+    'version' => '45.6.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,9 +39,9 @@
             "integrity": "sha512-HAMEy5L43+Rq3oJd+Sa1cCdYbO9gwBwSlIEs+H4HuGhv8oCBj28KCz0GT2KNllqem/13fIgvfytXVdOX0E08+A=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.7.0.tgz",
-            "integrity": "sha512-6Pl9v8XT+adq4tzNSJ/b06xayywicsGktVq6D+YVBDCsnH3zTPv1IYS7bcbTpBnsGqXkKb5EVtCU6tjWbrixrQ=="
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.7.1.tgz",
+            "integrity": "sha512-LTiTm+Qsr7TiyKDNgFY8Nv0w/4muVuIRfATjLCrDuOqU2xb0laSUbkhXlmo0pOAp89OKTqKvL/JniM578cCSqg=="
         },
         "amdefine": {
             "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^0.4.2",
         "@oat-sa/tao-core-sdk": "1.6.2",
         "@oat-sa/tao-core-shared-libs": "1.0.2",
-        "@oat-sa/tao-core-ui": "1.7.0",
+        "@oat-sa/tao-core-ui": "1.7.1",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",


### PR DESCRIPTION
**Related to this PR - Needs to this PR merge before and published**

https://github.com/oat-sa/tao-core-ui-fe/pull/163

**Related to this issue**

https://oat-sa.atlassian.net/browse/TAO-10464

**Description**

When the user drags the Media Interaction on the canvas, there's no file selection window opens. Instead 'Uncaught type error' appears on the browser console and the widow opens only after clicking empty space outside the interaction and clicking it again.

**Steps to reproduce**

- Go to the Items tab.
- Create a new item and go to Authoring.
- Drag and drop Media Interaction on the canvas.

**Actual result**

Error in console, the file selection window is not opened.

**Expected result**

The file selection window shows up without any errors.