### PR TITLE
Create try-catch block for `index` method

### DIFF
--- a/models/classes/search/tasks/UpdateResourceInIndex.php
+++ b/models/classes/search/tasks/UpdateResourceInIndex.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace oat\tao\model\search\tasks;
 
+use Exception;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\action\Action;
 use oat\tao\model\search\index\DocumentBuilder\IndexDocumentBuilder;
@@ -64,7 +65,11 @@ class UpdateResourceInIndex implements Action, ServiceLocatorAwareInterface, Tas
         /** @var Search $searchService */
         $searchService = $this->getServiceLocator()->get(Search::SERVICE_ID);
 
-        $numberOfIndexed = $searchService->index([$indexDocument]);
+        try {
+            $numberOfIndexed = $searchService->index([$indexDocument]);
+        } catch (Exception $exception) {
+            return new Report(Report::TYPE_ERROR, $exception->getMessage());
+        }
 
         if ($numberOfIndexed === 0) {
             $type = Report::TYPE_ERROR;


### PR DESCRIPTION
Cause we are now throwing an error on indexing (refer to this [PR](https://github.com/oat-sa/lib-tao-elasticsearch/pull/38))

I included try-catch when calling index method 

https://oat-sa.atlassian.net/browse/CON-23

