### PR TITLE
fix: use always generis to search roles

### DIFF
--- a/models/classes/search/GenerisSearchBridge.php
+++ b/models/classes/search/GenerisSearchBridge.php
@@ -21,29 +21,16 @@
 namespace oat\tao\model\search;
 
 use oat\oatbox\service\ConfigurableService;
-use oat\tao\model\search\strategy\GenerisSearch;
 
 class GenerisSearchBridge extends ConfigurableService implements SearchBridgeInterface
 {
     public function search(SearchQuery $query): ResultSet
     {
-        return $this->getSearchService()->query(
+        return $this->getServiceLocator()->get(Search::SERVICE_ID)->query(
             $query->getTerm(),
             $query->getParentClass(),
             $query->getStartRow(),
             $query->getRows()
         );
-    }
-
-    private function getSearchService(): Search
-    {
-        $search = $this->getServiceLocator()->get(Search::SERVICE_ID);
-
-        if (!$search instanceof GenerisSearch) {
-            $search = new GenerisSearch();
-            $search->setServiceManager($this->getServiceManager());
-        }
-
-        return $search;
     }
 }

--- a/models/classes/search/GenerisSearchBridge.php
+++ b/models/classes/search/GenerisSearchBridge.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020-2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\tao\model\search;

--- a/models/classes/search/GenerisSearchBridge.php
+++ b/models/classes/search/GenerisSearchBridge.php
@@ -15,22 +15,35 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2021 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\tao\model\search;
 
 use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\search\strategy\GenerisSearch;
 
 class GenerisSearchBridge extends ConfigurableService implements SearchBridgeInterface
 {
     public function search(SearchQuery $query): ResultSet
     {
-        return $this->getServiceLocator()->get(Search::SERVICE_ID)->query(
+        return $this->getSearchService()->query(
             $query->getTerm(),
             $query->getParentClass(),
             $query->getStartRow(),
             $query->getRows()
         );
+    }
+
+    private function getSearchService(): Search
+    {
+        $search = $this->getServiceLocator()->get(Search::SERVICE_ID);
+
+        if (!$search instanceof GenerisSearch) {
+            $search = new GenerisSearch();
+            $search->setServiceManager($this->getServiceManager());
+        }
+
+        return $search;
     }
 }

--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -114,8 +114,8 @@ class SearchProxy extends ConfigurableService
             /**
              * @TODO We need to implement better search driver management: https://oat-sa.atlassian.net/browse/ADF-251
              */
-            $generis = new GenerisSearch();
-            $generis->propagate($this->getServiceLocator());
+            $this->generisSearch = new GenerisSearch();
+            $this->generisSearch->propagate($this->getServiceLocator());
         }
 
         return $this->generisSearch;
@@ -123,7 +123,7 @@ class SearchProxy extends ConfigurableService
 
     private function searchWithGeneris(SearchQuery $query): ResultSet
     {
-        return $this->generisSearch->query(
+        return $this->getGenerisSearch()->query(
             $query->getTerm(),
             $query->getParentClass(),
             $query->getStartRow(),

--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\tao\model\search;
 
 use Exception;
+use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
@@ -34,7 +35,7 @@ class SearchProxy extends ConfigurableService
     use OntologyAwareTrait;
 
     private const GENERIS_SEARCH_WHITELIST = [
-        'http://www.tao.lu/Ontologies/generis.rdf#ClassRole'
+        GenerisRdf::CLASS_ROLE
     ];
 
     /**
@@ -92,11 +93,6 @@ class SearchProxy extends ConfigurableService
         return $this->getServiceLocator()->get(SearchQueryFactory::class);
     }
 
-    private function getGenerisSearch(): GenerisSearch
-    {
-        return $this->getServiceLocator()->get(GenerisSearch::class);
-    }
-
     private function isForcingGenerisSearch(SearchQuery $query): bool
     {
         return in_array($query->getParentClass(), self::GENERIS_SEARCH_WHITELIST);
@@ -104,7 +100,13 @@ class SearchProxy extends ConfigurableService
 
     private function searchWithGeneris(SearchQuery $query): ResultSet
     {
-        return $this->getGenerisSearch()->query(
+        /**
+         * @TODO We need to implement better search driver management: https://oat-sa.atlassian.net/browse/ADF-251
+         */
+        $generis = new GenerisSearch();
+        $generis->propagate($this->getServiceLocator());
+
+        return $generis->query(
             $query->getTerm(),
             $query->getParentClass(),
             $query->getStartRow(),


### PR DESCRIPTION
Forces use generis always to search roles, cause it is not indexed and not needed to be indexed.

Tickets:

- https://oat-sa.atlassian.net/browse/ADF-241
- https://oat-sa.atlassian.net/browse/ADF-250

This is a blocker task, the follow up tech debt will be done later. It is covered by unit tests 

Tech debt ticket: https://oat-sa.atlassian.net/browse/ADF-251