### PR TITLE
Fix UNO 444 - Broken layers in DEMO when background tasks menu opened

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.7.2',
+    'version' => '45.7.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -34,9 +34,9 @@
             }
         },
         "@oat-sa/tao-core-shared-libs": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.0.2.tgz",
-            "integrity": "sha512-HAMEy5L43+Rq3oJd+Sa1cCdYbO9gwBwSlIEs+H4HuGhv8oCBj28KCz0GT2KNllqem/13fIgvfytXVdOX0E08+A=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.0.3.tgz",
+            "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
             "version": "1.7.4",

--- a/views/package.json
+++ b/views/package.json
@@ -12,7 +12,7 @@
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/tao-core-libs": "^0.4.2",
         "@oat-sa/tao-core-sdk": "1.6.2",
-        "@oat-sa/tao-core-shared-libs": "1.0.2",
+        "@oat-sa/tao-core-shared-libs": "1.0.3",
         "@oat-sa/tao-core-ui": "1.7.4",
         "async": "0.2.10",
         "codemirror": "^5.54.0",


### PR DESCRIPTION
**Needs merge and publish this PR's first**

https://github.com/oat-sa/ckeditor-dev/pull/20

https://github.com/oat-sa/tao-core-shared-libs-fe/pull/9

**Related to**

https://oat-sa.atlassian.net/browse/UNO-444

**Description**

There're some issues with layers when the browser window resolution set to the smaller size e.g. 900x700 and the item has a property type set to Text - Long - HTML editor: the list of background tasks partially covered by edit item properties form. Reproduced only in `UDIR` demo environment.

**Preconditions**

Class property type is set to Text - Long - HTML editor.

**Steps to reproduce**

- Navigate to the Items tab
- Narrow the browser window 
- Open the Background tasks menu

**Actual result**

The opened Background tasks menu is partially covered by 'Kommentar' field in edit item properties filed.

**Expected result**

The opened Background tasks menu covers the edit item properties form.

![imagen](https://user-images.githubusercontent.com/34692207/91433018-e4209100-e862-11ea-9310-55fb6070c129.png)