### PR TITLE
fix(search): change click event handler

### DIFF
--- a/views/js/layout/search.js
+++ b/views/js/layout/search.js
@@ -57,7 +57,7 @@ define(['jquery', 'layout/actions', 'ui/searchModal', 'core/store', 'context', '
         const $searchInput = $('input', searchComponent.container);
         const $resultsBtn = $('button.icon-ul', searchComponent.container);
 
-        $searchBtn.off('.searchComponent').on('click.searchComponent', createSearchModalInstance);
+        $searchBtn.off('.searchComponent').on('click.searchComponent', () => createSearchModalInstance());
 
         $searchInput.off('.searchComponent').on('keypress.searchComponent', e => {
             if (e.which === 13) {


### PR DESCRIPTION
**related to:** https://oat-sa.atlassian.net/browse/TAO-10546

**Description**
Simple fix. `createSearchModalInstance` expects an optional first param and `$searchBtn.off('.searchComponent').on('click.searchComponent', createSearchModalInstance);` was sending `click` Event as this first param. 