### PR TITLE
Fix daily product ci

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.7.4',
+    'version' => '45.7.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/test/unit/service/EntryPointServiceTest.php
+++ b/test/unit/service/EntryPointServiceTest.php
@@ -41,6 +41,7 @@ class EntryPointServiceTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testRemoveEntryPoint()
     {

--- a/test/unit/session/Business/Service/SessionCookieServiceTest.php
+++ b/test/unit/session/Business/Service/SessionCookieServiceTest.php
@@ -152,6 +152,7 @@ namespace oat\tao\test\unit\session\Business\Service {
          *
          * @dataProvider dataProvider
          * @runInSeparateProcess
+         * @preserveGlobalState disabled
          */
         public function testInitializeSessionCookie(string $domain, int $lifetime): void
         {
@@ -166,6 +167,7 @@ namespace oat\tao\test\unit\session\Business\Service {
          *
          * @dataProvider dataProvider
          * @runInSeparateProcess
+         * @preserveGlobalState disabled
          */
         public function testReInitializeSessionCookie(string $domain, int $lifetime): void
         {

--- a/test/unit/session/DataAccess/Factory/SessionCookieAttributesFactoryTest.php
+++ b/test/unit/session/DataAccess/Factory/SessionCookieAttributesFactoryTest.php
@@ -54,6 +54,7 @@ class SessionCookieAttributesFactoryTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     * @preserveGlobalState disabled
      */
     public function testCreate(): void
     {


### PR DESCRIPTION
PHPUnit is sharing global space between separate processes if instructed by the `@runInSeparateProcess` annotation. This leads to errors such as [be seen in our daily product CI](http://qa.kitchen.it.taocloud.org/job/deploy-test-package/job/product-ci%252Ftaoce/408/#showFailuresLink). 

**Solution** is to isolate and make the separate processes completely independent by applying the `@preserveglobalstate disabled` annotation as described in [official documentation](https://phpunit.readthedocs.io/en/9.2/annotations.html#preserveglobalstate).