### PR TITLE
feature: making search proxy central point for search

### DIFF
--- a/actions/class.Search.php
+++ b/actions/class.Search.php
@@ -122,7 +122,7 @@ class tao_actions_Search extends tao_actions_CommonModule
 
     private function getSearchProxy(): SearchProxy
     {
-        return $this->getServiceLocator()->get(SearchProxy::class);
+        return $this->getServiceLocator()->get(SearchProxy::SERVICE_ID);
     }
 
     private function getResultSetMapper(): ResultSetMapper

--- a/config/default/search.conf.php
+++ b/config/default/search.conf.php
@@ -4,4 +4,11 @@
  * Default label search based on generis
  */
 
-return new oat\tao\model\search\strategy\GenerisSearch();
+use oat\tao\model\search\SearchProxy;
+use oat\tao\model\search\strategy\GenerisSearch;
+
+return new SearchProxy(
+    [
+        SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => GenerisSearch::class
+    ]
+);

--- a/manifest.php
+++ b/manifest.php
@@ -48,6 +48,7 @@ use oat\tao\scripts\install\RegisterResourceEvents;
 use oat\tao\scripts\install\RegisterResourceRelationService;
 use oat\tao\scripts\install\RegisterResourceWatcherService;
 use oat\tao\scripts\install\RegisterRtlLocales;
+use oat\tao\scripts\install\RegisterSearchServices;
 use oat\tao\scripts\install\RegisterSessionCookieService;
 use oat\tao\scripts\install\RegisterSignatureGenerator;
 use oat\tao\scripts\install\RegisterTaoUpdateEventListener;
@@ -157,7 +158,8 @@ return [
             RegisterResourceRelationService::class,
             RegisterTaoUpdateEventListener::class,
             RegisterActionAccessControl::class,
-            RegisterRtlLocales::class
+            RegisterRtlLocales::class,
+            RegisterSearchServices::class
         ],
     ],
     'update' => Updater::class,

--- a/migrations/Version202106010945122237_tao.php
+++ b/migrations/Version202106010945122237_tao.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace oat\tao\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\search\SearchProxy;
-use oat\tao\model\search\strategy\GenerisSearch;
+use oat\tao\model\search\Search;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 
 final class Version202106010945122237_tao extends AbstractMigration
@@ -18,18 +19,27 @@ final class Version202106010945122237_tao extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->getServiceManager()->register(
-            SearchProxy::SERVICE_ID,
-            new SearchProxy(
-                [
-                    SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => GenerisSearch::class
-                ]
-            )
+        /** @var Search $legacySearch */
+        $legacySearch = $this->getServiceManager()->get(Search::SERVICE_ID);
+
+        $searchProxy = new SearchProxy(
+            [
+                SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => $legacySearch
+            ]
         );
+
+        $this->getServiceManager()->register(SearchProxy::SERVICE_ID, $searchProxy);
     }
 
     public function down(Schema $schema): void
     {
+        /** @var SearchProxy $searchProxy */
+        $searchProxy = $this->getServiceManager()->get(SearchProxy::SERVICE_ID);
+
+        /** @var ConfigurableService|Search $legacySearch */
+        $legacySearch = $searchProxy->getOption(SearchProxy::OPTION_DEFAULT_SEARCH_CLASS);
+
         $this->getServiceManager()->unregister(SearchProxy::SERVICE_ID);
+        $this->getServiceManager()->register(Search::SERVICE_ID, $legacySearch);
     }
 }

--- a/migrations/Version202106010945122237_tao.php
+++ b/migrations/Version202106010945122237_tao.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\search\SearchProxy;
+use oat\tao\model\search\strategy\GenerisSearch;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+final class Version202106010945122237_tao extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register ' . SearchProxy::class;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->getServiceManager()->register(
+            SearchProxy::SERVICE_ID,
+            new SearchProxy(
+                [
+                    SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => GenerisSearch::class
+                ]
+            )
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->getServiceManager()->unregister(SearchProxy::SERVICE_ID);
+    }
+}

--- a/migrations/Version202106010945122237_tao.php
+++ b/migrations/Version202106010945122237_tao.php
@@ -25,10 +25,10 @@ final class Version202106010945122237_tao extends AbstractMigration
         $defaultSearch = $isGenerisSearch ? $currentSearch : new GenerisSearch();
 
         $searchProxy = new SearchProxy();
-        $searchProxy->setOption(SearchProxy::OPTION_DEFAULT_SEARCH_CLASS, $defaultSearch);
+        $searchProxy->withDefaultSearch($defaultSearch);
 
         if (!$isGenerisSearch) {
-            $searchProxy->setOption(SearchProxy::OPTION_ADVANCED_SEARCH_CLASS, $currentSearch);
+            $searchProxy->withAdvancedSearch($currentSearch);
         }
 
         $this->getServiceManager()->register(SearchProxy::SERVICE_ID, $searchProxy);
@@ -40,9 +40,7 @@ final class Version202106010945122237_tao extends AbstractMigration
         $searchProxy = $this->getServiceManager()->get(SearchProxy::SERVICE_ID);
 
         /** @var Search $search */
-        $legacySearch = $searchProxy->hasOption(SearchProxy::OPTION_ADVANCED_SEARCH_CLASS)
-            ? $searchProxy->getOption(SearchProxy::OPTION_ADVANCED_SEARCH_CLASS)
-            : $searchProxy->getOption(SearchProxy::OPTION_DEFAULT_SEARCH_CLASS);
+        $legacySearch = $searchProxy->getAdvancedSearch() ?? $searchProxy->getDefaultSearch();
 
         $this->getServiceManager()->unregister(SearchProxy::SERVICE_ID);
         $this->getServiceManager()->register(Search::SERVICE_ID, $legacySearch);

--- a/migrations/Version202106010945122237_tao.php
+++ b/migrations/Version202106010945122237_tao.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace oat\tao\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\search\SearchProxy;
 use oat\tao\model\search\Search;
+use oat\tao\model\search\strategy\GenerisSearch;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 
 final class Version202106010945122237_tao extends AbstractMigration
@@ -20,13 +20,16 @@ final class Version202106010945122237_tao extends AbstractMigration
     public function up(Schema $schema): void
     {
         /** @var Search $legacySearch */
-        $legacySearch = $this->getServiceManager()->get(Search::SERVICE_ID);
+        $currentSearch = $this->getServiceManager()->get(Search::SERVICE_ID);
+        $isGenerisSearch = $currentSearch instanceof GenerisSearch;
+        $defaultSearch = $isGenerisSearch ? $currentSearch : new GenerisSearch();
 
-        $searchProxy = new SearchProxy(
-            [
-                SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => $legacySearch
-            ]
-        );
+        $searchProxy = new SearchProxy();
+        $searchProxy->setOption(SearchProxy::OPTION_DEFAULT_SEARCH_CLASS, $defaultSearch);
+
+        if (!$isGenerisSearch) {
+            $searchProxy->setOption(SearchProxy::OPTION_ADVANCED_SEARCH_CLASS, $currentSearch);
+        }
 
         $this->getServiceManager()->register(SearchProxy::SERVICE_ID, $searchProxy);
     }
@@ -36,8 +39,10 @@ final class Version202106010945122237_tao extends AbstractMigration
         /** @var SearchProxy $searchProxy */
         $searchProxy = $this->getServiceManager()->get(SearchProxy::SERVICE_ID);
 
-        /** @var ConfigurableService|Search $legacySearch */
-        $legacySearch = $searchProxy->getOption(SearchProxy::OPTION_DEFAULT_SEARCH_CLASS);
+        /** @var Search $search */
+        $legacySearch = $searchProxy->hasOption(SearchProxy::OPTION_ADVANCED_SEARCH_CLASS)
+            ? $searchProxy->getOption(SearchProxy::OPTION_ADVANCED_SEARCH_CLASS)
+            : $searchProxy->getOption(SearchProxy::OPTION_DEFAULT_SEARCH_CLASS);
 
         $this->getServiceManager()->unregister(SearchProxy::SERVICE_ID);
         $this->getServiceManager()->register(Search::SERVICE_ID, $legacySearch);

--- a/migrations/Version202106010945122237_tao.php
+++ b/migrations/Version202106010945122237_tao.php
@@ -19,7 +19,7 @@ final class Version202106010945122237_tao extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        /** @var Search $legacySearch */
+        /** @var Search $currentSearch */
         $currentSearch = $this->getServiceManager()->get(Search::SERVICE_ID);
         $isGenerisSearch = $currentSearch instanceof GenerisSearch;
         $defaultSearch = $isGenerisSearch ? $currentSearch : new GenerisSearch();
@@ -39,7 +39,7 @@ final class Version202106010945122237_tao extends AbstractMigration
         /** @var SearchProxy $searchProxy */
         $searchProxy = $this->getServiceManager()->get(SearchProxy::SERVICE_ID);
 
-        /** @var Search $search */
+        /** @var Search $legacySearch */
         $legacySearch = $searchProxy->getAdvancedSearch() ?? $searchProxy->getDefaultSearch();
 
         $this->getServiceManager()->unregister(SearchProxy::SERVICE_ID);

--- a/models/classes/AdvancedSearch/AdvancedSearchChecker.php
+++ b/models/classes/AdvancedSearch/AdvancedSearchChecker.php
@@ -22,35 +22,19 @@ declare(strict_types=1);
 
 namespace oat\tao\model\AdvancedSearch;
 
-use oat\tao\model\search\Search;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\tao\model\search\SearchProxy;
 
 class AdvancedSearchChecker extends ConfigurableService
 {
     public const FEATURE_FLAG_ADVANCED_SEARCH_DISABLED = 'FEATURE_FLAG_ADVANCED_SEARCH_DISABLED';
 
-    public const OPTION_ALLOWED_SEARCH_CLASSES = 'allowedSearchClasses';
-
     public function isEnabled(): bool
     {
-        return $this->isAdvancedSearchEnabled() && $this->isElasticSearchEnabled();
-    }
-
-    private function isAdvancedSearchEnabled(): bool
-    {
-        return !$this->getFeatureFlagChecker()->isEnabled(self::FEATURE_FLAG_ADVANCED_SEARCH_DISABLED);
-    }
-
-    private function isElasticSearchEnabled(): bool
-    {
-        $allowedSearchClasses = (array) $this->getOption(
-            self::OPTION_ALLOWED_SEARCH_CLASSES,
-            ['oat\tao\elasticsearch\ElasticSearch']
-        );
-
-        return in_array(get_class($this->getSearchService()), $allowedSearchClasses, true);
+        return !$this->getFeatureFlagChecker()->isEnabled(self::FEATURE_FLAG_ADVANCED_SEARCH_DISABLED)
+            && $this->getSearchService()->hasOption(SearchProxy::OPTION_ADVANCED_SEARCH_CLASS);
     }
 
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
@@ -58,8 +42,8 @@ class AdvancedSearchChecker extends ConfigurableService
         return $this->getServiceLocator()->get(FeatureFlagChecker::class);
     }
 
-    private function getSearchService(): Search
+    private function getSearchService(): SearchProxy
     {
-        return $this->getServiceLocator()->get(Search::SERVICE_ID);
+        return $this->getServiceLocator()->get(SearchProxy::SERVICE_ID);
     }
 }

--- a/models/classes/AdvancedSearch/AdvancedSearchChecker.php
+++ b/models/classes/AdvancedSearch/AdvancedSearchChecker.php
@@ -34,7 +34,7 @@ class AdvancedSearchChecker extends ConfigurableService
     public function isEnabled(): bool
     {
         return !$this->getFeatureFlagChecker()->isEnabled(self::FEATURE_FLAG_ADVANCED_SEARCH_DISABLED)
-            && $this->getSearchService()->hasOption(SearchProxy::OPTION_ADVANCED_SEARCH_CLASS);
+            && $this->getSearchService()->getAdvancedSearch();
     }
 
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface

--- a/models/classes/search/ElasticSearchBridge.php
+++ b/models/classes/search/ElasticSearchBridge.php
@@ -24,6 +24,9 @@ namespace oat\tao\model\search;
 
 use oat\oatbox\service\ConfigurableService;
 
+/**
+ * @deprecated User SearchProxy instead
+ */
 class ElasticSearchBridge extends ConfigurableService implements SearchBridgeInterface
 {
     public function search(SearchQuery $query): ResultSet

--- a/models/classes/search/IdentifierSearcher.php
+++ b/models/classes/search/IdentifierSearcher.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\tao\model\search;
@@ -23,10 +23,7 @@ namespace oat\tao\model\search;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 
-/**
- * @deprecated User SearchProxy instead
- */
-class GenerisSearchBridge extends ConfigurableService implements SearchBridgeInterface
+class IdentifierSearcher extends ConfigurableService
 {
     use OntologyAwareTrait;
 
@@ -59,12 +56,7 @@ class GenerisSearchBridge extends ConfigurableService implements SearchBridgeInt
             }
         }
 
-        return $this->getServiceLocator()->get(Search::SERVICE_ID)->query(
-            $query->getTerm(),
-            $query->getParentClass(),
-            $query->getStartRow(),
-            $query->getRows()
-        );
+        return new ResultSet([], 0);
     }
 
     private function isUriSearch(string $queryString): bool

--- a/models/classes/search/Search.php
+++ b/models/classes/search/Search.php
@@ -33,6 +33,6 @@ use oat\oatbox\PhpSerializable;
  */
 interface Search extends PhpSerializable, SearchInterface
 {
-    /** @deprecated */
+    /** @deprecated When no class implement this interface anymore, more this constant to SearchProxy */
     public const SERVICE_ID = 'tao/search';
 }

--- a/models/classes/search/Search.php
+++ b/models/classes/search/Search.php
@@ -15,66 +15,24 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
- *
- *
+ * Copyright (c) 2014-2021 (original work) Open Assessment Technologies SA;
  */
+
+declare(strict_types=1);
 
 namespace oat\tao\model\search;
 
 use oat\oatbox\PhpSerializable;
-use oat\tao\model\search\index\IndexIterator;
 
 /**
  * Search interface
  *
  * @author Joel Bout <joel@taotesting.com>
+ *
+ * @deprecated use SearchInterface
  */
-interface Search extends PhpSerializable
+interface Search extends PhpSerializable, SearchInterface
 {
-    const SERVICE_ID = 'tao/search';
-
-    /**
-     * Search for instances using a Lucene query
-     *
-     * @param string $queryString
-     * @param string $type
-     * @param int $start
-     * @param int $count
-     * @param string $order
-     * @param string $dir
-     *
-     * @return ResultSet
-     */
-    public function query($queryString, $type, $start = 0, $count = 10, $order = 'id', $dir = 'DESC');
-
-    /**
-     * Delete all indexes
-     */
-    public function flush();
-
-    /**
-     * (Re)Generate the index for a given document
-     * If index is already exist, then it will merge the fields in index with the existing document
-     *
-     * @param IndexIterator|array $documents
-     * @return int count of indexed documents
-     */
-    public function index($documents);
-
-    /**
-     * Remove a resource from the index
-     *
-     * @param string $resourceId
-     * @return boolean true if successfully removed
-     */
-    public function remove($resourceId);
-
-    /**
-     * Whenever or not the current implementation supports
-     * custom indexes
-     *
-     * @return boolean
-     */
-    public function supportCustomIndex();
+    /** @deprecated */
+    public const SERVICE_ID = 'tao/search';
 }

--- a/models/classes/search/SearchInterface.php
+++ b/models/classes/search/SearchInterface.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA; *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\search;
+
+use oat\oatbox\PhpSerializable;
+use oat\tao\model\search\index\IndexIterator;
+
+interface SearchInterface extends PhpSerializable
+{
+    /**
+     * Search for instances using a Lucene query
+     *
+     * @param string $queryString
+     * @param string $type
+     * @param int $start
+     * @param int $count
+     * @param string $order
+     * @param string $dir
+     *
+     * @return ResultSet
+     */
+    public function query($queryString, $type, $start = 0, $count = 10, $order = 'id', $dir = 'DESC');
+
+    /**
+     * Delete all indexes
+     */
+    public function flush();
+
+    /**
+     * (Re)Generate the index for a given document
+     * If index is already exist, then it will merge the fields in index with the existing document
+     *
+     * @param IndexIterator|array $documents
+     * @return int count of indexed documents
+     */
+    public function index($documents);
+
+    /**
+     * Remove a resource from the index
+     *
+     * @param string $resourceId
+     * @return boolean true if successfully removed
+     */
+    public function remove($resourceId);
+
+    /**
+     * Whenever or not the current implementation supports
+     * custom indexes
+     *
+     * @return boolean
+     */
+    public function supportCustomIndex();
+}

--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -43,6 +43,36 @@ class SearchProxy extends ConfigurableService implements Search
         TaoOntology::CLASS_URI_TAO_USER,
     ];
 
+    public function getAdvancedSearch(): ?SearchInterface
+    {
+        return $this->getService(self::OPTION_ADVANCED_SEARCH_CLASS);
+    }
+
+    public function getDefaultSearch(): SearchInterface
+    {
+        $defaultSearch = $this->getService(self::OPTION_DEFAULT_SEARCH_CLASS);
+
+        if ($defaultSearch) {
+            return $defaultSearch;
+        }
+
+        throw new InvalidArgumentException(sprintf('Option %s is required', self::OPTION_DEFAULT_SEARCH_CLASS));
+    }
+
+    public function withAdvancedSearch(SearchInterface $search): self
+    {
+        $this->setOption(self::OPTION_ADVANCED_SEARCH_CLASS, $search);
+
+        return $this;
+    }
+
+    public function withDefaultSearch(SearchInterface $search): self
+    {
+        $this->setOption(self::OPTION_DEFAULT_SEARCH_CLASS, $search);
+
+        return $this;
+    }
+
     /**
      * @throws Exception
      */
@@ -159,22 +189,6 @@ class SearchProxy extends ConfigurableService implements Search
     private function isForcingDefaultSearch(SearchQuery $query): bool
     {
         return in_array($query->getParentClass(), self::GENERIS_SEARCH_WHITELIST, true);
-    }
-
-    private function getAdvancedSearch(): SearchInterface
-    {
-        return $this->getService(self::OPTION_ADVANCED_SEARCH_CLASS) ?? $this->getDefaultSearch();
-    }
-
-    private function getDefaultSearch(): SearchInterface
-    {
-        $defaultSearch = $this->getService(self::OPTION_DEFAULT_SEARCH_CLASS);
-
-        if ($defaultSearch) {
-            return $defaultSearch;
-        }
-
-        throw new InvalidArgumentException(sprintf('Option %s is required', self::OPTION_DEFAULT_SEARCH_CLASS));
     }
 
     private function getIndexSearch(): SearchInterface

--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -109,6 +109,10 @@ class SearchProxy extends ConfigurableService implements Search
 
     private function executeSearch(SearchQuery $query): ResultSet
     {
+        if ($query->isEmptySearch()) {
+            return new ResultSet([], 0);
+        }
+
         if ($this->isForcingDefaultSearch($query) || !$this->getAdvancedSearchChecker()->isEnabled()) {
             $result = $this->getIdentifierSearcher()->search($query);
 
@@ -122,13 +126,6 @@ class SearchProxy extends ConfigurableService implements Search
                 $query->getStartRow(),
                 $query->getRows()
             );
-        }
-
-        //@FIXME @TODO Extract to proper method when getting confirmation from PO
-        if (empty($query->getTerm())) {
-            $queryString = sprintf('parent_classes: "%s"', $query->getParentClass());
-        } else {
-            $queryString = $query->getTerm() . sprintf(' AND parent_classes: "%s"', $query->getParentClass());
         }
 
         return $this->getAdvancedSearch()->query(
@@ -204,9 +201,6 @@ class SearchProxy extends ConfigurableService implements Search
 
     private function getAdvancedSearchQueryString(SearchQuery $query): string
     {
-        //@FIXME @TODO Extract to proper method when getting confirmation from PO
-        return empty($query->getTerm())
-            ? sprintf('parent_classes: "%s"', $query->getParentClass())
-            : $query->getTerm() . sprintf(' AND parent_classes: "%s"', $query->getParentClass());
+        return $query->getTerm() . sprintf(' AND parent_classes: "%s"', $query->getParentClass());
     }
 }

--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -23,25 +23,25 @@ declare(strict_types=1);
 namespace oat\tao\model\search;
 
 use Exception;
+use InvalidArgumentException;
 use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
 use oat\tao\model\TaoOntology;
-use oat\tao\model\search\strategy\GenerisSearch;
 use Psr\Http\Message\ServerRequestInterface;
 
-class SearchProxy extends ConfigurableService
+class SearchProxy extends ConfigurableService implements Search
 {
     use OntologyAwareTrait;
+
+    public const OPTION_ADVANCED_SEARCH_CLASS = 'default_search_class';
+    public const OPTION_DEFAULT_SEARCH_CLASS = 'default_search_class';
 
     private const GENERIS_SEARCH_WHITELIST = [
         GenerisRdf::CLASS_ROLE,
         TaoOntology::CLASS_URI_TAO_USER,
     ];
-
-    /** @var GenerisSearch */
-    private $generisSearch;
 
     /**
      * @throws Exception
@@ -49,9 +49,6 @@ class SearchProxy extends ConfigurableService
     public function searchByQuery(SearchQuery $query): array
     {
         $results = $this->executeSearch($query);
-        if (!$results instanceof ResultSet) {
-            throw new Exception('Result has to be instance of ResultSet');
-        }
 
         return $this->getResultSetResponseNormalizer()
             ->normalize($query, $results, '');
@@ -66,32 +63,75 @@ class SearchProxy extends ConfigurableService
         $queryParams = $request->getQueryParams();
         $results = $this->executeSearch($query);
 
-        if (!$results instanceof ResultSet) {
-            throw new Exception('Result has to be instance of ResultSet');
-        }
-
         return $this->getResultSetResponseNormalizer()
             ->normalize($query, $results, $queryParams['params']['structure']);
     }
 
-    public function withGenerisSearch(GenerisSearch $search): self
+    /**
+     * @inheritDoc
+     */
+    public function query($queryString, $type, $start = 0, $count = 10, $order = 'id', $dir = 'DESC')
     {
-        $this->generisSearch = $search;
+        return $this->getIndexSearch()->query($queryString, $type, $start, $count, $order, $dir);
+    }
 
-        return $this;
+    /**
+     * @inheritDoc
+     */
+    public function flush()
+    {
+        return $this->getIndexSearch()->flush();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function index($documents)
+    {
+        return $this->getIndexSearch()->index($documents);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function remove($resourceId)
+    {
+        return $this->getIndexSearch()->remove($resourceId);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supportCustomIndex()
+    {
+        return $this->getIndexSearch()->supportCustomIndex();
     }
 
     private function executeSearch(SearchQuery $query): ResultSet
     {
-        if ($this->isForcingGenerisSearch($query)) {
-            return $this->searchWithGeneris($query);
+        if ($this->isForcingDefaultSearch($query) || !$this->getAdvancedSearchChecker()->isEnabled()) {
+            $result = $this->getIdentifierSearcher()->search($query);
+
+            if ($result->getTotalCount() > 0) {
+                return $result;
+            }
+
+            return $this->getDefaultSearch()->query(
+                $query->getTerm(),
+                $query->getParentClass(),
+                $query->getStartRow(),
+                $query->getRows()
+            );
         }
 
-        if ($this->getElasticSearchChecker()->isEnabled()) {
-            return $this->getElasticSearchBridge()->search($query);
-        }
+        $queryString = $query->getTerm() . sprintf(' AND parent_classes: "%s"', $query->getParentClass());
 
-        return $this->getGenerisSearchBridge()->search($query);
+        return $this->getAdvancedSearch()->query(
+            $queryString,
+            $query->getRootClass(),
+            $query->getStartRow(),
+            $query->getRows()
+        );
     }
 
     private function getResultSetResponseNormalizer(): ResultSetResponseNormalizer
@@ -99,19 +139,14 @@ class SearchProxy extends ConfigurableService
         return $this->getServiceLocator()->get(ResultSetResponseNormalizer::class);
     }
 
-    private function getElasticSearchChecker(): AdvancedSearchChecker
+    private function getAdvancedSearchChecker(): AdvancedSearchChecker
     {
         return $this->getServiceLocator()->get(AdvancedSearchChecker::class);
     }
 
-    private function getElasticSearchBridge(): ElasticSearchBridge
+    private function getIdentifierSearcher(): IdentifierSearcher
     {
-        return $this->getServiceLocator()->get(ElasticSearchBridge::class);
-    }
-
-    private function getGenerisSearchBridge(): GenerisSearchBridge
-    {
-        return $this->getServiceLocator()->get(GenerisSearchBridge::class);
+        return $this->getServiceLocator()->get(IdentifierSearcher::class);
     }
 
     private function getQueryFactory(): SearchQueryFactory
@@ -119,31 +154,33 @@ class SearchProxy extends ConfigurableService
         return $this->getServiceLocator()->get(SearchQueryFactory::class);
     }
 
-    private function isForcingGenerisSearch(SearchQuery $query): bool
+    private function isForcingDefaultSearch(SearchQuery $query): bool
     {
         return in_array($query->getParentClass(), self::GENERIS_SEARCH_WHITELIST, true);
     }
 
-    private function searchWithGeneris(SearchQuery $query): ResultSet
+    private function getAdvancedSearch(): SearchInterface
     {
-        return $this->getGenerisSearch()->query(
-            $query->getTerm(),
-            $query->getParentClass(),
-            $query->getStartRow(),
-            $query->getRows()
-        );
-    }
-
-    private function getGenerisSearch(): GenerisSearch
-    {
-        if (!$this->generisSearch) {
-            /**
-             * @TODO We need to implement better search driver management: https://oat-sa.atlassian.net/browse/ADF-251
-             */
-            $this->generisSearch = new GenerisSearch();
-            $this->propagate($this->generisSearch);
+        if ($this->hasOption(self::OPTION_ADVANCED_SEARCH_CLASS)) {
+            return $this->getServiceLocator()->get($this->getOption(self::OPTION_ADVANCED_SEARCH_CLASS));
         }
 
-        return $this->generisSearch;
+        return $this->getDefaultSearch();
+    }
+
+    private function getDefaultSearch(): SearchInterface
+    {
+        if ($this->hasOption(self::OPTION_DEFAULT_SEARCH_CLASS)) {
+            return $this->getServiceLocator()->get($this->getOption(self::OPTION_DEFAULT_SEARCH_CLASS));
+        }
+
+        throw new InvalidArgumentException(sprintf('Option %s is required', self::OPTION_DEFAULT_SEARCH_CLASS));
+    }
+
+    private function getIndexSearch(): SearchInterface
+    {
+        return $this->getAdvancedSearchChecker()->isEnabled()
+            ? $this->getAdvancedSearch()
+            : $this->getDefaultSearch();
     }
 }

--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -190,13 +190,12 @@ class SearchProxy extends ConfigurableService implements Search
             return null;
         }
 
-        $class = $this->getOption($option);
+        /** @var SearchInterface $search */
+        $search = $this->getOption($option);
 
-        if (is_object($class)) {
-            return $this->propagate($class);
-        }
+        $this->propagate($search);
 
-        return $this->getServiceLocator()->get($class);
+        return $search;
     }
 
     private function getAdvancedSearchQueryString(SearchQuery $query): string

--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -124,21 +124,19 @@ class SearchProxy extends ConfigurableService implements Search
             );
         }
 
-        $queryString = $query->getTerm() . sprintf((empty($query->getTerm()) ? '' : ' AND ') . 'parent_classes: "%s"', $query->getParentClass());
+        //@FIXME @TODO Extract to proper method when getting confirmation from PO
+        if (empty($query->getTerm())) {
+            $queryString = sprintf('parent_classes: "%s"', $query->getParentClass());
+        } else {
+            $queryString = $query->getTerm() . sprintf(' AND parent_classes: "%s"', $query->getParentClass());
+        }
 
-        //var_export($queryString); exit('_____________');//FIXME
-
-        $result = $this->getAdvancedSearch()->query(
-            $queryString,
+        return $this->getAdvancedSearch()->query(
+            $this->getAdvancedSearchQueryString($query),
             $query->getRootClass(),
             $query->getStartRow(),
             $query->getRows()
         );
-//
-//        var_dump(get_class($this->getAdvancedSearch()));
-//        var_dump($result->getTotalCount()); exit('__________dasdasdasdas'); //FIXME
-
-        return $result;
     }
 
     private function getResultSetResponseNormalizer(): ResultSetResponseNormalizer
@@ -202,5 +200,13 @@ class SearchProxy extends ConfigurableService implements Search
         }
 
         return $this->getServiceLocator()->get($class);
+    }
+
+    private function getAdvancedSearchQueryString(SearchQuery $query): string
+    {
+        //@FIXME @TODO Extract to proper method when getting confirmation from PO
+        return empty($query->getTerm())
+            ? sprintf('parent_classes: "%s"', $query->getParentClass())
+            : $query->getTerm() . sprintf(' AND parent_classes: "%s"', $query->getParentClass());
     }
 }

--- a/models/classes/search/SearchQuery.php
+++ b/models/classes/search/SearchQuery.php
@@ -57,6 +57,11 @@ class SearchQuery
         return $this->term;
     }
 
+    public function isEmptySearch(): bool
+    {
+        return empty($this->term);
+    }
+
     public function getRootClass(): string
     {
         return $this->rootClass;

--- a/models/classes/search/strategy/GenerisSearch.php
+++ b/models/classes/search/strategy/GenerisSearch.php
@@ -15,19 +15,16 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
- *
- *
+ * Copyright (c) 2014-2021 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\tao\model\search\strategy;
 
-use core_kernel_classes_Class;
 use oat\generis\model\OntologyRdfs;
-use oat\tao\model\search\Search;
 use oat\tao\model\search\ResultSet;
 use oat\oatbox\service\ConfigurableService;
 use oat\generis\model\OntologyAwareTrait;
+use oat\tao\model\search\SearchInterface;
 
 /**
  * Simple Search implementation that ignores the indexes
@@ -35,26 +32,30 @@ use oat\generis\model\OntologyAwareTrait;
  *
  * @author Joel Bout <joel@taotesting.com>
  */
-class GenerisSearch extends ConfigurableService implements Search
+class GenerisSearch extends ConfigurableService implements SearchInterface
 {
     use OntologyAwareTrait;
 
     /**
-     * (non-PHPdoc)
-     * @see \oat\tao\model\search\Search::query()
+     * @inheritDoc
      */
     public function query($queryString, $type, $start = 0, $count = 10, $order = 'id', $dir = 'DESC')
     {
         $rootClass = $this->getClass($type);
-        $results = $rootClass->searchInstances([
-            OntologyRdfs::RDFS_LABEL => $queryString
-        ], [
-            'recursive' => true,
-            'like'      => true,
-            'offset'    => $start,
-            'limit'     => $count,
-        ]);
+        $results = $rootClass->searchInstances(
+            [
+                OntologyRdfs::RDFS_LABEL => $queryString
+            ],
+            [
+                'recursive' => true,
+                'like' => true,
+                'offset' => $start,
+                'limit' => $count,
+            ]
+        );
+
         $ids = [];
+
         foreach ($results as $resource) {
             $ids[] = [
                 'id' => $resource->getUri(),
@@ -66,8 +67,7 @@ class GenerisSearch extends ConfigurableService implements Search
     }
 
     /**
-     * (non-PHPdoc)
-     * @see \oat\tao\model\search\Search::flush()
+     * @inheritDoc
      */
     public function flush()
     {
@@ -75,22 +75,15 @@ class GenerisSearch extends ConfigurableService implements Search
     }
 
     /**
-     * (non-PHPdoc)
-     * @see \oat\tao\model\search\Search::addIndexes()
+     * @inheritDoc
      */
     public function addIndexes(\Traversable $IndexIterator)
     {
-        // no indexation required
         return 0;
     }
 
     /**
-     * Return total count of corresponded instances
-     *
-     * @param string $queryString
-     * @param core_kernel_classes_Class $rootClass
-     *
-     * @return array
+     * @inheritDoc
      */
     private function getTotalCount($queryString, $rootClass = null)
     {
@@ -100,38 +93,35 @@ class GenerisSearch extends ConfigurableService implements Search
             ],
             [
                 'recursive' => true,
-                'like'      => true,
+                'like' => true,
             ]
         );
     }
 
     /**
-     * (non-PHPdoc)
-     * @see \oat\tao\model\search\Search::index()
+     * @inheritDoc
      */
     public function index($document = [])
     {
-        // nothing to do
         $i = 0;
-        foreach ($document as $resuource) {
+
+        foreach ($document as $resource) {
             $i++;
         }
+
         return $i;
     }
 
     /**
-     * (non-PHPdoc)
-     * @see \oat\tao\model\search\Search::remove()
+     * @inheritDoc
      */
     public function remove($resourceId)
     {
-        // nothing to do
         return true;
     }
 
     /**
-     * (non-PHPdoc)
-     * @see \oat\tao\model\search\Search::supportCustomIndex()
+     * @inheritDoc
      */
     public function supportCustomIndex()
     {

--- a/models/classes/search/strategy/GenerisSearch.php
+++ b/models/classes/search/strategy/GenerisSearch.php
@@ -18,13 +18,16 @@
  * Copyright (c) 2014-2021 (original work) Open Assessment Technologies SA;
  */
 
+declare(strict_types=1);
+
 namespace oat\tao\model\search\strategy;
 
 use oat\generis\model\OntologyRdfs;
 use oat\tao\model\search\ResultSet;
 use oat\oatbox\service\ConfigurableService;
 use oat\generis\model\OntologyAwareTrait;
-use oat\tao\model\search\SearchInterface;
+use oat\tao\model\search\Search;
+use Traversable;
 
 /**
  * Simple Search implementation that ignores the indexes
@@ -32,7 +35,7 @@ use oat\tao\model\search\SearchInterface;
  *
  * @author Joel Bout <joel@taotesting.com>
  */
-class GenerisSearch extends ConfigurableService implements SearchInterface
+class GenerisSearch extends ConfigurableService implements Search
 {
     use OntologyAwareTrait;
 
@@ -77,7 +80,7 @@ class GenerisSearch extends ConfigurableService implements SearchInterface
     /**
      * @inheritDoc
      */
-    public function addIndexes(\Traversable $IndexIterator)
+    public function addIndexes(Traversable $IndexIterator)
     {
         return 0;
     }

--- a/models/classes/user/GenerisUserService.php
+++ b/models/classes/user/GenerisUserService.php
@@ -38,7 +38,7 @@ class GenerisUserService extends ConfigurableService implements UserService
     public function findUser($searchString)
     {
         /** @var SearchProxy $searchProxy */
-        $searchProxy = $this->getServiceLocator()->get(SearchProxy::class);
+        $searchProxy = $this->getServiceLocator()->get(SearchProxy::SERVICE_ID);
 
         $query = new SearchQuery(
             $searchString,

--- a/scripts/install/RegisterSearchServices.php
+++ b/scripts/install/RegisterSearchServices.php
@@ -31,13 +31,9 @@ class RegisterSearchServices extends InstallAction
 {
     public function __invoke($params = [])
     {
-        $this->getServiceManager()->register(
-            SearchProxy::SERVICE_ID,
-            new SearchProxy(
-                [
-                    SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => new GenerisSearch()
-                ]
-            )
-        );
+        $proxy = new SearchProxy();
+        $proxy->withDefaultSearch(new GenerisSearch());
+
+        $this->getServiceManager()->register(SearchProxy::SERVICE_ID, $proxy);
     }
 }

--- a/scripts/install/RegisterSearchServices.php
+++ b/scripts/install/RegisterSearchServices.php
@@ -35,7 +35,7 @@ class RegisterSearchServices extends InstallAction
             SearchProxy::SERVICE_ID,
             new SearchProxy(
                 [
-                    SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => GenerisSearch::class
+                    SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => new GenerisSearch()
                 ]
             )
         );

--- a/scripts/install/RegisterSearchServices.php
+++ b/scripts/install/RegisterSearchServices.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020-2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\tao\model\search\SearchProxy;
+use oat\tao\model\search\strategy\GenerisSearch;
+
+class RegisterSearchServices extends InstallAction
+{
+    public function __invoke($params = [])
+    {
+        $this->getServiceManager()->register(
+            SearchProxy::SERVICE_ID,
+            new SearchProxy(
+                [
+                    SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => GenerisSearch::class
+                ]
+            )
+        );
+    }
+}

--- a/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
+++ b/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
@@ -41,9 +41,7 @@ class AdvancedSearchCheckerTest extends TestCase
         $this->featureFlagChecker = $this->createMock(FeatureFlagChecker::class);
         $search = $this->createMock(Search::class);
 
-        $this->advancedSearchChecker = new AdvancedSearchChecker([
-            AdvancedSearchChecker::OPTION_ALLOWED_SEARCH_CLASSES => [get_class($search)],
-        ]);
+        $this->advancedSearchChecker = new AdvancedSearchChecker();
         $this->advancedSearchChecker->setServiceLocator(
             $this->getServiceLocatorMock([
                 FeatureFlagChecker::class => $this->featureFlagChecker,

--- a/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
+++ b/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\tao\test\unit\AdvancedSearch;
 
 use oat\generis\test\TestCase;
+use oat\tao\model\search\SearchInterface;
 use oat\tao\model\search\SearchProxy;
 use PHPUnit\Framework\MockObject\MockObject;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
@@ -57,7 +58,7 @@ class AdvancedSearchCheckerTest extends TestCase
     /**
      * @dataProvider isEnabledDataProvider
      */
-    public function testIsEnabled(bool $advancedSearchDisabled, bool $hasAdvancedSearchOption, bool $expected): void
+    public function testIsEnabled(bool $advancedSearchDisabled, SearchInterface $advancedSearch, bool $expected): void
     {
         $this->featureFlagChecker
             ->expects(static::once())
@@ -65,9 +66,8 @@ class AdvancedSearchCheckerTest extends TestCase
             ->willReturn($advancedSearchDisabled);
 
         $this->search
-            ->method('hasOption')
-            ->with(SearchProxy::OPTION_ADVANCED_SEARCH_CLASS)
-            ->willReturn($hasAdvancedSearchOption);
+            ->method('getAdvancedSearch')
+            ->willReturn($advancedSearch);
 
         $this->assertEquals($expected, $this->advancedSearchChecker->isEnabled());
     }
@@ -77,12 +77,12 @@ class AdvancedSearchCheckerTest extends TestCase
         return [
             [
                 'advancedSearchDisabled' => true,
-                'hasAdvancedSearchOption' => true,
+                'advancedSearch' => $this->createMock(SearchInterface::class),
                 'expected' => false,
             ],
             [
                 'advancedSearchDisabled' => false,
-                'hasAdvancedSearchOption' => true,
+                'advancedSearch' => $this->createMock(SearchInterface::class),
                 'expected' => true,
             ],
         ];

--- a/test/unit/models/classes/search/IdentifierSearchTest.php
+++ b/test/unit/models/classes/search/IdentifierSearchTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\model\search;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\generis\test\TestCase;
+use oat\tao\model\search\IdentifierSearcher;
+use oat\tao\model\search\ResultSet;
+use oat\tao\model\search\SearchQuery;
+
+class IdentifierSearchTest extends TestCase
+{
+    private const LOCAL_NAMESPACE = 'http://something';
+
+    /** @var IdentifierSearcher */
+    private $subject;
+
+    /** @var Ontology */
+    private $ontology;
+
+    public function setUp(): void
+    {
+        $this->ontology = $this->createMock(Ontology::class);
+
+        $this->subject = new IdentifierSearcher();
+        $this->subject->withLocalNamespace(self::LOCAL_NAMESPACE);
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    Ontology::SERVICE_ID => $this->ontology,
+                ]
+            )
+        );
+    }
+
+    public function testSearchByNoUri(): void
+    {
+        $query = new SearchQuery(
+            'user input',
+            'rootClass',
+            'parentClass',
+            1,
+            10,
+            1
+        );
+
+        $this->assertEquals(new ResultSet([], 0), $this->subject->search($query));
+    }
+
+    public function testSearchByUri(): void
+    {
+        $uri = self::LOCAL_NAMESPACE;
+        $label = 'My Resource label';
+
+        $query = new SearchQuery(
+            $uri,
+            'rootClass',
+            'parentClass',
+            1,
+            10,
+            1
+        );
+
+        $resultSetMock = new ResultSet(
+            [
+                [
+                    'id' => $uri,
+                    'label' => $label,
+                ],
+            ],
+            1
+        );
+
+        $resource = $this->createMock(core_kernel_classes_Resource::class);
+        $class = $this->createMock(core_kernel_classes_Class::class);
+
+        $this->ontology
+            ->method('getResource')
+            ->willReturn($resource);
+
+        $this->ontology
+            ->method('getClass')
+            ->willReturn($class);
+
+        $resource
+            ->method('exists')
+            ->willReturn(true);
+
+        $resource
+            ->method('isInstanceOf')
+            ->willReturn(true);
+
+        $resource
+            ->method('getUri')
+            ->willReturn($uri);
+
+        $resource
+            ->method('getLabel')
+            ->willReturn($label);
+
+        $this->assertEquals($resultSetMock, $this->subject->search($query));
+    }
+}

--- a/test/unit/models/classes/search/SearchProxyTest.php
+++ b/test/unit/models/classes/search/SearchProxyTest.php
@@ -87,7 +87,6 @@ class SearchProxyTest extends TestCase
         );
 
         $this->subject = new SearchProxy();
-        $this->subject->withGenerisSearch($this->generisSearchMock);
         $this->subject->setServiceLocator(
             $this->getServiceLocatorMock(
                 [

--- a/test/unit/models/classes/search/SearchProxyTest.php
+++ b/test/unit/models/classes/search/SearchProxyTest.php
@@ -67,6 +67,7 @@ class SearchProxyTest extends TestCase
 
     public function setUp(): void
     {
+        //@TODO Fix test
         $this->advancedSearchCheckerMock = $this->createMock(AdvancedSearchChecker::class);
         $this->elasticSearchBridgeMock = $this->createMock(ElasticSearchBridge::class);
         $this->generisSearchBridgeMock = $this->createMock(GenerisSearchBridge::class);

--- a/test/unit/models/classes/search/SearchProxyTest.php
+++ b/test/unit/models/classes/search/SearchProxyTest.php
@@ -25,14 +25,13 @@ namespace oat\tao\test\unit\model\search;
 use oat\generis\model\GenerisRdf;
 use oat\generis\test\TestCase;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
-use oat\tao\model\search\ElasticSearchBridge;
-use oat\tao\model\search\GenerisSearchBridge;
+use oat\tao\model\search\IdentifierSearcher;
 use oat\tao\model\search\ResultSet;
 use oat\tao\model\search\ResultSetResponseNormalizer;
+use oat\tao\model\search\SearchInterface;
 use oat\tao\model\search\SearchProxy;
 use oat\tao\model\search\SearchQuery;
 use oat\tao\model\search\SearchQueryFactory;
-use oat\tao\model\search\strategy\GenerisSearch;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -44,14 +43,8 @@ class SearchProxyTest extends TestCase
     /** @var AdvancedSearchChecker|MockObject */
     private $advancedSearchCheckerMock;
 
-    /** @var ElasticSearchBridge|MockObject */
-    private $elasticSearchBridgeMock;
-
-    /** @var GenerisSearchBridge|MockObject */
-    private $generisSearchBridgeMock;
-
-    /** @var GenerisSearch|MockObject */
-    private $generisSearchMock;
+    /** @var IdentifierSearcher|MockObject */
+    private $identifierSearcher;
 
     /** @var SearchQueryFactory|MockObject */
     private $searchQueryFactoryMock;
@@ -65,14 +58,19 @@ class SearchProxyTest extends TestCase
     /** @var ResultSetResponseNormalizer|MockObject */
     private $resultSetResponseNormalizerMock;
 
+    /** @var SearchInterface|MockObject */
+    private $defaultSearch;
+
+    /** @var SearchInterface|MockObject */
+    private $advancedSearch;
+
     public function setUp(): void
     {
-        //@TODO Fix test
         $this->advancedSearchCheckerMock = $this->createMock(AdvancedSearchChecker::class);
-        $this->elasticSearchBridgeMock = $this->createMock(ElasticSearchBridge::class);
-        $this->generisSearchBridgeMock = $this->createMock(GenerisSearchBridge::class);
+        $this->identifierSearcher = $this->createMock(IdentifierSearcher::class);
+        $this->defaultSearch = $this->createMock(SearchInterface::class);
+        $this->advancedSearch = $this->createMock(SearchInterface::class);
         $this->searchQueryFactoryMock = $this->createMock(SearchQueryFactory::class);
-        $this->generisSearchMock = $this->createMock(GenerisSearch::class);
         $this->resultSetResponseNormalizerMock = $this->createMock(ResultSetResponseNormalizer::class);
 
         $this->resultSetMock = $this->createMock(ResultSet::class);
@@ -82,43 +80,70 @@ class SearchProxyTest extends TestCase
             [
                 'params' =>
                     [
+                        'query' => 'test',
                         'structure' => 'exampleRootNode',
                     ],
             ]
         );
 
-        $this->subject = new SearchProxy();
+        $this->subject = new SearchProxy(
+            [
+                SearchProxy::OPTION_DEFAULT_SEARCH_CLASS => $this->defaultSearch,
+                SearchProxy::OPTION_ADVANCED_SEARCH_CLASS => $this->advancedSearch,
+            ]
+        );
         $this->subject->setServiceLocator(
             $this->getServiceLocatorMock(
                 [
                     AdvancedSearchChecker::class => $this->advancedSearchCheckerMock,
-                    ElasticSearchBridge::class => $this->elasticSearchBridgeMock,
-                    GenerisSearchBridge::class => $this->generisSearchBridgeMock,
                     SearchQueryFactory::class => $this->searchQueryFactoryMock,
-                    ResultSetResponseNormalizer::class => $this->resultSetResponseNormalizerMock
+                    ResultSetResponseNormalizer::class => $this->resultSetResponseNormalizerMock,
+                    IdentifierSearcher::class => $this->identifierSearcher
                 ]
             )
         );
     }
 
-    public function testSearchWithoutElasticSearch(): void
+    public function testSearchByIdentifier(): void
     {
         $this->advancedSearchCheckerMock
             ->expects($this->once())
             ->method('isEnabled')
             ->willReturn(false);
 
-        $this->generisSearchBridgeMock
+        $this->identifierSearcher
             ->method('search')
-            ->willReturn($this->resultSetMock);
+            ->willReturn(new ResultSet([], 1));
 
         $this->resultSetResponseNormalizerMock
             ->expects($this->once())
             ->method('normalize')
             ->willReturn([]);
 
-        $result = $this->subject->search($this->requestMock);
-        $this->assertIsArray($result);
+        $this->assertSame([], $this->subject->search($this->requestMock));
+    }
+
+    public function testSearchByDefaultSearch(): void
+    {
+        $this->advancedSearchCheckerMock
+            ->expects($this->once())
+            ->method('isEnabled')
+            ->willReturn(false);
+
+        $this->identifierSearcher
+            ->method('search')
+            ->willReturn(new ResultSet([], 0));
+
+        $this->defaultSearch
+            ->method('query')
+            ->willReturn(new ResultSet([], 1));
+
+        $this->resultSetResponseNormalizerMock
+            ->expects($this->once())
+            ->method('normalize')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->subject->search($this->requestMock));
     }
 
     public function testForceGenerisSearch(): void
@@ -136,7 +161,7 @@ class SearchProxyTest extends TestCase
             ->method('create')
             ->willReturn($query);
 
-        $this->generisSearchMock
+        $this->defaultSearch
             ->method('query')
             ->willReturn($this->resultSetMock);
 
@@ -145,11 +170,10 @@ class SearchProxyTest extends TestCase
             ->method('normalize')
             ->willReturn([]);
 
-        $result = $this->subject->search($this->requestMock);
-        $this->assertIsArray($result);
+        $this->assertSame([], $this->subject->search($this->requestMock));
     }
 
-    public function testSearchWithNoPagination(): void
+    public function testSearchWithAdvancedSearchAndNoPagination(): void
     {
         $this->requestMock
             ->method('getQueryParams')
@@ -160,8 +184,8 @@ class SearchProxyTest extends TestCase
             ->method('isEnabled')
             ->willReturn(true);
 
-        $this->elasticSearchBridgeMock
-            ->method('search')
+        $this->advancedSearch
+            ->method('query')
             ->willReturn($this->resultSetMock);
 
         $this->resultSetResponseNormalizerMock
@@ -169,11 +193,10 @@ class SearchProxyTest extends TestCase
             ->method('normalize')
             ->willReturn([]);
 
-        $result = $this->subject->search($this->requestMock);
-        $this->assertIsArray($result);
+        $this->assertSame([], $this->subject->search($this->requestMock));
     }
 
-    public function testSearchWithElasticSearch(): void
+    public function testSearchWithAdvancedSearchAndPagination(): void
     {
         $this->requestMock
             ->method('getQueryParams')
@@ -189,8 +212,8 @@ class SearchProxyTest extends TestCase
             ->method('isEnabled')
             ->willReturn(true);
 
-        $this->elasticSearchBridgeMock
-            ->method('search')
+        $this->advancedSearch
+            ->method('query')
             ->willReturn($this->resultSetMock);
 
         $this->resultSetResponseNormalizerMock

--- a/test/unit/user/GenerisUserServiceTest.php
+++ b/test/unit/user/GenerisUserServiceTest.php
@@ -50,7 +50,7 @@ class GenerisUserServiceTest extends TestCase
             ->with($query)
             ->willReturn(['data' => [['id' => $testId]]]);
 
-        $serviceLocator = $this->getServiceLocatorMock([SearchProxy::class => $searchServiceMock]);
+        $serviceLocator = $this->getServiceLocatorMock([SearchProxy::SERVICE_ID => $searchServiceMock]);
         $generisUserServiceMock = $this->getMockBuilder(GenerisUserService::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getUser'])


### PR DESCRIPTION
Centralize search to proxy, so we can manage the feature flag in a single place

https://oat-sa.atlassian.net/browse/ADF-258

Related PRs

- [x] https://github.com/oat-sa/extension-tao-advanced-search/pull/27
- [x] https://github.com/oat-sa/lib-tao-elasticsearch/pull/45
- [x] https://github.com/oat-sa/extension-tao-publishing/pull/111
