### PR TITLE
Di sample

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
         "symfony/dotenv": "~4.3",
         "doctrine/migrations" : "3.0.1",
         "doctrine/collections": "1.6.7",
-        "flow/jsonpath": "~0.5"
+        "flow/jsonpath": "~0.5",
+        "php-di/php-di": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/models/classes/DependencyInjection/Container.php
+++ b/models/classes/DependencyInjection/Container.php
@@ -1,0 +1,7 @@
+<?php
+
+
+class Container
+{
+
+}

--- a/models/classes/DependencyInjection/Container.php
+++ b/models/classes/DependencyInjection/Container.php
@@ -1,7 +1,55 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
 
-class Container
+namespace oat\tao\model\DependencyInjection;
+
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class Container extends \DI\Container
 {
+    /** @var ServiceLocatorInterface */
+    private $serviceLocator;
 
+    public function setServiceLocator(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($id)
+    {
+        try {
+            return $this->serviceLocator->get($id);
+        } catch (ServiceNotFoundException $exception) {
+            return parent::get($id);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($id)
+    {
+        return $this->serviceLocator->has($id) || parent::has($id);
+    }
 }

--- a/models/classes/DependencyInjection/ContainerBuilder.php
+++ b/models/classes/DependencyInjection/ContainerBuilder.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\DependencyInjection;
+
+use DI\ContainerBuilder;
+use Psr\Container\ContainerInterface;
+use Throwable;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class Container implements ContainerInterface
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    /** @var ContainerInterface */
+    private $container2;
+
+    /** @var ContainerDefinitionInterface[] */
+    private $definitions;
+
+    /** @var ServiceLocatorInterface */
+    private $serviceLocator;
+
+    public function __construct(ServiceLocatorInterface $serviceLocator)
+    {
+        $this->serviceLocator = $serviceLocator;
+        $this->definitions = [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($id)
+    {
+        $service = null;
+
+        try {
+            $service = $this->serviceLocator->get($id);
+
+            return $service;
+        } catch (ServiceNotFoundException $exception) {
+            $service = $this->getContainer()->get($id);
+
+            return $service;
+        } catch (Throwable $exception) {
+            $service = $this->container2->get($id);
+
+            return $service;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($id)
+    {
+        return $this->serviceLocator->has($id) || $this->getContainer()->has($id);
+    }
+
+    public function addDefinition(ContainerDefinitionInterface $definition): self
+    {
+        $this->definitions = array_merge(
+            $this->definitions,
+            $definition->getDefinitions()
+        );
+
+        return $this;
+    }
+
+    private function getContainer(): ContainerInterface
+    {
+        if (!$this->container) {
+            $builder = new ContainerBuilder();
+            $builder->addDefinitions($this->definitions);
+
+            $this->container2 = $builder->build();
+
+            $this->container = $this;
+        }
+
+        return $this->container;
+    }
+}

--- a/models/classes/DependencyInjection/ContainerDefinitionInterface.php
+++ b/models/classes/DependencyInjection/ContainerDefinitionInterface.php
@@ -18,9 +18,9 @@
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
  */
 
-namespace oat\tao\model\entryPoint;
+namespace oat\tao\model\DependencyInjection;
 
-class ContainerDefinitionInterface
+interface ContainerDefinitionInterface
 {
-
+    public function getDefinitions(): array;
 }

--- a/models/classes/DependencyInjection/ContainerDefinitionInterface.php
+++ b/models/classes/DependencyInjection/ContainerDefinitionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\entryPoint;
+
+class ContainerDefinitionInterface
+{
+
+}

--- a/models/classes/DependencyInjection/ExampleClass.php
+++ b/models/classes/DependencyInjection/ExampleClass.php
@@ -26,7 +26,7 @@ namespace oat\tao\model\DependencyInjection;
 use oat\generis\persistence\PersistenceManager;
 use oat\oatbox\filesystem\FileSystemService;
 
-class ClassExample
+class ExampleClass
 {
     /** @var FileSystemService */
     private $fileSystemService;
@@ -43,5 +43,10 @@ class ClassExample
     public function test()
     {
         echo 'Worked!!';
+        echo PHP_EOL;
+        echo PHP_EOL;
+        var_export(get_class($this->fileSystemService));
+        echo PHP_EOL;
+        var_export(get_class($this->persistenceManager));
     }
 }

--- a/models/classes/DependencyInjection/ExampleClass.php
+++ b/models/classes/DependencyInjection/ExampleClass.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\DependencyInjection;
+
+#
+# @TODO This class will be removed. Just as sample.
+#
+use oat\generis\persistence\PersistenceManager;
+use oat\oatbox\filesystem\FileSystemService;
+
+class ClassExample
+{
+    /** @var FileSystemService */
+    private $fileSystemService;
+
+    /** @var PersistenceManager */
+    private $persistenceManager;
+
+    public function __construct(FileSystemService $fileSystemService, PersistenceManager $persistenceManager)
+    {
+        $this->fileSystemService = $fileSystemService;
+        $this->persistenceManager = $persistenceManager;
+    }
+
+    public function test()
+    {
+        echo 'Worked!!';
+    }
+}

--- a/models/classes/DependencyInjection/ExampleContainerDefinition.php
+++ b/models/classes/DependencyInjection/ExampleContainerDefinition.php
@@ -27,13 +27,13 @@ use oat\generis\persistence\PersistenceManager;
 use oat\oatbox\filesystem\FileSystemService;
 use Psr\Container\ContainerInterface;
 
-class ContainerDefinitionExample implements ContainerDefinitionInterface
+class ExampleContainerDefinition implements ContainerDefinitionInterface
 {
     public function getDefinitions(): array
     {
         return [
-            ClassExample::class => function (ContainerInterface $container) {
-                return new ClassExample(
+            ExampleClass::class => static function (ContainerInterface $container) {
+                return new ExampleClass(
                     $container->get(FileSystemService::SERVICE_ID),
                     $container->get(PersistenceManager::SERVICE_ID)
                 );

--- a/models/classes/DependencyInjection/ExampleContainerDefinition.php
+++ b/models/classes/DependencyInjection/ExampleContainerDefinition.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\DependencyInjection;
+
+#
+# @TODO This class will be removed. Just as sample.
+#
+use oat\generis\persistence\PersistenceManager;
+use oat\oatbox\filesystem\FileSystemService;
+use Psr\Container\ContainerInterface;
+
+class ContainerDefinitionExample implements ContainerDefinitionInterface
+{
+    public function getDefinitions(): array
+    {
+        return [
+            ClassExample::class => function (ContainerInterface $container) {
+                return new ClassExample(
+                    $container->get(FileSystemService::SERVICE_ID),
+                    $container->get(PersistenceManager::SERVICE_ID)
+                );
+            }
+        ];
+    }
+}


### PR DESCRIPTION
-- WIP --

DI container compatible with ServiceLocator in a transparent way:

Usage (to be bootstraped on TAO core)
```
$builder = new ContainerBuilder($serviceLocator);
$builder->addDefinitions(...[]);

$container = $build->build();
```

- How to create definitions:  https://github.com/oat-sa/tao-core/pull/2665/files#diff-09557e33efa63df5b500a9a7e337e76bR30
- Example using ServiceLocator dependencies: https://github.com/oat-sa/tao-core/pull/2665/files#diff-e06b22c7ab9c524f86adaabac7a8b9f4R37
