### PR TITLE
Fix/updater alarm norification error

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -64,7 +64,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '46.11.1',
+    'version' => '46.11.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.11.0',

--- a/models/classes/notifications/AlarmNotificationService.php
+++ b/models/classes/notifications/AlarmNotificationService.php
@@ -40,7 +40,7 @@ class AlarmNotificationService extends AbstractNotificationService
      */
     public function listenTaoUpdateEvent(TaoUpdateEvent $event)
     {
-        $reportMessages = $event->getReport()->filterChildrenByTypes($this->getOption(Report::TYPE_ERROR));
+        $reportMessages = $event->getReport()->filterChildrenByTypes([Report::TYPE_ERROR]);
 
         if (count($reportMessages) === 0) return;
 


### PR DESCRIPTION
fix of the following fatal at time of update:
```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to oat\oatbox\reporting\Report::filterChildrenByTypes() must be of the type array, null given, called in /Users/aleh/domains/package-tao/tao/models/classes/notifications/AlarmNotificationService.php on line 43 and defined in /Users/aleh/domains/package-tao/generis/common/oatbox/reporting/Report.php:316
```