### PR TITLE
fix/AUT-396/update @oat-sa/tao-core-ui

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,9 +39,8 @@
             "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.22.13",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.13.tgz",
-            "integrity": "sha512-vImhgxiN+9oJ23gt8KdRstupD0K2X9uBht0qtEzl3XuNgtt3V0jDcQgvSsl+5Au8XI8GdgSZVJQjzvr6bbdeww=="
+            "version": "git://github.com/oat-sa/tao-core-ui-fe.git#791c714efd0e9f5a9b03c23da5004e5034f1b478",
+            "from": "git://github.com/oat-sa/tao-core-ui-fe.git#feature/AUT-396/unclickable-propperties"
         },
         "amdefine": {
             "version": "1.0.1",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,8 +39,9 @@
             "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "git://github.com/oat-sa/tao-core-ui-fe.git#791c714efd0e9f5a9b03c23da5004e5034f1b478",
-            "from": "git://github.com/oat-sa/tao-core-ui-fe.git#feature/AUT-396/unclickable-propperties"
+            "version": "1.22.15",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.15.tgz",
+            "integrity": "sha512-CHKM/0Z4dAy7B8o5T0VYf6vL/opuDnbmSaF3HxPja2XCAgzC9RP6gxKtXw/l2qQ3Cxo8WjLTooS9fe+nmUY1mw=="
         },
         "amdefine": {
             "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "0.4.3",
         "@oat-sa/tao-core-sdk": "^1.12.0",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
-        "@oat-sa/tao-core-ui": "1.22.13",
+        "@oat-sa/tao-core-ui": "git://github.com/oat-sa/tao-core-ui-fe#feature/AUT-396/unclickable-propperties",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "0.4.3",
         "@oat-sa/tao-core-sdk": "^1.12.0",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
-        "@oat-sa/tao-core-ui": "git://github.com/oat-sa/tao-core-ui-fe#feature/AUT-396/unclickable-propperties",
+        "@oat-sa/tao-core-ui": "1.22.15",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",


### PR DESCRIPTION
Related to: [AUT-396](https://oat-sa.atlassian.net/browse/AUT-396)
Related to: https://github.com/oat-sa/tao-core-ui-fe/pull/279

**Description**
Added deleted node to `deleted.deleter` event. It is important because this event fires on the parent node, and we should have a possibility to detect which node was removed.