### PR TITLE
Lead 86/refactor/remove alarm notification service option dispatch types option

### DIFF
--- a/config/default/alarmNotificationService.conf.php
+++ b/config/default/alarmNotificationService.conf.php
@@ -13,9 +13,6 @@ return new oat\tao\model\notifications\AlarmNotificationService([
             'params' => ['1fc9e71d-5390-4634-a866-b727b0f7ca25']
         ]
     ],
-    'dispatchTypes' => [
-        \oat\oatbox\reporting\Report::TYPE_ERROR
-    ]
 ]);
 
 **/
@@ -23,6 +20,4 @@ return new oat\tao\model\notifications\AlarmNotificationService([
 return new oat\tao\model\notifications\AlarmNotificationService([
     'notifiers' => [
     ],
-    'dispatchTypes' => [
-    ]
 ]);

--- a/manifest.php
+++ b/manifest.php
@@ -64,7 +64,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '46.11.0',
+    'version' => '46.11.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.11.0',

--- a/migrations/Version202011041353202234_tao.php
+++ b/migrations/Version202011041353202234_tao.php
@@ -29,7 +29,6 @@ final class Version202011041353202234_tao extends AbstractMigration
     {
         $updatingNotificationService = new AlarmNotificationService();
         $updatingNotificationService->setOption(AlarmNotificationService::OPTION_NOTIFIERS, []);
-        $updatingNotificationService->setOption(AlarmNotificationService::OPTION_DISPATCH_TYPES, []);
 
         $this->getServiceManager()->register(
             $updatingNotificationService::SERVICE_ID,

--- a/models/classes/notifications/AlarmNotificationService.php
+++ b/models/classes/notifications/AlarmNotificationService.php
@@ -23,7 +23,6 @@ namespace oat\tao\model\notifications;
 
 use oat\oatbox\reporting\Report;
 use oat\tao\model\event\TaoUpdateEvent;
-use oat\tao\model\notifiers\Notifier;
 
 /**
  * Notifies when an update
@@ -35,14 +34,13 @@ use oat\tao\model\notifiers\Notifier;
 class AlarmNotificationService extends AbstractNotificationService
 {
     public const SERVICE_ID = 'tao/AlarmNotificationService';
-    public const OPTION_DISPATCH_TYPES = 'dispatchTypes';
 
     /**
      * @param TaoUpdateEvent $event
      */
     public function listenTaoUpdateEvent(TaoUpdateEvent $event)
     {
-        $reportMessages = $event->getReport()->filterChildrenByTypes($this->getOption(self::OPTION_DISPATCH_TYPES));
+        $reportMessages = $event->getReport()->filterChildrenByTypes($this->getOption(Report::TYPE_ERROR));
 
         if (count($reportMessages) === 0) return;
 


### PR DESCRIPTION
This option is relevant only for updater, not for entire AlarmNotificationService service and may be hardcoded.