### PR TITLE
Remove event aggregator

### DIFF
--- a/models/classes/mvc/Bootstrap.php
+++ b/models/classes/mvc/Bootstrap.php
@@ -33,7 +33,6 @@ use Exception;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
 use helpers_Report as ReportHelper;
-use oat\oatbox\event\EventAggregator;
 use oat\oatbox\service\ServiceConfigDriver;
 use oat\oatbox\service\ServiceManager;
 use oat\oatbox\service\ServiceManagerAwareInterface;
@@ -248,8 +247,6 @@ class Bootstrap implements ServiceManagerAwareInterface
             } else {
                 $this->dispatchHttp();
             }
-
-            $this->getServiceManager()->get(EventAggregator::SERVICE_ID)->triggerAggregatedEvents();
 
             self::$isDispatched = true;
         }


### PR DESCRIPTION
This PR aims to delete eventAggregator.

After investigation, this service aggregate events and iterate on it to emit them. It also defer emission that is a breaking change, especially for core_kernel_classes_Resource