### PR TITLE
Fix/uno 490/creating list wrong order

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.9.0',
+    'version' => '45.9.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepository.php
+++ b/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepository.php
@@ -75,6 +75,7 @@ class RdfValueCollectionRepository extends InjectionAwareService implements Valu
         $this->enrichQueryWithSubject($searchRequest, $query);
         $this->enrichQueryWithExcludedValueUris($searchRequest, $query);
         $this->enrichQueryWithObjects($searchRequest, $query);
+        $this->enrichQueryWithOrderById($query);
 
         $values = [];
         foreach ($query->execute()->fetchAll() as $rawValue) {
@@ -269,6 +270,11 @@ class RdfValueCollectionRepository extends InjectionAwareService implements Valu
             );
 
         return $query;
+    }
+
+    private function enrichQueryWithOrderById(QueryBuilder $query): void
+    {
+        $query->addOrderBy('element.id');
     }
 
     private function enrichWithSelect(ValueCollectionSearchRequest $searchRequest, QueryBuilder $query): QueryBuilder

--- a/test/unit/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepositoryTest.php
+++ b/test/unit/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepositoryTest.php
@@ -286,6 +286,7 @@ class RdfValueCollectionRepositoryTest extends TestCase
             $this->createSubjectCondition($searchRequest),
             $this->createExcludedCondition($searchRequest),
             $this->createCondition(),
+            $this->createOrderBy(),
             $this->createLimit($searchRequest),
         ];
 
@@ -374,6 +375,11 @@ class RdfValueCollectionRepositoryTest extends TestCase
         $this->conditions[] = 'AND (element.subject NOT IN (:excluded_value_uri))';
 
         return null;
+    }
+
+    private function createOrderBy(): string
+    {
+        return 'ORDER BY element.id ASC';
     }
 
     private function createCondition(): string


### PR DESCRIPTION
__task:__ https://oat-sa.atlassian.net/browse/UNO-490
__description:__ Creating list - Wrong order
__how to test:__
1. Add a new list with e.g. 5 elements;
2. Click 'Edit the list' button;
3. Add a new element to the list;
4. Save;

__expected Result:__ the order of the added elements must be preserved