### PR TITLE
TAO-10287 reindexed resources when moving classes

### DIFF
--- a/models/classes/resources/ResourceWatcher.php
+++ b/models/classes/resources/ResourceWatcher.php
@@ -158,8 +158,6 @@ class ResourceWatcher extends ConfigurableService
 
     private function hasResourceSupport(core_kernel_classes_Resource $resource): bool
     {
-        $this->logInfo(self::class. ' :: '. $resource->getUri(). ' ::' . $resource->getLabel() );
-
         $resourceTypeIds = array_map(
             function (core_kernel_classes_Class $resourceType): string {
                 return $resourceType->getUri();

--- a/models/classes/resources/ResourceWatcher.php
+++ b/models/classes/resources/ResourceWatcher.php
@@ -21,6 +21,7 @@
 
 namespace oat\tao\model\resources;
 
+use common_http_Request;
 use core_kernel_classes_Class;
 use core_kernel_classes_Resource;
 use oat\generis\model\data\event\ResourceCreated;
@@ -31,6 +32,7 @@ use oat\generis\model\OntologyRdfs;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\search\index\IndexUpdaterInterface;
 use oat\tao\model\search\Search;
+use oat\tao\model\search\tasks\UpdateClassInIndex;
 use oat\tao\model\search\tasks\UpdateResourceInIndex;
 use oat\tao\model\TaoOntology;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
@@ -139,6 +141,13 @@ class ResourceWatcher extends ConfigurableService
      */
     private function createResourceIndexingTask(core_kernel_classes_Resource $resource, string $message): void
     {
+        if ($this->hasClassSupport($resource) && !$this->ignoreEditIemClassUpdates()) {
+            $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
+            $queueDispatcher->createTask(new UpdateClassInIndex(), [$resource->getUri()], $message);
+
+            return;
+        }
+
         if ($this->hasResourceSupport($resource)) {
             $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
             $queueDispatcher->createTask(new UpdateResourceInIndex(), [$resource->getUri()], $message);
@@ -149,6 +158,8 @@ class ResourceWatcher extends ConfigurableService
 
     private function hasResourceSupport(core_kernel_classes_Resource $resource): bool
     {
+        $this->logInfo(self::class. ' :: '. $resource->getUri(). ' ::' . $resource->getLabel() );
+
         $resourceTypeIds = array_map(
             function (core_kernel_classes_Class $resourceType): string {
                 return $resourceType->getUri();
@@ -183,5 +194,21 @@ class ResourceWatcher extends ConfigurableService
         }
 
         return false;
+    }
+
+    private function hasClassSupport(core_kernel_classes_Resource $resource): bool
+    {
+        return $resource instanceof core_kernel_classes_Class;
+    }
+
+    private function ignoreEditIemClassUpdates(): bool
+    {
+        try {
+            $url = parse_url(common_http_Request::currentRequest()->getUrl());
+        } catch (\common_exception_Error $e) {
+            return false;
+        }
+
+        return isset($url['path']) && $url['path'] === '/taoItems/Items/editItemClass';
     }
 }

--- a/models/classes/search/index/IndexIteratorFactory.php
+++ b/models/classes/search/index/IndexIteratorFactory.php
@@ -35,7 +35,7 @@ class IndexIteratorFactory
         $this->serviceLocator = $serviceLocator;
     }
 
-    public function make(array $classes): IndexIterator
+    public function create(array $classes): IndexIterator
     {
         $iterator = new ResourceIterator($classes);
         $iterator->setServiceLocator($this->getServiceLocator());

--- a/models/classes/search/index/IndexIteratorFactory.php
+++ b/models/classes/search/index/IndexIteratorFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\search\index;
+
+use oat\tao\model\resources\ResourceIterator;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class IndexIteratorFactory
+{
+    use ServiceLocatorAwareTrait;
+
+    public function __construct(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    public function make (array $classes): IndexIterator
+    {
+        $iterator = new ResourceIterator($classes);
+        $iterator->setServiceLocator($this->getServiceLocator());
+
+        $indexIterator = new IndexIterator($iterator);
+        $indexIterator->setServiceLocator($this->getServiceLocator());
+
+        return $indexIterator;
+    }
+}

--- a/models/classes/search/index/IndexIteratorFactory.php
+++ b/models/classes/search/index/IndexIteratorFactory.php
@@ -35,7 +35,7 @@ class IndexIteratorFactory
         $this->serviceLocator = $serviceLocator;
     }
 
-    public function make (array $classes): IndexIterator
+    public function make(array $classes): IndexIterator
     {
         $iterator = new ResourceIterator($classes);
         $iterator->setServiceLocator($this->getServiceLocator());

--- a/models/classes/search/tasks/UpdateClassInIndex.php
+++ b/models/classes/search/tasks/UpdateClassInIndex.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/models/classes/search/tasks/UpdateClassInIndex.php
+++ b/models/classes/search/tasks/UpdateClassInIndex.php
@@ -63,16 +63,16 @@ class UpdateClassInIndex implements Action, ServiceLocatorAwareInterface, TaskAw
         }
 
         $searchService = $this->getServiceLocator()->get(Search::SERVICE_ID);
-        $numberOfIndexed = $searchService->index(
-            $this->getIndexIteratorFactory()->make($params)
+        $numberOfIndexedResources = $searchService->index(
+            $this->getIndexIteratorFactory()->create($params)
         );
 
-        $this->logInfo($numberOfIndexed . ' resources have been indexed by ' . static::class);
+        $this->logInfo($numberOfIndexedResources . ' resources have been indexed by ' . static::class);
 
         $type = Report::TYPE_SUCCESS;
         $message = "Documents in index were successfully updated.";
 
-        if ($numberOfIndexed < 1) {
+        if ($numberOfIndexedResources < 1) {
             $type = Report::TYPE_INFO;
             $message = "Zero documents were added/updated in index.";
         }

--- a/models/classes/search/tasks/UpdateClassInIndex.php
+++ b/models/classes/search/tasks/UpdateClassInIndex.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\search\tasks;
+
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\action\Action;
+use oat\oatbox\log\LoggerAwareTrait;
+use oat\tao\model\resources\ResourceIterator;
+use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilder;
+use oat\tao\model\search\index\IndexIterator;
+use oat\tao\model\search\index\IndexService;
+use oat\tao\model\search\Search;
+use oat\tao\model\taskQueue\Task\TaskAwareInterface;
+use oat\tao\model\taskQueue\Task\TaskAwareTrait;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+use \common_report_Report as Report;
+
+/**
+ * Class UpdateResourceInIndex
+ *
+ * @author Ilya Yarkavets <ilya@taotesting.com>
+ * @package oat\tao\model\search\tasks
+ */
+class UpdateClassInIndex implements Action, ServiceLocatorAwareInterface, TaskAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+    use OntologyAwareTrait;
+    use TaskAwareTrait;
+    use LoggerAwareTrait;
+
+    public function __invoke($params): Report
+    {
+        if (empty($params) || empty($params[0])) {
+            throw new common_exception_MissingParameter();
+        }
+
+        $iterator = new ResourceIterator($params);
+        $iterator->setServiceLocator($this->getServiceLocator());
+
+        $indexIterator = new IndexIterator($iterator);
+        $indexIterator->setServiceLocator($this->getServiceLocator());
+
+        $searchService = $this->getServiceLocator()->get(Search::SERVICE_ID);
+        $numberOfIndexed = $searchService->index($indexIterator);
+
+        $this->logInfo($numberOfIndexed . ' resources have been indexed by ' . static::class);
+
+        $type = Report::TYPE_SUCCESS;
+        $message = "Documents in index were successfully updated.";
+
+        if ($numberOfIndexed < 1) {
+            $type = Report::TYPE_INFO;
+            $message = "Zero documents were added/updated in index.";
+        }
+
+        return new Report($type, $message);
+    }
+}

--- a/test/unit/extension/UpdateExtensionsTest.php
+++ b/test/unit/extension/UpdateExtensionsTest.php
@@ -128,7 +128,8 @@ class UpdateExtensionsTest extends TestCase
             ->willReturn([]);
         $extensionFoo->method('getManifest')
             ->willReturn($fooManifest);
-
+        $extensionFoo->method('getDir')
+            ->willReturn(dirname(dirname(dirname(__DIR__))));
 
         $barManifest = $this->getMockBuilder(Manifest::class)->disableOriginalConstructor()
             ->getMock();
@@ -145,6 +146,8 @@ class UpdateExtensionsTest extends TestCase
             ->willReturn(['foo' => '*']);
         $extensionBar->method('getManifest')
             ->willReturn($barManifest);
+        $extensionBar->method('getDir')
+            ->willReturn(dirname(dirname(dirname(__DIR__))));
 
 
         $extensionsManagerMock = $this->getMockBuilder(ExtensionsManager::class)

--- a/test/unit/model/validator/PropertyChangedValidatorTest.php
+++ b/test/unit/model/validator/PropertyChangedValidatorTest.php
@@ -28,7 +28,7 @@ class PropertyChangedValidatorTest extends TestCase
 {
     public function testDoNotTriggerIfDoesNotHaveChanges(): void
     {
-        $property = $this->createPropertyMock();
+        $property = $this->createPropertyMock('');
 
         $this->assertFalse(
             (new PropertyChangedValidator())->isPropertyChanged($property, new OldProperty('', $property))
@@ -50,7 +50,7 @@ class PropertyChangedValidatorTest extends TestCase
 
     public function testTriggerIfHaveCurrentPropertyTypeButDoesNotHaveOldPropertyType(): void
     {
-        $property = $this->createPropertyMock();
+        $property = $this->createPropertyMock('');
 
         $this->assertTrue(
             (new PropertyChangedValidator())->isPropertyChanged($property, new OldProperty('', null))

--- a/test/unit/model/validator/PropertyChangedValidatorTest.php
+++ b/test/unit/model/validator/PropertyChangedValidatorTest.php
@@ -101,6 +101,7 @@ class PropertyChangedValidatorTest extends TestCase
     private function createPropertyMock(string $widgetPropertyId = null): core_kernel_classes_Property
     {
         $property = $this->createMock(core_kernel_classes_Property::class);
+        $property->expects($this->any())->method('getUri')->willReturn('');
         $property->expects($this->once())
             ->method('getOnePropertyValue')
             ->with(new core_kernel_classes_Property(WidgetRdf::PROPERTY_WIDGET))

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -34,8 +34,10 @@ use oat\oatbox\log\LoggerService;
 use oat\tao\model\resources\ResourceWatcher;
 use oat\tao\model\search\index\IndexUpdaterInterface;
 use oat\tao\model\search\Search;
+use oat\tao\model\search\tasks\UpdateClassInIndex;
 use oat\tao\model\search\tasks\UpdateResourceInIndex;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
+use oat\tao\model\taskQueue\Task\TaskAwareInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use Psr\Log\LoggerInterface;
@@ -94,7 +96,11 @@ class ResourceWatcherTest extends TestCase
         $this->mockGetTypesResource($classUri);
 
         $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
-        $this->mockCreateTaskQueueDispatcher($resourceUri, 'Adding search index for created resource');
+        $this->mockCreateTaskQueueDispatcher(
+            $resourceUri,
+            'Adding search index for created resource',
+            new UpdateResourceInIndex()
+        );
 
         $this->mockGetPropertyOntology($this->once());
 
@@ -107,7 +113,8 @@ class ResourceWatcherTest extends TestCase
         );
     }
 
-    public function testCatchCreatedResourceEvent_mustCreateIndexTaskInCaseResourceIsSupportedByIndexWhenRootClassBelongsToParent(): void
+    public function testCatchCreatedResourceEvent_mustCreateIndexTaskInCaseResourceIsSupportedByIndexWhenRootClassBelongsToParent(
+    ): void
     {
         $classUri = 'https://tao.docker.localhost/ontologies/tao.rdf#Item';
         $this->indexUpdater->expects($this->at(0))
@@ -126,7 +133,11 @@ class ResourceWatcherTest extends TestCase
         $this->mockGetTypesResource($classUri);
 
         $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
-        $this->mockCreateTaskQueueDispatcher($resourceUri, 'Adding search index for created resource');
+        $this->mockCreateTaskQueueDispatcher(
+            $resourceUri,
+            'Adding search index for created resource',
+            new UpdateResourceInIndex()
+        );
 
         $this->mockGetPropertyOntology($this->once());
 
@@ -205,11 +216,40 @@ class ResourceWatcherTest extends TestCase
         $this->mockGetTypesResource($classUri);
 
         $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
-        $this->mockCreateTaskQueueDispatcher($resourceUri, 'Adding/updating search index for updated resource');
+        $this->mockCreateTaskQueueDispatcher(
+            $resourceUri,
+            'Adding/updating search index for updated resource',
+            new UpdateResourceInIndex()
+        );
 
         $this->mockGetPropertyOntology($this->atLeast(2));
 
         $this->mockGetUriResource($resourceUri);
+
+        $this->mockDebugLogger('triggering index update on resourceUpdated event');
+
+        $this->resource->expects($this->once())->method('editPropertyValues');
+
+        $this->sut->catchUpdatedResourceEvent(
+            new ResourceUpdated($this->resource)
+        );
+    }
+
+    public function testCatchUpdatedResourceEvent_mustCreateIndexTaskInCaseClassIsSupportedByIndex(): void
+    {
+        $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+        $this->mockCreateTaskQueueDispatcher(
+            $resourceUri,
+            'Adding/updating search index for updated resource',
+            new UpdateClassInIndex()
+        );
+
+        $this->mockGetPropertyOntology($this->atLeast(2));
+
+        $this->resource = $this->createMock(core_kernel_classes_Class::class);
+        $this->resource->expects($this->any())
+            ->method('getUri')
+            ->willReturn($resourceUri);
 
         $this->mockDebugLogger('triggering index update on resourceUpdated event');
 
@@ -275,12 +315,15 @@ class ResourceWatcherTest extends TestCase
             );
     }
 
-    private function mockCreateTaskQueueDispatcher(string $resourceUri, string $taskMessage): void
-    {
+    private function mockCreateTaskQueueDispatcher(
+        string $resourceUri,
+        string $taskMessage,
+        TaskAwareInterface $task
+    ): void {
         $this->queueDispatcher->expects($this->once())
             ->method('createTask')
             ->with(
-                new UpdateResourceInIndex(),
+                $task,
                 [$resourceUri],
                 $taskMessage,
                 null,

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -113,8 +113,7 @@ class ResourceWatcherTest extends TestCase
         );
     }
 
-    public function testCatchCreatedResourceEvent_mustCreateIndexTaskInCaseResourceIsSupportedByIndexWhenRootClassBelongsToParent(
-    ): void
+    public function testCatchCreatedResourceEvent_mustCreateIndexTaskInCaseResourceIsSupportedByIndexWhenRootClassBelongsToParent(): void
     {
         $classUri = 'https://tao.docker.localhost/ontologies/tao.rdf#Item';
         $this->indexUpdater->expects($this->at(0))

--- a/test/unit/models/classes/search/index/GenerisIndexDocumentBuilderTest.php
+++ b/test/unit/models/classes/search/index/GenerisIndexDocumentBuilderTest.php
@@ -22,6 +22,8 @@
 
 declare(strict_types=1);
 
+namespace oat\tao\test\unit\models\classes\search\index;
+
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\oatbox\service\ServiceManager;

--- a/test/unit/models/classes/search/index/GenerisIndexDocumentBuilderTest.php
+++ b/test/unit/models/classes/search/index/GenerisIndexDocumentBuilderTest.php
@@ -24,14 +24,16 @@ declare(strict_types=1);
 
 namespace oat\tao\test\unit\models\classes\search\index;
 
+use common_ext_ExtensionsManager;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\oatbox\service\ServiceManager;
+use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilder;
+use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
 use oat\tao\model\search\index\IndexDocument;
-use oat\taoDacSimple\model\DataBaseAccess;
 use PHPUnit\Framework\MockObject\MockObject;
-use \oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilderInterface;
-use \oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilder;
 
 class GenerisIndexDocumentBuilderTest extends TestCase
 {

--- a/test/unit/models/classes/search/index/IndexIteratorFactoryTest.php
+++ b/test/unit/models/classes/search/index/IndexIteratorFactoryTest.php
@@ -29,7 +29,7 @@ class IndexIteratorFactoryTest extends TestCase
 {
     public function testMakeIterator(): void
     {
-        $iterator = (new IndexIteratorFactory($this->getServiceLocatorMock()))->make([]);
+        $iterator = (new IndexIteratorFactory($this->getServiceLocatorMock()))->create([]);
         $this->assertInstanceOf(IndexIterator::class, $iterator);
         $this->assertEquals($this->getServiceLocatorMock(), $iterator->getServiceLocator());
     }

--- a/test/unit/models/classes/search/index/IndexIteratorFactoryTest.php
+++ b/test/unit/models/classes/search/index/IndexIteratorFactoryTest.php
@@ -17,32 +17,20 @@
  *
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
  */
-
 declare(strict_types=1);
 
-namespace oat\tao\model\search\index;
+namespace oat\tao\test\unit\models\classes\search\index;
 
-use oat\tao\model\resources\ResourceIterator;
-use Zend\ServiceManager\ServiceLocatorAwareTrait;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\generis\test\TestCase;
+use oat\tao\model\search\index\IndexIterator;
+use oat\tao\model\search\index\IndexIteratorFactory;
 
-class IndexIteratorFactory
+class IndexIteratorFactoryTest extends TestCase
 {
-    use ServiceLocatorAwareTrait;
-
-    public function __construct(ServiceLocatorInterface $serviceLocator)
+    public function testMakeIterator(): void
     {
-        $this->serviceLocator = $serviceLocator;
-    }
-
-    public function make (array $classes): IndexIterator
-    {
-        $iterator = new ResourceIterator($classes);
-        $iterator->setServiceLocator($this->getServiceLocator());
-
-        $indexIterator = new IndexIterator($iterator);
-        $indexIterator->setServiceLocator($this->getServiceLocator());
-
-        return $indexIterator;
+        $iterator = (new IndexIteratorFactory($this->getServiceLocatorMock()))->make([]);
+        $this->assertInstanceOf(IndexIterator::class, $iterator);
+        $this->assertEquals($this->getServiceLocatorMock(), $iterator->getServiceLocator());
     }
 }

--- a/test/unit/models/classes/search/index/IndexServiceTest.php
+++ b/test/unit/models/classes/search/index/IndexServiceTest.php
@@ -22,6 +22,8 @@
 
 declare(strict_types=1);
 
+namespace oat\tao\test\unit\models\classes\search\index;
+
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\oatbox\service\ServiceManager;

--- a/test/unit/models/classes/search/index/IndexServiceTest.php
+++ b/test/unit/models/classes/search/index/IndexServiceTest.php
@@ -24,6 +24,10 @@ declare(strict_types=1);
 
 namespace oat\tao\test\unit\models\classes\search\index;
 
+use common_ext_ExtensionsManager;
+use core_kernel_classes_Class;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\oatbox\service\ServiceManager;

--- a/test/unit/models/classes/search/tasks/UpdateClassInIndexTest.php
+++ b/test/unit/models/classes/search/tasks/UpdateClassInIndexTest.php
@@ -1,0 +1,156 @@
+<?php /** @noinspection PhpUndefinedClassInspection */
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\search\tasks;
+
+use common_exception_MissingParameter;
+use common_report_Report as Report;
+use oat\generis\test\TestCase;
+use oat\oatbox\log\LoggerService;
+use oat\tao\model\search\index\IndexIterator;
+use oat\tao\model\search\index\IndexIteratorFactory;
+use oat\tao\model\search\Search;
+use oat\tao\model\search\tasks\UpdateClassInIndex;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+class UpdateClassInIndexTest extends TestCase
+{
+    /** @var UpdateClassInIndex */
+    private $sut;
+
+    /** @var IndexIteratorFactory|MockObject */
+    private $indexIterator;
+
+    /** @var Search */
+    private $search;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function setUp(): void
+    {
+        $this->indexIterator = $this->createMock(IndexIteratorFactory::class);
+
+        $this->sut = new UpdateClassInIndex(
+            $this->indexIterator
+        );
+        $this->search = $this->createMock(Search::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $serviceLocator = $this->getServiceLocatorMock(
+            [
+                Search::SERVICE_ID => $this->search,
+                LoggerService::SERVICE_ID => $this->logger
+            ]
+        );
+
+        $this->sut->setServiceLocator($serviceLocator);
+    }
+
+    public function testTaskThereIsNoResourcesToIndex(): void
+    {
+        $indexIterator = $this->createMock(IndexIterator::class);
+
+        $this->indexIterator->expects($this->once())
+            ->method('make')
+            ->willReturn(
+                $indexIterator
+            );
+
+        $this->search->expects($this->once())
+            ->method('index')
+            ->with($indexIterator)
+            ->willReturn(0);
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('0 resources have been indexed by oat\tao\model\search\tasks\UpdateClassInIndex');
+
+        $report = $this->sut->__invoke(
+            ['https://tao.docker.localhost/ontologies/tao.rdf#i5f478159bc6a0794b51ee1a7f8cf0a4c']
+        );
+
+        $this->assertInstanceOf(Report::class, $report);
+        $this->assertEquals('Zero documents were added/updated in index.', $report->getMessage());
+        $this->assertEquals(Report::TYPE_INFO, $report->getType());
+    }
+
+    public function testTaskThereIsResourcesToIndex(): void
+    {
+        $indexIterator = $this->createMock(IndexIterator::class);
+
+        $this->indexIterator->expects($this->once())
+            ->method('make')
+            ->willReturn(
+                $indexIterator
+            );
+
+        $this->search->expects($this->once())
+            ->method('index')
+            ->with($indexIterator)
+            ->willReturn(5);
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('5 resources have been indexed by oat\tao\model\search\tasks\UpdateClassInIndex');
+
+        $report = $this->sut->__invoke(
+            ['https://tao.docker.localhost/ontologies/tao.rdf#i5f478159bc6a0794b51ee1a7f8cf0a4c']
+        );
+
+        $this->assertInstanceOf(Report::class, $report);
+        $this->assertEquals('Documents in index were successfully updated.', $report->getMessage());
+        $this->assertEquals(Report::TYPE_SUCCESS, $report->getType());
+    }
+
+    /**
+     * @dataProvider provideInvalidParameters
+     *
+     * @param mixed $parameter
+     *
+     * @throws common_exception_MissingParameter
+     *
+     */
+    public function testTaskInvalidInvokableParameters($parameter): void
+    {
+        $this->expectException(common_exception_MissingParameter::class);
+
+        $this->sut->__invoke(
+            $parameter
+        );
+    }
+
+    public function provideInvalidParameters(): array
+    {
+        return [
+            'Empty Array' => [
+                []
+            ],
+            'String' => [
+                ''
+            ],
+            'Null' => [
+                null
+            ],
+        ];
+    }
+}

--- a/test/unit/models/classes/search/tasks/UpdateClassInIndexTest.php
+++ b/test/unit/models/classes/search/tasks/UpdateClassInIndexTest.php
@@ -71,7 +71,7 @@ class UpdateClassInIndexTest extends TestCase
         $indexIterator = $this->createMock(IndexIterator::class);
 
         $this->indexIterator->expects($this->once())
-            ->method('make')
+            ->method('create')
             ->willReturn(
                 $indexIterator
             );
@@ -99,7 +99,7 @@ class UpdateClassInIndexTest extends TestCase
         $indexIterator = $this->createMock(IndexIterator::class);
 
         $this->indexIterator->expects($this->once())
-            ->method('make')
+            ->method('create')
             ->willReturn(
                 $indexIterator
             );


### PR DESCRIPTION
This implementation is intended to cover the ticket https://oat-sa.atlassian.net/browse/TAO-10287.

**Before this implementation:**
- Resources were not indexed when the owner class was changed (Move the class to another one).

**After this implementation:**
- Resources are now indexed by using the ResourceUpdate event. Exception for the editItemClass HTTP action, which is using other events (ClassPropertiesChangedEvent, ClassPropertyRemovedEvent) to reindex the documents.

- Old unit tests were fixed by adding namespaces, mocks 