### PR TITLE
Determine when template requested by path instead of id

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -63,7 +63,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '46.7.3',
+    'version' => '46.7.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.10.0',

--- a/models/classes/theme/ConfigurablePlatformTheme.php
+++ b/models/classes/theme/ConfigurablePlatformTheme.php
@@ -196,7 +196,8 @@ class ConfigurablePlatformTheme extends Configurable implements Theme
         $templates = $this->getOption(static::TEMPLATES);
 
         if (is_null($templates) || empty($templates[$id])) {
-            return Template::getTemplate('blocks/' . $id . '.tpl', 'tao');
+            $realPath = strpos($id, '.tpl') !== false ? $id : 'blocks/' . $id . '.tpl';
+            return Template::getTemplate($realPath, 'tao');
         }
 
         if ($templates[$id] === static::DEFAULT_PATH) {


### PR DESCRIPTION
Hotfix under task [CGF-69](https://oat-sa.atlassian.net/browse/CGF-69)

Due to the mess in theming code sometimes templates requested by path instead of ID and the current implementation does not handle such situations. My fix improves the situation but does not solve the root issue. In other words, it is a hotfix that avoids us unblock customers environments.

### How to test

Install on any instance [Look & Feel extension](https://github.com/oat-sa/extension-tao-styles) (note, that it is private, so do not forget to add repo link into repositories section in composer file).

After go to https://YOUR_INSTANCE_URL/tao/Main/index?structure=settings&ext=tao&section=taoStyles_main and try to change the theme. Before with you will see a blank screen with javascript errors and nothing more. Also, in logs a lot of warnings about not found templates.

After the fix, it should work well.