### PR TITLE
Fix/TR-1131/Emit an event when the theme is applied

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,9 +39,8 @@
             "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.22.16",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.22.16.tgz",
-            "integrity": "sha512-Pn3/G80bWj14O6bDBoQnzStLfwQyx2WC2zoS79njLJQlEhAUykduKBGEIQlf3jvOtVtG5QbrVF4aUriYtBv0Sw=="
+            "version": "github:oat-sa/tao-core-ui-fe#189ad034f3dfec84884fa89a56cd60f24d32a74c",
+            "from": "github:oat-sa/tao-core-ui-fe#feature/TR-1131/emit-theme-applied-event"
         },
         "amdefine": {
             "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "0.4.3",
         "@oat-sa/tao-core-sdk": "^1.12.0",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
-        "@oat-sa/tao-core-ui": "1.22.16",
+        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#feature/TR-1131/emit-theme-applied-event",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1131

Requires: 
 - [ ] https://github.com/oat-sa/tao-core-ui-fe/pull/284
 - [ ] once the companion PR has been merged, the package.json and package-lock.json files must updated with the proper version

Apply the feature that emits an event when the theme gets applied. Actually, an event was already emitted, but it was scoped for internal purpose and was not namespaceable. We need an event that can be namespaced in order to properly manage the life cycle.