### PR TITLE
Feature/TR-1207/Add locale format for DateTime in UTC

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -24,8 +24,9 @@
             "integrity": "sha512-6H4B5ETIWK011gJIPNxOMP2xIdWLNcTpDRsQvLuHO/716KbGG5PCAFCgQwdhmyIBAx9ApUeTF2ee0Xn6Ds0FAA=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "github:oat-sa/tao-core-sdk-fe#b81c02adb8bd8fe93eaee9594b3833d322209b01",
-            "from": "github:oat-sa/tao-core-sdk-fe#feature/TR-1207/support-locale-format-datetime-in-utc",
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.14.0.tgz",
+            "integrity": "sha512-vVEPWR3+P3bSN/a24hWs0W/NjpYMmp0tzJZ/MHp2b26UBhSNJ8ej1RmOGChZo8fqcRzjNgKPRvzw0Ww3SGb9gw==",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",
                 "idb-wrapper": "1.7.0",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -24,9 +24,8 @@
             "integrity": "sha512-6H4B5ETIWK011gJIPNxOMP2xIdWLNcTpDRsQvLuHO/716KbGG5PCAFCgQwdhmyIBAx9ApUeTF2ee0Xn6Ds0FAA=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.13.0.tgz",
-            "integrity": "sha512-TykNcKRXh0RZyW55SaVsAebWNSxYMjnW6xHOBtaPJyU69SeCXbxxvcFalvDQ3MQk6oLtVDNMecBGeSl6XkgMtw==",
+            "version": "github:oat-sa/tao-core-sdk-fe#b81c02adb8bd8fe93eaee9594b3833d322209b01",
+            "from": "github:oat-sa/tao-core-sdk-fe#feature/TR-1207/support-locale-format-datetime-in-utc",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",
                 "idb-wrapper": "1.7.0",
@@ -55,9 +54,9 @@
             "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "codemirror": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
-            "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
+            "version": "5.61.1",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.1.tgz",
+            "integrity": "sha512-+D1NZjAucuzE93vJGbAaXzvoBHwp9nJZWWWF9utjv25+5AZUiah6CIlfb4ikG4MoDsFsCG8niiJH5++OO2LgIQ=="
         },
         "core-js": {
             "version": "2.6.12",

--- a/views/package.json
+++ b/views/package.json
@@ -11,7 +11,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/tao-core-libs": "0.4.3",
-        "@oat-sa/tao-core-sdk": "^1.12.0",
+        "@oat-sa/tao-core-sdk": "github:oat-sa/tao-core-sdk-fe#feature/TR-1207/support-locale-format-datetime-in-utc",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
         "@oat-sa/tao-core-ui": "1.24.1",
         "async": "0.2.10",

--- a/views/package.json
+++ b/views/package.json
@@ -11,7 +11,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.0",
         "@oat-sa/tao-core-libs": "0.4.3",
-        "@oat-sa/tao-core-sdk": "github:oat-sa/tao-core-sdk-fe#feature/TR-1207/support-locale-format-datetime-in-utc",
+        "@oat-sa/tao-core-sdk": "1.14.0",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
         "@oat-sa/tao-core-ui": "1.24.1",
         "async": "0.2.10",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1207

Requires: 
 - [x] https://github.com/oat-sa/tao-core-sdk-fe/pull/106
 - [x] once the companion PR is merged, don't forget to update both `package.json` and `package-lock.json`

Update the package `@oat-sa/tao-core-sdk`.

> Add a variant for the helper `formatDateTime()` to also support timestamp in UTC.
>
> By default, the helper will continue assuming the supplied timestamp is in the user's timezone. However, the second parameter of the helper allows qualifying the timestamp as being in UTC instead.