### PR TITLE
Regenerate package-lock without eve@git weirdness

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -55,14 +55,14 @@
             "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "codemirror": {
-            "version": "5.58.2",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.2.tgz",
-            "integrity": "sha512-K/hOh24cCwRutd1Mk3uLtjWzNISOkm4fvXiMO7LucCrqbh6aJDdtqUziim3MZUI6wOY0rvY1SlL1Ork01uMy6w=="
+            "version": "5.60.0",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.60.0.tgz",
+            "integrity": "sha512-AEL7LhFOlxPlCL8IdTcJDblJm8yrAGib7I+DErJPdZd4l6imx8IMgKK3RblVgBQqz3TZJR4oknQ03bz+uNjBYA=="
         },
         "core-js": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-            "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "decimal.js": {
             "version": "10.1.1",
@@ -75,8 +75,8 @@
             "integrity": "sha512-XywCTXZtc/qCX3iprD1pIklRVk/uhl8BKpkTxr+ZyMVUzSUg7wkQXRBp/euJ5J5moa1QvfpvaPQVP71z1O59dQ=="
         },
         "eve": {
-            "version": "git+ssh://git@github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "eve@git://github.com/adobe-webplatform/eve.git#eef80ed"
+            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed"
         },
         "fastestsmallesttextencoderdecoder": {
             "version": "1.0.14",
@@ -148,7 +148,7 @@
             "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.2.0.tgz",
             "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
             "requires": {
-                "eve": "eve@git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
             }
         },
         "regenerator-runtime": {


### PR DESCRIPTION
Previous package-lock gave error
> Could not install from "node_modules/raphael/eve@git:/github.com/adobe-webplatform/eve.git#eef80ed" as it does not contain a package.json file.

Please check:
`cd views`
`npm ci`