### PR TITLE
ci: use https protocol instad of ssh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,9 @@ jobs:
           cd $EXT_ID
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
+          git config --global url."https://github.com/".insteadOf git@github.com:
+          git config --global url."https://".insteadOf git://
+          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
           git remote set-url --push origin https://${GITHUB_TOKEN}@github.com/$REPO_NAME.git
           git checkout .
           cd ..


### PR DESCRIPTION
That fix should solve the error during automated release:
```
npm ERR! Error while executing:
npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/adobe-webplatform/eve.git
npm ERR! 
npm ERR! Warning: Permanently added the RSA host key for IP address '140.82.114.3' to the list of known hosts.
npm ERR! git@github.com: Permission denied (publickey).
npm ERR! fatal: Could not read from remote repository.
```