### PR TITLE
[TAO-10569] Manage schema - List values don't preserve selected value if add several properties

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '46.5.0',
+    'version' => '46.5.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.10.0',

--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -571,7 +571,7 @@ define([
 
                         $propValuesSelect.html($elt.closest('.property-edit-container').find('.' + rangedPropertyName + '-template').html());
 
-                        if (propValue && $(`option[value="${propValue}"]`, $propValuesSelect).length) {
+                        if (propValue && propValue !== ' ' && $(`option[value="${propValue}"]`, $propValuesSelect).length) {
                             $propValuesSelect.val(propValue);
                         }
 


### PR DESCRIPTION
Related to : https://oat-sa.atlassian.net/browse/TAO-10569
 
Do not set value for property list values, if it is empty.
  
#### How to test
 
- manage schema of any items class
- add some properties
- select `List - Single choice - Radio button` as property type
- select some list value
- save schema and make sure the property value and list type saved
 