### PR TITLE
Feature/tao 10592/search keyboard navigation

### DIFF
--- a/views/js/layout/search.js
+++ b/views/js/layout/search.js
@@ -75,13 +75,13 @@ define(['jquery', 'layout/actions', 'ui/searchModal', 'core/store', 'context', '
                 });
         });
 
-        $(window).keydown(function (event) {
+        $(window).on('keydown.searchComponent', e => {
             if (
                 $('.action-bar .search-area').closest('.content-panel').css('display') === 'flex' &&
-                event.ctrlKey &&
-                event.keyCode == 75
+                e.ctrlKey &&
+                e.which == 75
             ) {
-                event.preventDefault();
+                e.preventDefault();
                 createSearchModalInstance();
             }
         });

--- a/views/js/layout/search.js
+++ b/views/js/layout/search.js
@@ -49,7 +49,8 @@ define(['jquery', 'layout/actions', 'ui/searchModal', 'core/store', 'context', '
     };
 
     /**
-     * Sets events to init searchModal instance on search and results icons click, and enter keypress
+     * Sets events to init searchModal instance on search and results icons click, enter keypress
+     * and ctrl + k shortcut
      */
     function initializeEvents() {
         searchComponent.container = $('.action-bar .search-area');
@@ -72,6 +73,17 @@ define(['jquery', 'layout/actions', 'ui/searchModal', 'core/store', 'context', '
                 .catch(e => {
                     actionManager.trigger('error', e);
                 });
+        });
+
+        $(window).keydown(function (event) {
+            if (
+                $('.action-bar .search-area').closest('.content-panel').css('display') === 'flex' &&
+                event.ctrlKey &&
+                event.keyCode == 75
+            ) {
+                event.preventDefault();
+                createSearchModalInstance();
+            }
         });
     }
 

--- a/views/js/layout/search.js
+++ b/views/js/layout/search.js
@@ -75,7 +75,7 @@ define(['jquery', 'layout/actions', 'ui/searchModal', 'core/store', 'context', '
                 });
         });
 
-        $(window).on('keydown.searchComponent', e => {
+        $(document).on('keydown.searchComponent', e => {
             if (
                 $('.action-bar .search-area').closest('.content-panel').css('display') === 'flex' &&
                 e.ctrlKey &&


### PR DESCRIPTION
**Related to**: https://oat-sa.atlassian.net/browse/TAO-10592
**Related PR:** https://github.com/oat-sa/tao-core-ui-fe/pull/195
**Description**: Enables opening search modal by `ctrl + k` keypress. I have not found other way to know if search bar is present besides than relying on css properties and markup, I know the problems it can give if structure or styles change, so I'm open to suggestions.