### PR TITLE
Remove obsolete warning message

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -63,7 +63,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '46.7.2',
+    'version' => '46.7.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.10.0',

--- a/models/classes/theme/ConfigurableTheme.php
+++ b/models/classes/theme/ConfigurableTheme.php
@@ -158,7 +158,6 @@ class ConfigurableTheme extends Configurable implements Theme
                 $template = Template::getTemplate('blocks/login.tpl', 'tao');
                 break;
             default:
-                \common_Logger::w('Unknown template ' . $id);
                 $template = null;
         }
         return $template;


### PR DESCRIPTION
Hotfix for [CGF-69](https://oat-sa.atlassian.net/browse/CGF-69)

The problem, that in templates used helper `Template::inc` that requires blocks by the path, but theming used, it passes this path to a special method in Theme implementation, but such as these classes deprecated, it works unproperly. It tries to check template id and switch construction always fails with the warning message in the log when templating works well.

As a hotfix, and unblock customers I just removed this warning, but total refactoring will be done under [CGF-134](https://oat-sa.atlassian.net/browse/CGF-134)