### PR TITLE
[Fix] ADF-100 - CORE: The 'Cancel' button in warning message does not prevent the object from moving to another class.

### DIFF
--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -149,7 +149,7 @@ define([
 
                         treeState = $container.data('tree-state');
                         if(treeState.rollback){
-                            tree.rollback(treeState.rollback);
+                            $.tree.rollback(treeState.rollback);
 
                             //remove the rollback infos.
                             setTreeState(_.omit(treeState, 'rollback'));
@@ -544,7 +544,8 @@ define([
                         actionManager.exec(options.actions.moveInstance, {
                             uri: $(node).data('uri'),
                             destinationClassUri: $(refNode).data('uri'),
-                            signature: $(node).data('signature')
+                            signature: $(node).data('signature'),
+                            tree: node
                         });
 
                         $container.trigger('change.taotree');


### PR DESCRIPTION
**Ticket**

https://oat-sa.atlassian.net/browse/ADF-100

**Environment to test**

The link to the playground is in the ticket

**Description**

When user tries to move the item from one class to another using Drag-and-Drop, there's a warning pop-up message about replacing current object's properties with the new ones from destination class. However, clicking the 'Cancel' button in this message does not prevent the object from moving to the new class. Therefore, item is moved and the properties are replaced or removed nevertheless.

**Steps to reproduce**

- Go to Items tab and create 2 new classes.

- Click 'Manage schema' and then 'Add property' for one of the classes.

- Click on 'pencil' icon on the newly added property and set 'Type' (f.e. 'List - Single choice - Drop down')

- Create a new item within class with added property.

- Choose created item and drag-and-drop it to another class.

- Click 'Cancel' in pop-up message.

**Actual result**

The item seems to be moved in frontend, but as soon as the page is refreshed we can see that the item is still found in the original class.

**Expected result**

The moving is cancelled, the item remains in the first class.