### PR TITLE
feat: show 404 page when unable to resolve url

### DIFF
--- a/models/classes/controllerMap/ActionNotFoundException.php
+++ b/models/classes/controllerMap/ActionNotFoundException.php
@@ -29,5 +29,8 @@ namespace oat\tao\model\controllerMap;
  */
 class ActionNotFoundException extends \common_Exception
 {
-    
+    public function getSeverity()
+    {
+        return \common_Logger::DEBUG_LEVEL;
+    }
 }

--- a/models/classes/mvc/error/ExceptionInterpretor.php
+++ b/models/classes/mvc/error/ExceptionInterpretor.php
@@ -30,6 +30,7 @@ use tao_models_classes_MissingRequestParameterException;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 use oat\tao\model\exceptions\UserErrorException;
+use oat\tao\model\controllerMap\ActionNotFoundException;
 
 /**
  * Description of ExceptionInterpretor
@@ -104,6 +105,7 @@ class ExceptionInterpretor implements ServiceLocatorAwareInterface
                 break;
             case 'ActionEnforcingException':
             case 'tao_models_classes_FileNotFoundException':
+            case ActionNotFoundException::class:
             case common_exception_ResourceNotFound::class:
                 $this->returnHttpCode    = StatusCode::HTTP_NOT_FOUND;
                 $this->responseClassName = 'MainResponse';

--- a/models/classes/mvc/error/HtmlResponse.php
+++ b/models/classes/mvc/error/HtmlResponse.php
@@ -38,7 +38,7 @@ class HtmlResponse extends ResponseAbstract
             $message = $this->exception->getMessage();
             $trace = $this->exception->getTraceAsString();
         }
-        $referer = $_SERVER['HTTP_REFERER'];
+        $referer = $_SERVER['HTTP_REFERER'] ?? ROOT_URL;
         $returnUrl = (parse_url($referer, PHP_URL_HOST) === parse_url(ROOT_URL, PHP_URL_HOST))
             ? htmlentities($referer, ENT_QUOTES)
             : false;

--- a/models/classes/routing/Resolver.php
+++ b/models/classes/routing/Resolver.php
@@ -28,6 +28,7 @@ use Zend\ServiceManager\ServiceLocatorAwareTrait;
 use GuzzleHttp\Psr7\ServerRequest;
 use Psr\Http\Message\ServerRequestInterface;
 use oat\oatbox\extension\exception\ManifestNotFoundException;
+use oat\tao\model\controllerMap\ActionNotFoundException;
 
 /**
  * Resolves a http request to a controller and method
@@ -163,7 +164,7 @@ class Resolver implements ServiceLocatorAwareInterface
      * Tries to resolve the current request using the routes first
      * and then falls back to the legacy controllers
      * @return bool
-     * @throws \ResolverException
+     * @throws ActionNotFoundException
      * @throws \common_exception_InconsistentData
      * @throws ManifestNotFoundException
      */
@@ -188,7 +189,7 @@ class Resolver implements ServiceLocatorAwareInterface
             }
         }
 
-        throw new \ResolverException('Unable to resolve ' . $this->request->getUri()->getPath());
+        throw new ActionNotFoundException('Unable to resolve ' . $this->request->getUri()->getPath());
     }
 
     /**


### PR DESCRIPTION
Tao logs are full of `Unable to resolve` errors which actually not errors but expected behaviour when user (or bot/parser) make request to non-existent page. 404 error page should be shown in that case.
<img width="1341" alt="Screenshot 2021-03-11 at 10 56 33" src="https://user-images.githubusercontent.com/11025793/110754277-aad8cd00-8258-11eb-9428-5030223d307e.png">

Log level needs to be changed to debug and instead of redirect to login page 404 error page should be shown

How to test:

Open any inexistent Tao page: `<tao_url>/foobar`