### PR TITLE
Fix/uno 302/500 error when adding second property item manage schema

### DIFF
--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -283,6 +283,18 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
     }
 
     /**
+     * @param core_kernel_classes_Class $clazz
+     * @param array $classData
+     * @param array $propertyData
+     * @return tao_helpers_form_Form
+     */
+    private function getForm(core_kernel_classes_Class $clazz, array $classData, array $propertyData)
+    {
+        $formContainer = new tao_actions_form_Clazz($clazz, $classData, $propertyData);
+        return $formContainer->getForm();
+    }
+
+    /**
      * Create an edit form for a class and its property
      * and handle the submited data on save
      *
@@ -293,8 +305,10 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
     public function getClassForm(core_kernel_classes_Class $clazz)
     {
         $data = $this->getRequestParameters();
-        $formContainer = new tao_actions_form_Clazz($clazz, $this->extractClassData($data), $this->extractPropertyData($data));
-        $myForm = $formContainer->getForm();
+
+        $classData = $this->extractClassData($data);
+        $propertyData = $this->extractPropertyData($data);
+        $myForm = $this->getForm($clazz, $classData, $propertyData);
 
         if ($myForm->isSubmited()) {
             if ($myForm->isValid()) {
@@ -329,6 +343,8 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
                         }
                     }
                 }
+                // get the form again but with the saved properties
+                $myForm = $this->getForm($clazz, $classData, $propertyData);
             }
         }
         return $myForm;

--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -342,9 +342,9 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
                             }
                         }
                     }
+                    // get the form again but with the saved properties
+                    $myForm = $this->getForm($clazz, $classData, $propertyData);
                 }
-                // get the form again but with the saved properties
-                $myForm = $this->getForm($clazz, $classData, $propertyData);
             }
         }
         return $myForm;

--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.11.0',
+    'version' => '45.11.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.5.1',


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/UNO-302
**Description:** 500 error when adding second property right after added first one without page refresh
**How to test:** 
1. Select a folder;
2. Click 'Manage Schema';
3. Click 'Add property';
4. Click pencil icon;
5. Select 'List - Single choice - Drop down' as a type';
6. Select any 'List values';
7. Save;
8. Repeat steps 3-7 to add one more property.