### PR TITLE
Fix: form token is no longer used as a regular CSRF token

### DIFF
--- a/models/classes/security/xsrf/TokenService.php
+++ b/models/classes/security/xsrf/TokenService.php
@@ -67,7 +67,6 @@ class TokenService extends ConfigurableService
     ];
 
     public const CSRF_TOKEN_HEADER       = 'X-CSRF-Token';
-    public const FORM_POOL               = 'form_pool';
     public const FORM_TOKEN_NAMESPACE    = 'form_token';
     public const JS_DATA_KEY             = 'tokenHandler';
     public const JS_TOKEN_KEY            = 'tokens';
@@ -233,7 +232,7 @@ class TokenService extends ConfigurableService
     /**
      * Get the configured pool size
      *
-     * @param bool $withForm - Takes care of the FORM_POOL
+     * @param bool $withForm - Takes care of the form token
      *
      * @return int the pool size, 10 by default
      *
@@ -324,10 +323,13 @@ class TokenService extends ConfigurableService
     {
         $tokenPool = $this->generateTokenPool();
         $jsTokenPool = [];
-        foreach ($tokenPool as $key => $token) {
-            if ($key !== self::FORM_POOL) {
-                $jsTokenPool[] = $token->getValue();
+        $storedFormToken = $this->getStore()->getToken(self::FORM_TOKEN_NAMESPACE);;
+        foreach ($tokenPool as $token) {
+            if ($storedFormToken && $token->getValue() === $storedFormToken->getValue()) {
+                // exclude form token from client configuration
+                continue;
             }
+            $jsTokenPool[] = $token->getValue();
         }
 
         return [

--- a/models/classes/security/xsrf/TokenStoreSession.php
+++ b/models/classes/security/xsrf/TokenStoreSession.php
@@ -88,12 +88,11 @@ class TokenStoreSession extends Configurable implements TokenStore
     public function getAll(): array
     {
         $tokens = [];
-        foreach($this->getSession()->getAttributeNames() as $key) {
-            if (strpos($key, self::TOKEN_NAMESPACE) === 0) {
-                $tokens[] = $this->getSession()->getAttribute($key);
+        foreach ($this->getSession()->getAttributeNames() as $sessionAttributeKey) {
+            if (strpos($sessionAttributeKey, self::TOKEN_NAMESPACE) === 0) {
+                $tokens[] = $this->getSession()->getAttribute($sessionAttributeKey);
             }
         }
-
         return $tokens;
     }
 }


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/TR-1040

Root cause: TokenService relies on a storage key that doesn't exist when filtering out the form token before the token pull is provided to a client. As a result, there are 10 regular CSRF tokens mixed with a form token that should never be there.

This has been tested in Kitchen already by QA.