### PR TITLE
ci: discard changes in repository before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           php -r '$composerArray = json_decode(file_get_contents("./composer.json"), true);
             $composerArray["require"][$composerArray["name"]] = "dev-develop";
-            $composerArray["repositories"] = is_array($composerArray["repositories"]) ? $composerArray["repositories"] : [];
+            $composerArray["repositories"] = array_key_exists("repositories", $composerArray) ? $composerArray["repositories"] : [];
             $composerArray["repositories"][] = [
               "type" => "vcs",
               "url" => "https://github.com/".$composerArray["name"].".git"
@@ -71,5 +71,6 @@ jobs:
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
           git remote set-url --push origin https://${GITHUB_TOKEN}@github.com/$REPO_NAME.git
+          git checkout .
           cd ..
           taoRelease extensionRelease --extension-to-release ${EXT_ID} --no-interactive --no-write


### PR DESCRIPTION
Automated release of the extensions fails because of the changes in repository:
```
➡ Checking extension status
The extension tao has local changes, please clean or stash them before releasing
```
The changes are:
```
Changes not staged for commit:
	modified:   views/package-lock.json
```
