### PR TITLE
Fix/TR-903/Continue dragging element outside of the window

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,8 +39,9 @@
             "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "github:oat-sa/tao-core-ui-fe#61ad4d64dc28b558ecaa39ed48e2faa0936b4f71",
-            "from": "github:oat-sa/tao-core-ui-fe#fix/TR-903/continue-dragging-outside-of-window"
+            "version": "1.22.11",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.11.tgz",
+            "integrity": "sha512-9afuMbiV3JHl8CBazwm5y+CjRNlbFEtfy8Z8+I5apG8xMYTCHeAt0tlaM09SLEOk5SQQDpBiKEbuxjyFD4nG5Q=="
         },
         "amdefine": {
             "version": "1.0.1",
@@ -54,9 +55,9 @@
             "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "codemirror": {
-            "version": "5.60.0",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.60.0.tgz",
-            "integrity": "sha512-AEL7LhFOlxPlCL8IdTcJDblJm8yrAGib7I+DErJPdZd4l6imx8IMgKK3RblVgBQqz3TZJR4oknQ03bz+uNjBYA=="
+            "version": "5.61.0",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
+            "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
         },
         "core-js": {
             "version": "2.6.12",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,9 +39,8 @@
             "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.10.tgz",
-            "integrity": "sha512-7flEe9EUWgtS8mH3is9CQ0zXFowFO7MeGCylWJGewwuxVaxIgb9vMD8SoRNS8kt7dmXaTQI+y9ELlPOePM3Z+Q=="
+            "version": "github:oat-sa/tao-core-ui-fe#61ad4d64dc28b558ecaa39ed48e2faa0936b4f71",
+            "from": "github:oat-sa/tao-core-ui-fe#fix/TR-903/continue-dragging-outside-of-window"
         },
         "amdefine": {
             "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "0.4.3",
         "@oat-sa/tao-core-sdk": "^1.12.0",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
-        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#fix/TR-903/continue-dragging-outside-of-window",
+        "@oat-sa/tao-core-ui": "1.22.11",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "0.4.3",
         "@oat-sa/tao-core-sdk": "^1.12.0",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
-        "@oat-sa/tao-core-ui": "1.22.10",
+        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#fix/TR-903/continue-dragging-outside-of-window",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-903

Requires: 
 - [x] https://github.com/oat-sa/tao-core-ui-fe/pull/272
 - [x] Once the companion has been merged, the `package.json` and `package-lock.json` files need to be updated with the released version. Pay attention to have the npm package instead of the GitHub repository in the lock file.

Fix a drag&drop issue while trying to drag the element outside of the window: once back to the window, the link with the dragged element is lost.

How to test:
- Have a test with a GraphicGapMatch interaction. It would also be better to check other drag&drop compatible interactions (check the JIRA ticket for a sample test)
- Publish and take the tets
- When dragging an element of the interaction, you can try going outside the window and going back into it

Expected:
- with the PR, you continue dragging the element even after tried to go outside of the window
- without the PR, the drag&drop looks broken as you lose control of the element as soon as you leave the window while dragging

Note: the `ui/interactUtils` helper has been added by these PR:
- https://github.com/oat-sa/tao-core/pull/844
- https://github.com/oat-sa/extension-tao-itemqti/pull/691

It looks like it is only used by QTI interactions (cf. https://github.com/search?q=org%3Aoat-sa+iFrameDragFixOn&type=Code).