### PR TITLE
fix error when property has not have a widget

### DIFF
--- a/models/classes/Lists/Business/Service/ClassMetadataService.php
+++ b/models/classes/Lists/Business/Service/ClassMetadataService.php
@@ -184,6 +184,10 @@ class ClassMetadataService extends InjectionAwareService
 
     private function isTextWidget(core_kernel_classes_Property $property): bool
     {
+        if ($property->getWidget()) {
+            $this->logWarning($property->getLabel() . 'is not including a widget property');
+            return false;
+        }
         return in_array($property->getWidget()->getUri(), self::TEXT_WIDGETS);
     }
 


### PR DESCRIPTION
When widget is not present in property this error will be thrown:

```200: Fatal error: Uncaught Error: Call to a member function getUri() on null in /tao/code/tao/models/classes/Lists/Busin ess/Service/ClassMetadataService.php:187```

