### PR TITLE
Fix: TR-981/scrollbar-between-item-pages

### DIFF
--- a/views/js/layout/loading-bar.js
+++ b/views/js/layout/loading-bar.js
@@ -30,7 +30,6 @@ define(['jquery'],
             originalHeight = $loadingBar.height(),
             $win = $(window),
             $doc = $(document),
-            loadingBarHeight = $(document).height(),
             $contentWrap = $('.content-wrap'),
             headerElements = {
                 $versionWarning: $contentWrap.find('.version-warning'),
@@ -61,6 +60,7 @@ define(['jquery'],
          * Update height of cover element
          */
         function updateHeight() {
+            var loadingBarHeight = $doc.height();
             if (!$loadingBar.hasClass('loading')) {
                 return;
             }

--- a/views/js/layout/loading-bar.js
+++ b/views/js/layout/loading-bar.js
@@ -30,8 +30,8 @@ define(['jquery'],
             originalHeight = $loadingBar.height(),
             $win = $(window),
             $doc = $(document),
-            $contentWrap    = $('.content-wrap'),
-            headerElements  = {
+            $contentWrap = $('.content-wrap'),
+            headerElements = {
                 $versionWarning: $contentWrap.find('.version-warning'),
                 $header: $contentWrap.find('header:first()')
             },
@@ -45,11 +45,11 @@ define(['jquery'],
          *
          * @param headerElements
          */
-        function getHeaderHeight(headerElements){
+        function getHeaderHeight(headerElements) {
             var $element;
             headerHeight = 0;
-            for($element in headerElements) {
-                if(headerElements[$element].length && headerElements[$element].is(':visible')) {
+            for ($element in headerElements) {
+                if (headerElements[$element].length && headerElements[$element].is(':visible')) {
                     headerHeight += headerElements[$element].outerHeight();
                 }
             }
@@ -73,7 +73,7 @@ define(['jquery'],
             }
 
             if ($loadingBar.hasClass('loadingbar-covered')) {
-                $loadingBar.height($doc.height());
+                $loadingBar.height($doc.height() - 1);
             } else {
                 $loadingBar.height('');
             }

--- a/views/js/layout/loading-bar.js
+++ b/views/js/layout/loading-bar.js
@@ -73,7 +73,7 @@ define(['jquery'],
             }
 
             if ($loadingBar.hasClass('loadingbar-covered')) {
-                var loadingBarHeight = $doc.height();
+                let loadingBarHeight = $doc.height();
                 if (window.devicePixelRatio !== 1) {
                     loadingBarHeight--;
                 }

--- a/views/js/layout/loading-bar.js
+++ b/views/js/layout/loading-bar.js
@@ -30,6 +30,7 @@ define(['jquery'],
             originalHeight = $loadingBar.height(),
             $win = $(window),
             $doc = $(document),
+            loadingBarHeight = $(document).height(),
             $contentWrap = $('.content-wrap'),
             headerElements = {
                 $versionWarning: $contentWrap.find('.version-warning'),
@@ -73,7 +74,6 @@ define(['jquery'],
             }
 
             if ($loadingBar.hasClass('loadingbar-covered')) {
-                let loadingBarHeight = $doc.height();
                 if (window.devicePixelRatio !== 1) {
                     loadingBarHeight--;
                 }

--- a/views/js/layout/loading-bar.js
+++ b/views/js/layout/loading-bar.js
@@ -73,7 +73,11 @@ define(['jquery'],
             }
 
             if ($loadingBar.hasClass('loadingbar-covered')) {
-                $loadingBar.height($doc.height() - 1);
+                var loadingBarHeight = $doc.height();
+                if (window.devicePixelRatio !== 1) {
+                    loadingBarHeight--;
+                }
+                $loadingBar.height(loadingBarHeight);
             } else {
                 $loadingBar.height('');
             }


### PR DESCRIPTION
Related to: [TR-981](https://oat-sa.atlassian.net/browse/TR-981)

It happens when the page's height has decimals. Browser zoom enabled creates this situation. 
Loader set a full height without decimals and overflow the page.
I can reproduce it in any browser.

**Steps to reproduce**:
Ej: 881 x 982 px body height + zoom 150% (Chrome)