### PR TITLE
Fix/adf 508/cypress form flickering

### DIFF
--- a/views/cypress/support/resourceTree.js
+++ b/views/cypress/support/resourceTree.js
@@ -22,9 +22,6 @@
 Cypress.Commands.add('addClass', formSelector => {
     cy.log('COMMAND: addClass');
     cy.get('[data-context=resource][data-action=subClass]').click();
-
-    // hack to cope with flickering
-    cy.get(formSelector).should('not.exist');
     cy.get(formSelector).should('exist');
 });
 
@@ -45,7 +42,8 @@ Cypress.Commands.add('deleteClass', (formSelector, deleteSelector, confirmSelect
 
     cy.contains('a', name).click();
     cy.get(formSelector).should('exist');
-
+    // Wait for update to finish otherwise the modal is not accessible from cy
+    cy.wait(1000);
     cy.get(deleteSelector).click();
     cy.get('.modal-body').then((body) => {
         if (body.find('label[for=confirm]').length) {
@@ -72,9 +70,6 @@ Cypress.Commands.add('addNode', (formSelector, addSelector) => {
     cy.log('COMMAND: addNode');
 
     cy.get(addSelector).click();
-
-    // hack to cope with the forms flickering
-    cy.get(formSelector).should('not.exist');
     cy.get(formSelector).should('exist');
 });
 
@@ -109,8 +104,6 @@ Cypress.Commands.add('renameSelected', (formSelector, newName) => {
             cy.get('button').click();
         });
 
-    // hack to cope with the forms flickering
-    cy.get(formSelector).should('not.exist');
     cy.get(formSelector).should('exist');
 
     cy.contains('a', newName).should('exist');

--- a/views/js/layout/actions/common.js
+++ b/views/js/layout/actions/common.js
@@ -102,7 +102,7 @@ define([
                 signature = actionContext.classSignature;
             }
 
-            var currentSection = section.current();
+            const currentSection = section.current();
             if (currentSection.clearContentBlock) {
                 currentSection.clearContentBlock();
             }
@@ -391,10 +391,10 @@ define([
                         message += "\n";
                         for (i = 0; i < response.data.length; i++) {
                             if (response.data[i].label) {
-                                message += "- " + response.data[i].label + "\n";
+                                message += `- ${response.data[i].label}\n`;
                             }
                         }
-                        message += __("Please confirm this operation.") + "\n";
+                        message += `${__("Please confirm this operation.")}\n`;
 
                         // eslint-disable-next-line no-alert
                         if (window.confirm(message)) {

--- a/views/js/layout/actions/common.js
+++ b/views/js/layout/actions/common.js
@@ -101,6 +101,12 @@ define([
             if (actionContext.type !== 'class') {
                 signature = actionContext.classSignature;
             }
+
+            var currentSection = section.current();
+            if (currentSection.clearContentBlock) {
+                currentSection.clearContentBlock();
+            }
+
             return request({
                 url: self.url,
                 method: "POST",

--- a/views/js/layout/section.js
+++ b/views/js/layout/section.js
@@ -77,7 +77,7 @@ define([
                 var $sectionOpener = $(this);
                 var $link = $sectionOpener.children('a');
                 var id = $link.attr('href').replace('#panel-', '');
-                var $panel = $('#panel-' + id);
+                var $panel = $(`#panel-${id}`);
                 var isActive = defaultSection ? defaultSection === id : index === 0;
 
                 $panel.removeClass('hidden');
@@ -98,7 +98,7 @@ define([
 
             //to be sure at least one is active, for example when the given default section does not exists
             if(_(this.sections).where({'active' : true }).size() === 0){
-                for(var id in this.sections){
+                for(let id in this.sections){
                     this.sections[id].active =  true;
                     restore = false;
                     break;
@@ -141,12 +141,12 @@ define([
             $openersContainer
                 .off('click.section', 'li')
                 .on('click.section', 'li', function(e){
-                     e.preventDefault();
-                     var id = $(this).children('a').attr('href').replace('#panel-', '');
-                     var section = self.sections[id];
-                     if(!section.disabled){
-                         self.get(id).activate();
-                     }
+                    e.preventDefault();
+                    let id = $(this).children('a').attr('href').replace('#panel-', '');
+                    let section = self.sections[id];
+                    if(!section.disabled){
+                        self.get(id).activate();
+                    }
                 });
 
             //display the openers only if there is more than 1 section
@@ -243,7 +243,7 @@ define([
                     section.active = false;
                 });
                 this.sections[this.selected.id].active = true;
-             } else {
+            } else {
                 this.current();
             }
 
@@ -381,15 +381,13 @@ define([
             if(!section){
 
                 //TODO use templates
-                $sectionPanel = $('<div id="panel-' + data.id +'" class="clear"></div>');
+                $sectionPanel = $(`<div id="panel-${data.id}" class="clear"></div>`);
                 if(data.contentBlock === true){
                     $sectionPanel.append('<section class="content-container"><ul class="plain action-bar content-action-bar horizontal-action-bar"></ul><div class="content-block"></div></section>');
                 }
-                $sectionOpener = $('<li class="small ' + (!data.visible ? 'hidden' : '') +'"><a title="'+data.name+'" data-url="'+data.url+'" href="#panel-' + data.id +'">'+data.name+'</a></li>');
+                $sectionOpener = $(`<li class="small ${  !data.visible ? 'hidden' : '' }"><a title="${data.name}" data-url="${data.url}" href="#panel-${  data.id }">${data.name}</a></li>`);
                 $openersContainer.append($sectionOpener);
                 this.scope.append($sectionPanel);
-
-
 
                 section =  {
                     id          : data.id,
@@ -466,7 +464,7 @@ define([
          * @fires SectionApi#load.section
          */
         load : function load(url, data, loaded){
-            var self = this;
+            let self = this;
 
             if(!this.selected){
                 this.current();
@@ -497,11 +495,14 @@ define([
             return this;
         },
 
+        /**
+         * Clears content from the content block area.
+         **/
         clearContentBlock: function clearContentBlock() {
             if(!this.selected){
-                return
+                return;
             }
-            var $contentblock = $('.content-block', this.selected.panel);
+            const $contentblock = $('.content-block', this.selected.panel);
             if($contentblock.length){
                 $contentblock.empty();
             }
@@ -563,14 +564,13 @@ define([
 
         /**
          * Sugar to help you listen for event on sections
-         *
          * @param {String} eventName - the name of the event (without the namespace)
-         * @param {Function} cg - the event callback
+         * @param {Function} cb - the event callbacks
          * @returns {SectionApi} instance for chaining
          */
         on : function(eventName, cb){
-            var self = this;
-            this.scope.on(eventName + '.section', function(e){
+            let self = this;
+            this.scope.on(`${eventName}.section`, function() {
                 cb.apply(self, Array.prototype.slice.call(arguments, 1));
             });
             return this;
@@ -583,7 +583,7 @@ define([
          * @returns {SectionApi} instance for chaining
          */
         off : function(eventName){
-            this.scope.off(eventName + '.section');
+            this.scope.off(`${eventName  }.section`);
             return this;
         }
     };

--- a/views/js/layout/section.js
+++ b/views/js/layout/section.js
@@ -497,6 +497,16 @@ define([
             return this;
         },
 
+        clearContentBlock: function clearContentBlock() {
+            if(!this.selected){
+                return
+            }
+            var $contentblock = $('.content-block', this.selected.panel);
+            if($contentblock.length){
+                $contentblock.empty();
+            }
+        },
+
         /**
          * Loads content from a URL but try to target first the content block area before the panel.
          *

--- a/views/js/layout/section.js
+++ b/views/js/layout/section.js
@@ -97,8 +97,8 @@ define([
             });
 
             //to be sure at least one is active, for example when the given default section does not exists
-            if(_(this.sections).where({'active' : true }).size() === 0){
-                for(let id in this.sections){
+            if (_(this.sections).where({'active' : true }).size() === 0) {
+                for (let id in this.sections) {
                     this.sections[id].active =  true;
                     restore = false;
                     break;
@@ -150,7 +150,7 @@ define([
                 });
 
             //display the openers only if there is more than 1 section
-            if($('li:not(.hidden)', $openersContainer).length < 2){
+            if ($('li:not(.hidden)', $openersContainer).length < 2) {
                 $openersContainer.hide();
             } else {
                 $openersContainer.show();
@@ -168,10 +168,10 @@ define([
          * @fires SectionApi#show.section
          */
         activate : function(){
-            if(!this.selected){
+            if (!this.selected) {
                 this.current();
             }
-            if(this.options.history !== false){
+            if (this.options.history !== false) {
                 generisRouter.pushSectionState(location.href, this.selected.id, 'activate');
             }
             return this._activate();
@@ -189,7 +189,7 @@ define([
          */
         _activate : function(){
             this._show();
-            if(this.selected.activated === false){
+            if (this.selected.activated === false) {
                 this.selected.activated = true;
 
                 /**
@@ -213,10 +213,10 @@ define([
          * @fires SectionApi#show.section
          */
         show : function(){
-            if(!this.selected){
+            if (!this.selected) {
                 this.current();
             }
-            if(this.options.history !== false){
+            if (this.options.history !== false) {
                 generisRouter.pushSectionState(location.href, this.selected.id, 'show');
             }
             return this._show();
@@ -238,7 +238,7 @@ define([
             var active = _(this.sections).where({'active' : true }).first();
 
             //switch the active section if set previously
-            if(this.selected && this.selected.id !== active.id){
+            if (this.selected && this.selected.id !== active.id) {
                 _.forEach(this.sections, function(section){
                     section.active = false;
                 });
@@ -292,10 +292,10 @@ define([
          * @fires SectionApi#enable.section
          */
         enable : function(){
-            if(!this.selected){
+            if (!this.selected) {
                 this.current();
             }
-            if(this.selected.disabled === true){
+            if (this.selected.disabled === true) {
                 this.selected.disabled = false;
                 this.selected.opener.removeClass('disabled');
 
@@ -316,10 +316,10 @@ define([
          * @fires SectionApi#disable.section
          */
         disable : function(){
-            if(!this.selected){
+            if (!this.selected) {
                 this.current();
             }
-            if(this.selected.disabled === false){
+            if (this.selected.disabled === false) {
                 this.selected.disabled = true;
                 this.selected.opener.addClass('disabled');
 
@@ -364,13 +364,13 @@ define([
                 $sectionPanel,
                 section;
 
-            if(!_.isObject(data)){
+            if (!_.isObject(data)) {
                 throw new TypeError("The create() method requires an object with section data as parameter.");
             }
-            if(!_.isString(data.id) || !_.isString(data.url) || !_.isString(data.name)){
+            if (!_.isString(data.id) || !_.isString(data.url) || !_.isString(data.name)) {
                 throw new TypeError("The create() method requires data with id, url and name to create a new section.");
             }
-            if(typeof data.visible === 'undefined'){
+            if (typeof data.visible === 'undefined') {
                 data.visible = true;
             }
 
@@ -378,7 +378,7 @@ define([
             section = this.selected && this.selected.id === data.id ? this.selected : undefined;
 
 
-            if(!section){
+            if (!section) {
 
                 //TODO use templates
                 $sectionPanel = $(`<div id="panel-${data.id}" class="clear"></div>`);
@@ -403,15 +403,15 @@ define([
             section.url = section.url === data.url || data.url === undefined ? section.url : data.url;
             this.selected = section;
 
-            if(data.content){
-                if(data.contentBlock === true){
+            if (data.content) {
+                if (data.contentBlock === true) {
                     this.updateContentBlock(data.content);
                 } else {
                     section.panel.html(data.content);
                 }
 
             } else {
-                if(data.contentBlock === true){
+                if (data.contentBlock === true) {
                     this.loadContentBlock();
                 } else {
                     this.load();
@@ -433,7 +433,7 @@ define([
          */
         get : function(value){
             var section;
-            if(!_.isString(value)){
+            if (!_.isString(value)) {
                 throw new TypeError("The get() method requires a string parameter, the section id or url.");
             }
 
@@ -443,7 +443,7 @@ define([
                 this.sections[value.replace('panel-', '')] ||
                 _(this.sections).where({'url' : value }).first() ||
                 _(this.sections).where({'url' : context.root_url + value }).first();
-            if(section){
+            if (section) {
                 this.selected = section;
             } else {
                 this.current();
@@ -466,12 +466,12 @@ define([
         load : function load(url, data, loaded){
             let self = this;
 
-            if(!this.selected){
+            if (!this.selected) {
                 this.current();
             }
             url = url || this.selected.url;
 
-            if(this.selected.type === 'tree'){
+            if (this.selected.type === 'tree') {
                 this.selected.panel.addClass('content-panel');
             } else {
                 this.selected.panel.removeClass('content-panel');
@@ -487,7 +487,7 @@ define([
                  */
                 self.scope.trigger('load.section', [self.selected, response]);
 
-                if(_.isFunction(loaded)){
+                if (_.isFunction(loaded)) {
                     loaded();
                 }
             });
@@ -499,11 +499,11 @@ define([
          * Clears content from the content block area.
          **/
         clearContentBlock: function clearContentBlock() {
-            if(!this.selected){
+            if (!this.selected) {
                 return;
             }
             const $contentblock = $('.content-block', this.selected.panel);
-            if($contentblock.length){
+            if ($contentblock.length) {
                 $contentblock.empty();
             }
         },
@@ -522,12 +522,12 @@ define([
         loadContentBlock : function loadContentBlock(url, data, loaded){
             var $contentblock;
 
-            if(!this.selected){
+            if (!this.selected) {
                 this.current();
             }
             url = url || this.selected.url;
 
-            if(this.selected.type === 'tree'){
+            if (this.selected.type === 'tree') {
                 this.selected.panel.addClass('content-panel');
             } else {
                 this.selected.panel.removeClass('content-panel');
@@ -535,7 +535,7 @@ define([
 
             $contentblock = $('.content-block', this.selected.panel);
 
-            if($contentblock.length){
+            if ($contentblock.length) {
 
                 //do not yet trigger event on content block load, but may be required
                 $contentblock.empty().load(url, data, loaded);


### PR DESCRIPTION
**Jira**
https://oat-sa.atlassian.net/browse/ADF-508

**The fix**
Clear content block before sending the request for `subClass`

**Bonus**
Added `wait` in class delete test helper to guarantee that the app is ready to open confirmation modal. The issue with cypress not catching the modal is not related directly to the fix, however appeared several times on my local machine while I was working on the ticket. For better understanding the issue with the modal we can create a tech debt ticket if needed. 

**How to test the fix**
Test locally with cypress, make sure the https://github.com/oat-sa/extension-tao-item is up to date with `develop` on your local env

**How to test for regressions**
// TODO: Kitchen env link is in the ticket
