### PR TITLE
fix: add missing event manager

### DIFF
--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -1424,4 +1424,9 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule
             throw new InvalidArgumentException('Wrong destination class uri');
         }
     }
+
+    private function getEventManager(): EventManager
+    {
+        return $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+    }
 }


### PR DESCRIPTION
When controllers that are based on `tao_actions_RdfController` were trying to execute event and they did not used use `\oat\oatbox\event\EventManagerAwareTrait`, it was causing fatal error. 

related  PR
https://github.com/oat-sa/extension-tao-mediamanager/pull/292