### PR TITLE
Advanced search: Add criteria option is unclickable after opening Modal view.

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,9 +39,8 @@
             "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.24.2",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.24.2.tgz",
-            "integrity": "sha512-rMLwJK0J68JlK3lFaBLBDJ46so6Cticrx2EbEtnYimauqd8eXqhSj/QegC2Z4MlebnME/Q72ukEZyESaSFH29w=="
+            "version": "git://github.com/oat-sa/tao-core-ui-fe.git#f14624eb8be6b7a565c97ef4b7007e3fe8c8608c",
+            "from": "git://github.com/oat-sa/tao-core-ui-fe.git#fix/ADF-343/add-criteria-unclickable"
         },
         "amdefine": {
             "version": "1.0.1",
@@ -55,9 +54,9 @@
             "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "codemirror": {
-            "version": "5.61.0",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.0.tgz",
-            "integrity": "sha512-D3wYH90tYY1BsKlUe0oNj2JAhQ9TepkD51auk3N7q+4uz7A/cgJ5JsWHreT0PqieW1QhOuqxQ2reCXV1YXzecg=="
+            "version": "5.61.1",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.1.tgz",
+            "integrity": "sha512-+D1NZjAucuzE93vJGbAaXzvoBHwp9nJZWWWF9utjv25+5AZUiah6CIlfb4ikG4MoDsFsCG8niiJH5++OO2LgIQ=="
         },
         "core-js": {
             "version": "2.6.12",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "0.4.3",
         "@oat-sa/tao-core-sdk": "^1.12.0",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
-        "@oat-sa/tao-core-ui": "1.24.2",
+        "@oat-sa/tao-core-ui": "git://github.com/oat-sa/tao-core-ui-fe#fix/ADF-343/add-criteria-unclickable",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",


### PR DESCRIPTION
**Ticket**

https://oat-sa.atlassian.net/browse/ADF-343

**Description**

The issue is randomly reproduced (about 1 of 10 times) - when the user opens the Modal view by clicking the Search icon, the "add criteria" button is unclickable and the "+" icon on the left of it is replaced with endlessly turning spinner. After clicking the 'Clear' button the user is able to click on the button and to see a dropdown list but the spinner is still there.

**Steps to reproduce**

- Open any tab.
- Click the Search icon to open Modal view.

**Actual result**

About 1 of 10 times the 'add criteria' button becomes unclickable and has a constantly turning spinner icon on its left.

**Expected result**

There's no case when 'add criteria' becomes unclickable right after opening Modal view.