### PR TITLE
UNO-277: Added InfoBox to the export form

### DIFF
--- a/actions/class.Export.php
+++ b/actions/class.Export.php
@@ -69,6 +69,9 @@ class tao_actions_Export extends tao_actions_CommonModule
 
         $handlers = $this->getAvailableExportHandlers();
         $exporter = $this->getCurrentExporter();
+        if ($exporter === null) {
+            throw new common_exception_BadRequest('Exporter is not found');
+        }
 
         $selectedResource = $formData['instance'] ?? $formData['class'];
 
@@ -76,11 +79,9 @@ class tao_actions_Export extends tao_actions_CommonModule
             throw new common_exception_MissingParameter();
         }
 
-        $formFactory = new tao_actions_form_Export($handlers, $exporter->getExportForm($selectedResource), $formData);
+        $formFactory = $this->getFormFactory($handlers, $exporter, $selectedResource, $formData);
         $exportForm = $formFactory->getForm();
-        if ($exporter !== null) {
-            $exportForm->setValues(['exportHandler' => get_class($exporter)]);
-        }
+        $exportForm->setValues(['exportHandler' => get_class($exporter)]);
         $this->setData('exportForm', $exportForm->render());
 
         // if export form submitted
@@ -136,6 +137,16 @@ class tao_actions_Export extends tao_actions_CommonModule
 
         $this->setData('formTitle', __('Export '));
         $this->setView('form/export.tpl', 'tao');
+    }
+
+    protected function getFormFactory(
+        array $handlers,
+        tao_models_classes_export_ExportHandler $exporter,
+        core_kernel_classes_Resource $selectedResource,
+        array $formData
+    ): tao_actions_form_Export
+    {
+        return new tao_actions_form_Export($handlers, $exporter->getExportForm($selectedResource), $formData);
     }
 
     /**

--- a/actions/form/class.Export.php
+++ b/actions/form/class.Export.php
@@ -32,12 +32,15 @@ class tao_actions_form_Export extends tao_helpers_form_FormContainer
 
 
     // --- ATTRIBUTES ---
-    private $exportHandlers = [];
-    
+    /**
+     * @var array
+     */
+    private $exportHandlers;
+
     /**
      * @var tao_helpers_form_Form
      */
-    private $subForm = null;
+    private $subForm;
 
     // --- OPERATIONS ---
 
@@ -47,6 +50,14 @@ class tao_actions_form_Export extends tao_helpers_form_FormContainer
         $this->subForm = $subForm;
         parent::__construct($data);
     }
+
+    public function setInfoBox(string $msg): void
+    {
+        $infoElement = tao_helpers_form_FormFactory::getElement('infoBox', 'Free');
+        $infoElement->setValue($msg);
+        $this->form->addElement($infoElement);
+    }
+
     /**
      * Short description of method initForm
      *
@@ -69,8 +80,6 @@ class tao_actions_form_Export extends tao_helpers_form_FormContainer
 
         $exportElt = tao_helpers_form_FormFactory::getElement('export', 'Free');
         $exportElt->setValue('<a href="#" class="form-submitter btn-success small"><span class="icon-export"></span>' . __('Export') . '</a>');
-        
-
         $this->form->setActions([$exportElt], 'bottom');
     }
 
@@ -78,27 +87,27 @@ class tao_actions_form_Export extends tao_helpers_form_FormContainer
      * Short description of method initElements
      *
      * @access public
-     * @author Joel Bout, <joel.bout@tudor.lu>
      * @return mixed
+     * @throws common_Exception
+     * @author Joel Bout, <joel.bout@tudor.lu>
      */
     public function initElements()
     {
-
         if (count($this->exportHandlers) > 1) {
             //create the element to select the import format
             $formatElt = tao_helpers_form_FormFactory::getElement('exportHandler', 'Radiobox');
             $formatElt->setDescription(__('Choose export format'));
-    
+
             //mandatory field
             $formatElt->addValidator(tao_helpers_form_FormFactory::getValidator('NotEmpty'));
             $formatElt->setOptions($this->getFormats());
-            
+
             if (isset($_POST['exportHandler'])) {
                 if (array_key_exists($_POST['exportHandler'], $this->getFormats())) {
                     $formatElt->setValue($_POST['exportHandler']);
                 }
             }
-    
+
             $this->form->addElement($formatElt);
             $this->form->createGroup('formats', '<h3>' . __('Supported export formats') . '</h3>', ['exportHandler']);
         }
@@ -121,11 +130,10 @@ class tao_actions_form_Export extends tao_helpers_form_FormContainer
                 $this->form->addElement($classUriElt);
             }
         }
-        
+
         $idElt = tao_helpers_form_FormFactory::getElement('id', 'Hidden');
         $this->form->addElement($idElt);
-         
-        
+
         foreach ($this->subForm->getElements() as $element) {
             $this->form->addElement($element);
         }
@@ -133,7 +141,7 @@ class tao_actions_form_Export extends tao_helpers_form_FormContainer
             $this->form->createGroup($group['title'], $group['title'], $group['elements'], $group['options']);
         }
     }
-    
+
     private function getFormats()
     {
         $returnValue = [];

--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '46.3.3',
+    'version' => '46.4.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.10.0',


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/UNO-277
 
Added InfoBox to the export form factory.
  
#### How to test
 
run $form->setInfoBox('message') and you will see this message on top of the export form:
 
![2020-10-22_10-14-49](https://user-images.githubusercontent.com/1445911/96861634-03a3f680-146d-11eb-9789-c9fd569fbe45.png)

#### Dependencies
 
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-item/pull/435