### PR TITLE
fix: TR-908 enable CSRF token validation

### DIFF
--- a/test/unit/model/security/xsrf/TokenServiceTest.php
+++ b/test/unit/model/security/xsrf/TokenServiceTest.php
@@ -26,7 +26,6 @@ use oat\oatbox\service\exception\InvalidService;
 use oat\tao\model\security\xsrf\Token;
 use oat\tao\model\security\xsrf\TokenService;
 use oat\tao\model\security\xsrf\TokenStore;
-use Prophecy\Argument;
 
 /**
  * Unit Test of oat\tao\model\security\TokenGenerator
@@ -60,15 +59,14 @@ class TokenServiceTest extends TestCase
         );
     }
 
-
-    public function testInstantiateNoStore()
+    public function testInstantiateNoStore(): void
     {
         $this->expectException(InvalidService::class);
         $service = new TokenService();
         $service->checkToken('unusedString');
     }
 
-    public function testInstantiateBadStore()
+    public function testInstantiateBadStore(): void
     {
         $this->expectException(InvalidService::class);
         $service = new TokenService([
@@ -77,24 +75,7 @@ class TokenServiceTest extends TestCase
         $service->checkToken('unusedString');
     }
 
-    public function testCreateToken_ReturnsNewToken()
-    {
-        $this->tokenStoreMock
-            ->expects(self::once())
-            ->method('getAll')
-            ->willReturn([]);
-
-        $this->tokenStoreMock
-            ->expects(self::once())
-            ->method('setToken');
-
-        /** @var Token $token */
-        $token = $this->subject->createToken();
-
-        self::assertInstanceOf(Token::class, $token, 'Method must return an instance of Token class');
-    }
-
-    public function testCreateToken_WhenCalledTwice_ThenReturnsDifferentNewTokes()
+    public function testCreateToken_WhenCalledTwice_ThenReturnsDifferentNewTokes(): void
     {
         $this->tokenStoreMock
             ->expects(self::exactly(2))
@@ -105,12 +86,9 @@ class TokenServiceTest extends TestCase
             ->expects(self::exactly(2))
             ->method('setToken');
 
-        /** @var Token $token */
         $token1 = $this->subject->createToken();
         $token2 = $this->subject->createToken();
 
-        self::assertInstanceOf(Token::class, $token1, 'Method must return an instance of Token class');
-        self::assertInstanceOf(Token::class, $token2, 'Method must return an instance of Token class');
         self::assertNotEquals($token1->getValue(), $token2->getValue(), 'Method must return new token on each call.');
     }
 
@@ -301,8 +279,7 @@ class TokenServiceTest extends TestCase
                 [$tokenString2]
             );
 
-        $result = $this->subject->createToken();
-        self::assertInstanceOf(Token::class, $result);
+        $this->subject->createToken();
     }
 
     public function testInvalidateRemovesOldestTokensWhenPoolIfFull(): void
@@ -348,8 +325,7 @@ class TokenServiceTest extends TestCase
                 [$tokenString2]
             );
 
-        $result = $this->subject->createToken();
-        self::assertInstanceOf(Token::class, $result);
+        $this->subject->createToken();
     }
 
     /**


### PR DESCRIPTION
This fixes `TokenService::validateToken()` not actually checking the provided token value, and accepting anything.

- chore: [TR-908](https://oat-sa.atlassian.net/browse/TR-908) clean up useless test cases and conditions from `TokenServiceTest`
- fix: [TR-908](https://oat-sa.atlassian.net/browse/TR-908) check `X-CSRF-Token` header value against server-stored tokens via `TokenService::validateToken()`

Caused by https://github.com/oat-sa/tao-core/pull/2655/files#diff-755eff4da554fe5ca1678fdd0bce56daff2827518c160ba87f347a56051f9c47R147