### PR TITLE
fix: propagate services for the added Queue

### DIFF
--- a/models/classes/taskQueue/QueueDispatcher.php
+++ b/models/classes/taskQueue/QueueDispatcher.php
@@ -145,7 +145,7 @@ class QueueDispatcher extends ConfigurableService implements QueueDispatcherInte
         $this->propagated = false;
 
         $queues = $this->getQueues();
-        $queues[] = $queue;
+        $queues[] = $this->propagateServices($queue);
 
         $this->setOption(self::OPTION_QUEUES, $queues);
 


### PR DESCRIPTION
_During fresh installation via Seed file some Queues may not be propagated with the necessary services._
---
**How to test:**
1. _[Seed file]:_ add `taoTaskQueue` to the `extensions` section:
```
  "extensions": [
    "taoCe",
    "taoTaskQueue"
  ]
```
2. _[Seed file]:_ add queue initialization script to the `postInstall` section:
```
  "postInstall": {
    "InitializeQueue": {
      "class": "oat\\taoTaskQueue\\scripts\\tools\\InitializeQueue",
      "params": [
        "--broker=rds",
        "--persistence=default",
        "--receive=10"
      ]
    }
  }
```
3. Install a fresh instance via seed file: `php tao/scripts/taoSetup [seed file].json -vvv`.
---
**Previous behavior:** error during Queue initialization:
```
Fatal error: Uncaught TypeError: Argument 1 passed to oat\tao\model\taskQueue\Queue\Broker\AbstractQueueBroker::setServiceLocator() must implement interface Zend\ServiceManager\ServiceLocatorInterface, null given, called in /var/www/udir/tao/models/classes/taskQueue/Queue.php on line 150 and defined in /var/www/udir/vendor/zendframework/zend-servicemanager/src/ServiceLocatorAwareTrait.php:25
```
**Current behavior:** successful installation.