### PR TITLE
Fix/tao 10108/use interface in method type

### DIFF
--- a/actions/class.Search.php
+++ b/actions/class.Search.php
@@ -27,7 +27,7 @@ use oat\generis\model\OntologyAwareTrait;
 use oat\generis\model\OntologyRdfs;
 use oat\tao\model\search\index\OntologyIndexService;
 use oat\tao\model\search\ResultSet;
-use oat\tao\model\search\strategy\GenerisSearch;
+use oat\tao\model\search\Search;
 
 /**
  * Controller for indexed searches
@@ -68,10 +68,10 @@ class tao_actions_Search extends tao_actions_CommonModule
      * Search results
      * The search is paginated and initiated by the datatable component.
      *
-     * @param GenerisSearch    $searchService
+     * @param Search    $searchService
      * @param PermissionHelper $permissionHelper
      */
-    public function search(GenerisSearch $searchService, PermissionHelper $permissionHelper): void
+    public function search(Search $searchService, PermissionHelper $permissionHelper): void
     {
         $params = $this->getRequestParameter('params');
         $query = $params['query'];

--- a/manifest.php
+++ b/manifest.php
@@ -61,7 +61,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.6.4',
+    'version' => '45.6.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/models/classes/routing/ActionEnforcer.php
+++ b/models/classes/routing/ActionEnforcer.php
@@ -269,7 +269,7 @@ class ActionEnforcer implements IExecutable, ServiceManagerAwareInterface, TaoLo
                 $actionParameters[$paramName] = $parameters[$paramName];
             } elseif($paramTypeName === ServerRequest::class) {
                 $actionParameters[$paramName] = $request;
-            } elseif (class_exists($paramTypeName)) {
+            } elseif (class_exists($paramTypeName) || interface_exists($paramTypeName)) {
                 $actionParameters[$paramName] = $this->getClassInstance($paramTypeName);
             } elseif (!$param->isDefaultValueAvailable()) {
                 $this->logWarning('Missing parameter ' . $paramName . ' for ' . $this->getControllerClass() . '@' . $action);


### PR DESCRIPTION
JIRA ticket: https://oat-sa.atlassian.net/browse/TAO-10108

Fixed input parameter type to support other implementations of search service

Details: 
Previous change made in https://github.com/oat-sa/tao-core/pull/2636 broke advanced search functionality when using elasticsearch implementation - https://github.com/oat-sa/lib-tao-elasticsearch/blob/master/src/ElasticSearch.php as a SearchService.

How to test:
- configure search.conf.php to retunr instnce of `ElasticSearch` instead of `GenerisSearch`
- make sure it doesn't fail when trying to use advanced search
