### PR TITLE
Fix/ADF-532/Fix DAC annotation which blocks class property deletion

### DIFF
--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -1140,7 +1140,7 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule
     /**
      * Copy of \tao_actions_PropertiesAuthoring::removeClassProperty to split access between extensions
      *
-     * @requiresRight classUri WRIT
+     * @requiresRight classUri WRITE
      * @throws common_Exception
      */
     public function removeClassProperty(RemoveClassPropertyService $removeClassPropertyService): void

--- a/models/classes/accessControl/ActionAccessControl.php
+++ b/models/classes/accessControl/ActionAccessControl.php
@@ -147,6 +147,19 @@ class ActionAccessControl extends ConfigurableService
             }
         }
 
+        if ($roleIsListed) {
+            $this->logWarning(
+                sprintf(
+                    'User roles "%s" permissions "%s" do not have allowed permissions "%s" for controller "%s::%s',
+                    implode(', ', $userRoles),
+                    implode(', ', $permissions),
+                    implode(', ', $allowedPermissions),
+                    $controller,
+                    $action
+                )
+            );
+        }
+
         return !$roleIsListed;
     }
 

--- a/test/unit/accessControl/ActionAccessControlTest.php
+++ b/test/unit/accessControl/ActionAccessControlTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\tao\test\unit\accessControl;
 
 use oat\generis\test\TestCase;
+use oat\oatbox\log\LoggerService;
 use common_test_TestUser as TestUser;
 use oat\tao\model\accessControl\ActionAccessControl;
 
@@ -40,6 +41,13 @@ class ActionAccessControlTest extends TestCase
     public function setUp(): void
     {
         $this->actionAccessControl = new ActionAccessControl();
+        $this->actionAccessControl->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    LoggerService::SERVICE_ID => $this->createMock(LoggerService::class)
+                ]
+            )
+        );
 
         $this->user = $this->createUser();
         $this->user->setRoles(['role1']);


### PR DESCRIPTION
**Relates to:** _[ADF-532](https://oat-sa.atlassian.net/browse/ADF-532)_

**Changes:**
* Fixed invalid annotation;
* Added log to check actions access;
* Fixed test.

**Require:** _installed `taoDacSimple`._

**How to test:**
1. Open Items tab;
2. Select any class;
3. Open `Schema Management`;
4. Add new property;
5. Try to delete it;
6. Click save or reload the page and reopen `Schema Management`.

**Bug:** _property was not deleted._
**Fix:** _property successfully deleted._