### PR TITLE
Fix CICD-141 certain tests do not run in a separate process

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.7.3',
+    'version' => '45.7.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/test/unit/service/EntryPointServiceTest.php
+++ b/test/unit/service/EntryPointServiceTest.php
@@ -25,9 +25,6 @@ namespace oat\tao\test\unit\service;
 use oat\generis\test\TestCase;
 use oat\tao\model\entryPoint\EntryPointService;
 
-/**
- * @runClassInSeparateProcess
- */
 class EntryPointServiceTest extends TestCase
 {
     /**
@@ -42,6 +39,9 @@ class EntryPointServiceTest extends TestCase
         $this->service = require __DIR__ . DIRECTORY_SEPARATOR . 'samples' . DIRECTORY_SEPARATOR . 'entrypoint.conf.php';
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testRemoveEntryPoint()
     {
 

--- a/test/unit/session/Business/Service/SessionCookieServiceTest.php
+++ b/test/unit/session/Business/Service/SessionCookieServiceTest.php
@@ -74,7 +74,6 @@ namespace oat\tao\test\unit\session\Business\Service {
 
     /**
      * @covers \oat\tao\model\session\Business\Service\SessionCookieService
-     * @runClassInSeparateProcess
      */
     class SessionCookieServiceTest extends TestCase
     {
@@ -107,21 +106,21 @@ namespace oat\tao\test\unit\session\Business\Service {
         }
 
         /**
-         * @beforeClass
-         */
-        public static function initializeConfiguration(): void
-        {
-            define('ROOT_URL', 'http://test.com/');
-            define('GENERIS_SESSION_NAME', 'test');
-        }
-
-        /**
          * @before
          * @afterClass
          */
         public static function resetGlobalFunctionExpectations(): void
         {
             self::$mockFunctions = [];
+        }
+
+        /**
+         * @before
+         */
+        public function initializeConfiguration(): void
+        {
+            define('ROOT_URL', 'http://test.com/');
+            define('GENERIS_SESSION_NAME', 'test');
         }
 
         /**
@@ -152,6 +151,7 @@ namespace oat\tao\test\unit\session\Business\Service {
          * @param int    $lifetime
          *
          * @dataProvider dataProvider
+         * @runInSeparateProcess
          */
         public function testInitializeSessionCookie(string $domain, int $lifetime): void
         {

--- a/test/unit/session/DataAccess/Factory/SessionCookieAttributesFactoryTest.php
+++ b/test/unit/session/DataAccess/Factory/SessionCookieAttributesFactoryTest.php
@@ -30,7 +30,6 @@ use tao_helpers_Uri as UriHelper;
 
 /**
  * @covers \oat\tao\model\session\DataAccess\Factory\SessionCookieAttributesFactory
- * @runClassInSeparateProcess
  */
 class SessionCookieAttributesFactoryTest extends TestCase
 {
@@ -38,9 +37,9 @@ class SessionCookieAttributesFactoryTest extends TestCase
     private $sut;
 
     /**
-     * @beforeClass
+     * @before
      */
-    public static function initializeConfiguration(): void
+    public function initializeConfiguration(): void
     {
         define('ROOT_URL', 'http://test.com/');
     }
@@ -53,6 +52,9 @@ class SessionCookieAttributesFactoryTest extends TestCase
         $this->sut = new SessionCookieAttributesFactory();
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testCreate(): void
     {
         static::assertEquals(


### PR DESCRIPTION
- [CICD-141](https://oat-sa.atlassian.net/browse/CICD-141) fix: set `@runInSeparateProcess` on each test instead of running a whole test class in a separate proccess, which apparently fails for some set ups
- [CICD-141](https://oat-sa.atlassian.net/browse/CICD-141) chore(version): bump a fix one