### PR TITLE
[Fix] ADF-450 Moving object from class to class by drag-and-drop causes error

### DIFF
--- a/views/js/layout/actions/common.js
+++ b/views/js/layout/actions/common.js
@@ -377,7 +377,12 @@ define([
                 .then(function(response) {
                     var message;
                     var i;
-                    if (response && response.status === 'diff') {
+
+                    if (response && response.status === true) {
+                        return
+                    }
+
+                    else if (response && response.status === 'diff') {
                         message = __("Moving this element will replace the properties of the previous class by those of the destination class :");
                         message += "\n";
                         for (i = 0; i < response.data.length; i++) {
@@ -392,12 +397,6 @@ define([
                             data.confirmed = true;
                             return  _moveNode(url, data);
                         }
-                    } else if (response && response.status === true) {
-                        //open the destination branch
-                        $(actionContext.tree).trigger('openbranch.taotree', [{
-                            id : actionContext.destinationClassUri
-                        }]);
-                        return;
                     }
 
                     //ask to rollback the tree


### PR DESCRIPTION
**Description**

Whenever user is trying to move the object (item, test etc.) from one class to another by dragging the object, the error appear in browser console after clicking 'OK' in pop-up message (in case it appears).

**Preconditions**

Having at least 2 classes and at least 1 resource created on any tab.

**Steps to reproduce:**

- Go to Items tab.

- Choose any existing item.

- Drag and drop the chosen item to another class.

- Click 'OK' on pop-up message (if it appears).

**Actual result**

 The error appears in browser console.

**Expected result**

No errors in browser console.

**Environment**

Deployed for testing, link in ticket