### PR TITLE
fix/TR-552_fix-javascript-asset-mime-type

### DIFF
--- a/models/classes/websource/BaseWebsource.php
+++ b/models/classes/websource/BaseWebsource.php
@@ -129,7 +129,7 @@ abstract class BaseWebsource extends Configurable implements Websource
             //manage bugs in finfo
             switch ($pathParts['extension']) {
                 case 'js':
-                    if (in_array($mimeType, ['text/plain', 'text/html', 'text/x-asm', 'text/x-c'], true)) {
+                    if (in_array($mimeType, ['text/plain', 'text/html', 'text/x-asm', 'text/x-c', 'text/x-java'], true)) {
                         return 'text/javascript';
                     }
                     break;

--- a/models/classes/websource/BaseWebsource.php
+++ b/models/classes/websource/BaseWebsource.php
@@ -129,7 +129,7 @@ abstract class BaseWebsource extends Configurable implements Websource
             //manage bugs in finfo
             switch ($pathParts['extension']) {
                 case 'js':
-                    if ($mimeType === 'text/plain' || $mimeType === 'text/x-asm' || $mimeType === 'text/x-c') {
+                    if (in_array($mimeType, ['text/plain', 'text/html', 'text/x-asm', 'text/x-c'], true)) {
                         return 'text/javascript';
                     }
                     break;


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-552

- Fix minified PCI javascript file mime-type, that was wrongly detected as HTML.

Test:
- serve an HTML file with `.js` extension and check mime-type in browser.