### PR TITLE
removed condition and added check if there is a widget

### DIFF
--- a/models/classes/Lists/Business/Service/ClassMetadataService.php
+++ b/models/classes/Lists/Business/Service/ClassMetadataService.php
@@ -25,21 +25,21 @@ namespace oat\tao\model\Lists\Business\Service;
 
 use core_kernel_classes_Class;
 use core_kernel_classes_Property;
-use oat\tao\model\Lists\Business\Domain\ClassMetadata;
+use oat\generis\model\OntologyAwareTrait;
 use oat\tao\model\Lists\Business\Domain\ClassCollection;
+use oat\tao\model\Lists\Business\Domain\ClassMetadata;
 use oat\tao\model\Lists\Business\Domain\Metadata;
 use oat\tao\model\Lists\Business\Domain\MetadataCollection;
 use oat\tao\model\Lists\Business\Domain\ValueCollectionSearchRequest;
 use oat\tao\model\Lists\Business\Input\ClassMetadataSearchInput;
 use oat\tao\model\Lists\Business\Input\ValueCollectionSearchInput;
 use oat\tao\model\service\InjectionAwareService;
-use oat\generis\model\OntologyAwareTrait;
-use tao_helpers_form_elements_Textbox as TextBox;
-use tao_helpers_form_elements_Textarea as TextArea;
-use tao_helpers_form_elements_Htmlarea as HtmlArea;
-use tao_helpers_form_elements_Radiobox as RadioBox;
 use tao_helpers_form_elements_Checkbox as CheckBox;
 use tao_helpers_form_elements_Combobox as ComboBox;
+use tao_helpers_form_elements_Htmlarea as HtmlArea;
+use tao_helpers_form_elements_Radiobox as RadioBox;
+use tao_helpers_form_elements_Textarea as TextArea;
+use tao_helpers_form_elements_Textbox as TextBox;
 use tao_helpers_form_elements_xhtml_Searchtextbox as SearchTextBox;
 
 class ClassMetadataService extends InjectionAwareService
@@ -130,9 +130,6 @@ class ClassMetadataService extends InjectionAwareService
         $collection = new MetadataCollection();
 
         foreach ($class->getProperties(true) as $property) {
-            if (strpos($property->getUri(), self::CUSTOM_PROPERTY_FILTER) === false) {
-                continue;
-            }
 
             if (!$this->isTextWidget($property) && !$this->isListWidget($property)) {
                 continue;
@@ -184,12 +181,16 @@ class ClassMetadataService extends InjectionAwareService
 
     private function isTextWidget(core_kernel_classes_Property $property): bool
     {
-        return in_array($property->getWidget()->getUri(), self::TEXT_WIDGETS);
+        return ($property->getWidget()->getUri())
+            ? in_array($property->getWidget()->getUri(), self::TEXT_WIDGETS, true)
+            : false;
     }
 
     private function isListWidget(core_kernel_classes_Property $property): bool
     {
-        return in_array($property->getWidget()->getUri(), self::LIST_WIDGETS);
+        return ($property->getWidget()->getUri()) ?
+            in_array($property->getWidget()->getUri(), self::LIST_WIDGETS, true)
+            : false;
     }
 
     private function getListItemsUri(core_kernel_classes_Property $property, ?array $values): ?string

--- a/models/classes/Lists/Business/Service/ClassMetadataService.php
+++ b/models/classes/Lists/Business/Service/ClassMetadataService.php
@@ -181,15 +181,17 @@ class ClassMetadataService extends InjectionAwareService
 
     private function isTextWidget(core_kernel_classes_Property $property): bool
     {
-        return ($property->getWidget()->getUri())
-            ? in_array($property->getWidget()->getUri(), self::TEXT_WIDGETS, true)
+        $uri = $property->getWidget()->getUri();
+        return ($uri)
+            ? in_array($uri, self::TEXT_WIDGETS, true)
             : false;
     }
 
     private function isListWidget(core_kernel_classes_Property $property): bool
     {
-        return ($property->getWidget()->getUri()) ?
-            in_array($property->getWidget()->getUri(), self::LIST_WIDGETS, true)
+        $uri = $property->getWidget()->getUri();
+        return ($uri) ?
+            in_array($uri, self::LIST_WIDGETS, true)
             : false;
     }
 

--- a/models/classes/Lists/Business/Service/ClassMetadataService.php
+++ b/models/classes/Lists/Business/Service/ClassMetadataService.php
@@ -181,17 +181,17 @@ class ClassMetadataService extends InjectionAwareService
 
     private function isTextWidget(core_kernel_classes_Property $property): bool
     {
-        $uri = $property->getWidget()->getUri();
-        return ($uri)
-            ? in_array($uri, self::TEXT_WIDGETS, true)
+        $widgetUri = $property->getWidget()->getUri();
+        return ($widgetUri)
+            ? in_array($widgetUri, self::TEXT_WIDGETS, true)
             : false;
     }
 
     private function isListWidget(core_kernel_classes_Property $property): bool
     {
-        $uri = $property->getWidget()->getUri();
-        return ($uri) ?
-            in_array($uri, self::LIST_WIDGETS, true)
+        $widgetUri = $property->getWidget()->getUri();
+        return ($widgetUri) ?
+            in_array($widgetUri, self::LIST_WIDGETS, true)
             : false;
     }
 


### PR DESCRIPTION
#Description
When the user sets a property to the item, he is not able to select this property as a criterion in the modal view. 

Preconditions: added property to the class.

#Steps to reproduce:

Trigger a search from the "Search bar" to open a modal view

Click "add criteria"

 Actual result: no items shown in drop-down menu (please see actual_result.gif in the Attachments).
Expected result: existing properties are shown in the criteria drop-down menu (please see expected_result.gif in the Attachments).

ticket:
https://oat-sa.atlassian.net/browse/CON-176

can be tested here :
https://noudi01aud.udir.taocloud.org/tao/Main/index
