### PR TITLE
Feature/uno 312/configured show users timezone

### DIFF
--- a/actions/form/class.UserSettings.php
+++ b/actions/form/class.UserSettings.php
@@ -20,7 +20,9 @@
  *
  */
 
+use oat\oatbox\service\ServiceManager;
 use oat\oatbox\user\UserLanguageServiceInterface;
+use oat\oatbox\user\UserTimezoneServiceInterface;
 
 /**
  * This container initialize the settings form.
@@ -47,6 +49,11 @@ class tao_actions_form_UserSettings extends tao_helpers_form_FormContainer
         $this->form->setActions($actions);
     }
 
+    private function getServiceManager(): ServiceManager
+    {
+        return oat\oatbox\service\ServiceManager::getServiceManager();
+    }
+
     /**
      * @inheritdoc
      * @throws common_Exception
@@ -55,7 +62,7 @@ class tao_actions_form_UserSettings extends tao_helpers_form_FormContainer
     protected function initElements()
     {
         $langService = tao_models_classes_LanguageService::singleton();
-        $userLangService = oat\oatbox\service\ServiceManager::getServiceManager()->get(UserLanguageServiceInterface::class);
+        $userLangService = $this->getServiceManager()->get(UserLanguageServiceInterface::class);
 
         // Retrieve languages available for a GUI usage.
         $guiUsage = new core_kernel_classes_Resource(tao_models_classes_LanguageService::INSTANCE_LANGUAGE_USAGE_GUI);
@@ -84,14 +91,27 @@ class tao_actions_form_UserSettings extends tao_helpers_form_FormContainer
             $this->form->addElement($dataLangElement);
         }
 
-        $tzElement = tao_helpers_form_FormFactory::getElement('timezone', 'Combobox');
-        $tzElement->setDescription(__('Time zone'));
-        $options = [];
-        foreach (DateTimeZone::listIdentifiers() as $id) {
-            $options[$id] = $id;
-        }
-        $tzElement->setOptions($options);
+        $this->addTimezoneEl($this->form);
+    }
 
-        $this->form->addElement($tzElement);
+    private function getUserTimezoneService(): UserTimezoneServiceInterface
+    {
+        return $this->getServiceManager()->get(UserTimezoneServiceInterface::SERVICE_ID);
+    }
+
+    private function addTimezoneEl($form): void
+    {
+        if ($this->getUserTimezoneService()->isUserTimezoneEnabled()) {
+            $tzElement = tao_helpers_form_FormFactory::getElement('timezone', 'Combobox');
+            $tzElement->setDescription(__('Time zone'));
+
+            $options = [];
+            foreach (DateTimeZone::listIdentifiers() as $id) {
+                $options[$id] = $id;
+            }
+            $tzElement->setOptions($options);
+
+            $form->addElement($tzElement);
+        }
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -62,10 +62,10 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.9.0',
+    'version' => '45.10.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
-        'generis' => '>=13.0.0',
+        'generis' => '>=13.4.0',
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAO.rdf',

--- a/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepository.php
+++ b/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepository.php
@@ -75,6 +75,7 @@ class RdfValueCollectionRepository extends InjectionAwareService implements Valu
         $this->enrichQueryWithSubject($searchRequest, $query);
         $this->enrichQueryWithExcludedValueUris($searchRequest, $query);
         $this->enrichQueryWithObjects($searchRequest, $query);
+        $this->enrichQueryWithOrderById($query);
 
         $values = [];
         foreach ($query->execute()->fetchAll() as $rawValue) {
@@ -269,6 +270,11 @@ class RdfValueCollectionRepository extends InjectionAwareService implements Valu
             );
 
         return $query;
+    }
+
+    private function enrichQueryWithOrderById(QueryBuilder $query): void
+    {
+        $query->addOrderBy('element.id');
     }
 
     private function enrichWithSelect(ValueCollectionSearchRequest $searchRequest, QueryBuilder $query): QueryBuilder

--- a/test/unit/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepositoryTest.php
+++ b/test/unit/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepositoryTest.php
@@ -286,6 +286,7 @@ class RdfValueCollectionRepositoryTest extends TestCase
             $this->createSubjectCondition($searchRequest),
             $this->createExcludedCondition($searchRequest),
             $this->createCondition(),
+            $this->createOrderBy(),
             $this->createLimit($searchRequest),
         ];
 
@@ -374,6 +375,11 @@ class RdfValueCollectionRepositoryTest extends TestCase
         $this->conditions[] = 'AND (element.subject NOT IN (:excluded_value_uri))';
 
         return null;
+    }
+
+    private function createOrderBy(): string
+    {
+        return 'ORDER BY element.id ASC';
     }
 
     private function createCondition(): string


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/UNO-312
 
Make users timezone configurable.
 
#### How to test
 
1. Log in as admin
2. Click the 'User settings' button on the top right of the window (2nd button from the right);
3. There is no Timezone for the user if system configured with `config/generis/UserTimezoneService.conf.php`
```
    'userTimezoneEnabled' => false
```

#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/generis/pull/835