### PR TITLE
When running IndexPopulator command we are breaking loop on first loop

### DIFF
--- a/scripts/tools/index/IndexPopulator.php
+++ b/scripts/tools/index/IndexPopulator.php
@@ -115,7 +115,7 @@ class IndexPopulator extends ScriptAction implements ServiceLocatorAwareInterfac
                 ->setLimit($limit)
                 ->setOffset($offset);
 
-            $criteria = $search->searchType($queryBuilder, $class->getUri(), false);
+            $criteria = $search->searchType($queryBuilder, $class->getUri(), true);
 
             $queryBuilder = $queryBuilder->setCriteria($criteria);
             $resources = $search->getGateway()->search($queryBuilder);

--- a/scripts/tools/index/IndexPopulator.php
+++ b/scripts/tools/index/IndexPopulator.php
@@ -96,6 +96,7 @@ class IndexPopulator extends ScriptAction implements ServiceLocatorAwareInterfac
      */
     protected function run(): common_report_Report
     {
+        $report = common_report_Report::createInfo('Excuting');
         $classIterator = new \core_kernel_classes_ClassIterator($this->getIndexedClasses());
         $currentClass = $this->getOption('class');
         $limit = (int)$this->getOption('limit');
@@ -139,13 +140,12 @@ class IndexPopulator extends ScriptAction implements ServiceLocatorAwareInterfac
             $result = $searchService->index($indexIterator);
 
             $this->logInfo(sprintf('%s resources have been indexed by %s', $result, static::class));
-
-            return $this->getScriptReport($result, $reportedClass, $limit, $offset);
+            $report->add($this->getScriptReport($result, $reportedClass, $limit, $offset));
         }
 
         file_put_contents($this->getOption('lock'), $class->getUri() . PHP_EOL . 'FINISHED');
 
-        return $this->getScriptReport($result, $reportedClass, $limit, $offset);
+        return $report;
     }
 
     protected function getIndexedClasses(): array


### PR DESCRIPTION
This is partially related to my task. 

In order to index all resources in tao I had to execute this command:

```
docker exec -it package-tao-phpfpm php index.php "oat\tao\scripts\tools\index\IndexPopulator"
```

I recognise that after first item my loop was breaking and bulk operations for any other resources was not executed. 

I would like to introduce this change in order to make it work before I publish my code that will improve indexing functionality