### PR TITLE
Standard unit test configuration

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -65,7 +65,7 @@ return [
     'version' => '45.10.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
-        'generis' => '>=13.4.2',
+        'generis' => '>=13.5.1',
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAO.rdf',

--- a/manifest.php
+++ b/manifest.php
@@ -62,10 +62,10 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.10.0',
+    'version' => '45.10.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
-        'generis' => '>=13.4.0',
+        'generis' => '>=13.4.2',
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAO.rdf',

--- a/test/unit/session/Business/Service/SessionCookieServiceTest.php
+++ b/test/unit/session/Business/Service/SessionCookieServiceTest.php
@@ -117,15 +117,6 @@ namespace oat\tao\test\unit\session\Business\Service {
         /**
          * @before
          */
-        public function initializeConfiguration(): void
-        {
-            define('ROOT_URL', 'http://test.com/');
-            define('GENERIS_SESSION_NAME', 'test');
-        }
-
-        /**
-         * @before
-         */
         public function init(): void
         {
             $this->sut = new SessionCookieService(
@@ -151,8 +142,6 @@ namespace oat\tao\test\unit\session\Business\Service {
          * @param int    $lifetime
          *
          * @dataProvider dataProvider
-         * @runInSeparateProcess
-         * @preserveGlobalState disabled
          */
         public function testInitializeSessionCookie(string $domain, int $lifetime): void
         {
@@ -166,8 +155,6 @@ namespace oat\tao\test\unit\session\Business\Service {
          * @param int    $lifetime
          *
          * @dataProvider dataProvider
-         * @runInSeparateProcess
-         * @preserveGlobalState disabled
          */
         public function testReInitializeSessionCookie(string $domain, int $lifetime): void
         {

--- a/test/unit/session/DataAccess/Factory/SessionCookieAttributesFactoryTest.php
+++ b/test/unit/session/DataAccess/Factory/SessionCookieAttributesFactoryTest.php
@@ -39,23 +39,11 @@ class SessionCookieAttributesFactoryTest extends TestCase
     /**
      * @before
      */
-    public function initializeConfiguration(): void
-    {
-        define('ROOT_URL', 'http://test.com/');
-    }
-
-    /**
-     * @before
-     */
     public function init(): void
     {
         $this->sut = new SessionCookieAttributesFactory();
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testCreate(): void
     {
         static::assertEquals(


### PR DESCRIPTION
Some global constants being used in unit tests [are updated](https://github.com/oat-sa/generis/pull/837) in `generis` to have valid values. 

Hence in this PR we are removing the constant definitions to avoid constant reduplication errors.

Could be merged only after https://github.com/oat-sa/generis/pull/837