### PR TITLE
fix: draft fix for html injections in user management

### DIFF
--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -357,7 +357,7 @@ class tao_actions_Main extends tao_actions_CommonModule
         $this->setData('logout', $urlRouteService->getLogoutUrl());
 
         $this->setData('user_lang', $this->getSession()->getDataLanguage());
-        $this->setData('userLabel', $this->getSession()->getUserLabel());
+        $this->setData('userLabel', htmlspecialchars($this->getSession()->getUserLabel()));
         // re-added to highlight selected extension in menu
         $this->setData('shownExtension', $extension);
         $this->setData('shownStructure', $structure);

--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -357,7 +357,7 @@ class tao_actions_Main extends tao_actions_CommonModule
         $this->setData('logout', $urlRouteService->getLogoutUrl());
 
         $this->setData('user_lang', $this->getSession()->getDataLanguage());
-        $this->setData('userLabel', htmlspecialchars($this->getSession()->getUserLabel()));
+        $this->setData('userLabel', tao_helpers_Display::htmlEscape($this->getSession()->getUserLabel()));
         // re-added to highlight selected extension in menu
         $this->setData('shownExtension', $extension);
         $this->setData('shownStructure', $structure);

--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -42,6 +42,7 @@ use oat\tao\model\notification\Notification;
 use oat\tao\model\notification\NotificationServiceInterface;
 use oat\tao\model\user\UserLocks;
 use oat\oatbox\log\LoggerAwareTrait;
+use tao_helpers_Display as DisplayHelper;
 
 /**
  * @author CRP Henri Tudor - TAO Team - {@link http://www.tao.lu}
@@ -357,7 +358,7 @@ class tao_actions_Main extends tao_actions_CommonModule
         $this->setData('logout', $urlRouteService->getLogoutUrl());
 
         $this->setData('user_lang', $this->getSession()->getDataLanguage());
-        $this->setData('userLabel', tao_helpers_Display::htmlEscape($this->getSession()->getUserLabel()));
+        $this->setData('userLabel', DisplayHelper::htmlEscape($this->getSession()->getUserLabel()));
         // re-added to highlight selected extension in menu
         $this->setData('shownExtension', $extension);
         $this->setData('shownStructure', $structure);

--- a/actions/class.Users.php
+++ b/actions/class.Users.php
@@ -34,6 +34,7 @@ use oat\tao\model\user\UserLocks;
 use oat\oatbox\user\UserLanguageServiceInterface;
 use oat\oatbox\log\LoggerAwareTrait;
 use tao_helpers_form_FormContainer as FormContainer;
+use tao_helpers_Display as DisplayHelper;
 
 /**
  * This controller provide the actions to manage the application users (list/add/edit/delete)
@@ -163,10 +164,10 @@ class tao_actions_Users extends tao_actions_CommonModule
 
             $email = (string)current($propValues[GenerisRdf::PROPERTY_USER_MAIL]);
             $response->data[$index]['id'] = $id;
-            $response->data[$index]['login'] = tao_helpers_Display::htmlEscape($login);
-            $response->data[$index]['firstname'] = tao_helpers_Display::htmlEscape($firstName);
-            $response->data[$index]['lastname'] = tao_helpers_Display::htmlEscape($lastName);
-            $response->data[$index]['email'] = tao_helpers_Display::htmlEscape($email);
+            $response->data[$index]['login'] = DisplayHelper::htmlEscape($login);
+            $response->data[$index]['firstname'] = DisplayHelper::htmlEscape($firstName);
+            $response->data[$index]['lastname'] = DisplayHelper::htmlEscape($lastName);
+            $response->data[$index]['email'] = DisplayHelper::htmlEscape($email);
             $response->data[$index]['roles'] = implode(', ', $labels);
             $response->data[$index]['guiLg'] = is_null($uiRes) ? '' : $uiRes->getLabel();
 

--- a/actions/class.Users.php
+++ b/actions/class.Users.php
@@ -163,10 +163,10 @@ class tao_actions_Users extends tao_actions_CommonModule
 
             $email = (string)current($propValues[GenerisRdf::PROPERTY_USER_MAIL]);
             $response->data[$index]['id'] = $id;
-            $response->data[$index]['login'] = htmlspecialchars($login);
-            $response->data[$index]['firstname'] = htmlspecialchars($firstName);
-            $response->data[$index]['lastname'] = htmlspecialchars($lastName);
-            $response->data[$index]['email'] = htmlspecialchars($email);
+            $response->data[$index]['login'] = tao_helpers_Display::htmlEscape($login);
+            $response->data[$index]['firstname'] = tao_helpers_Display::htmlEscape($firstName);
+            $response->data[$index]['lastname'] = tao_helpers_Display::htmlEscape($lastName);
+            $response->data[$index]['email'] = tao_helpers_Display::htmlEscape($email);
             $response->data[$index]['roles'] = implode(', ', $labels);
             $response->data[$index]['guiLg'] = is_null($uiRes) ? '' : $uiRes->getLabel();
 

--- a/actions/class.Users.php
+++ b/actions/class.Users.php
@@ -161,11 +161,12 @@ class tao_actions_Users extends tao_actions_CommonModule
                 $response->data[$index]['dataLg'] = is_null($dataRes) ? '' : $dataRes->getLabel();
             }
 
+            $email = (string)current($propValues[GenerisRdf::PROPERTY_USER_MAIL]);
             $response->data[$index]['id'] = $id;
-            $response->data[$index]['login'] = $login;
-            $response->data[$index]['firstname'] = $firstName;
-            $response->data[$index]['lastname'] = $lastName;
-            $response->data[$index]['email'] = (string)current($propValues[GenerisRdf::PROPERTY_USER_MAIL]);
+            $response->data[$index]['login'] = htmlspecialchars($login);
+            $response->data[$index]['firstname'] = htmlspecialchars($firstName);
+            $response->data[$index]['lastname'] = htmlspecialchars($lastName);
+            $response->data[$index]['email'] = htmlspecialchars($email);
             $response->data[$index]['roles'] = implode(', ', $labels);
             $response->data[$index]['guiLg'] = is_null($uiRes) ? '' : $uiRes->getLabel();
 


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-342
This PR fixing html injection vulnerability according this report 1.1 https://www.exploit-db.com/exploits/48341

***How to check:***
- go to http://test-nik.playground.kitchen.it.taocloud.org:48161/
- Move on top right to the user button and click manage users
- Inject html script code payload into the vulnerable input fields
- Save the entry
- Open to the manage users listing
- Validate that html injections not appear as DOM objects
