### PR TITLE
Fix/ADF-480/Fix permissions to view buttons

### DIFF
--- a/actions/class.Import.php
+++ b/actions/class.Import.php
@@ -58,6 +58,7 @@ class tao_actions_Import extends tao_actions_CommonModule
      * initialize the classUri and execute the upload action
      *
      * @requiresRight id WRITE
+     * @requiresRight classUri WRITE
      */
     public function index()
     {

--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -451,7 +451,9 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule
 
     /**
      * Add an instance of the selected class
+     *
      * @requiresRight id WRITE
+     * @requiresRight classUri WRITE
      *
      * @throws SecurityException
      * @throws InconsistencyConfigException
@@ -501,6 +503,8 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule
     /**
      * Add a subclass to the currently selected class
      * @requiresRight id WRITE
+     * @requiresRight classUri WRITE
+     *
      * @throws Exception
      * @throws common_exception_BadRequest
      */
@@ -954,6 +958,8 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule
      *
      * @throws common_exception_BadRequest
      * @throws common_exception_MissingParameter
+     *
+     * @requiresRight id WRITE
      */
     public function delete()
     {


### PR DESCRIPTION
**Relates to:** _[ADF-480](https://oat-sa.atlassian.net/browse/ADF-480)_

---

**How to test:**
1. Create new role `Test Takers Author` with included `Test Takers Manager` role;
2. Create a new user (e.g `Test User`) with the following list of roles:  
a. Item Author;
b. Test Author;
c. Test Takers Author (our new role);
3. Go to Items and create a new class;
4. Change Access Rights for this class:
a. Add `Global Manager` role and set `GRANT` access level to him;
b. Set `READ` access level to `Back Office` role;
5. Create a new item in this class;
6. Change Access Rights for this item: set `GRANT` access level to our new user (`Test User`);
7. Log in as Test User and select this item.

**Previous behavior:** _user can see `New class`, `Import`, `New item` buttons._
**Current behavior:** _user cannot see `New class`, `Import`, `New item` buttons._

```diff
! Repeat steps 3 - 7 for: Tests, Test-takers, Assets.
```
---

**Companion PRs:**
* https://github.com/oat-sa/extension-tao-item/pull/488
* https://github.com/oat-sa/extension-tao-mediamanager/pull/294
* https://github.com/oat-sa/extension-tao-itemqti/pull/1827
* https://github.com/oat-sa/extension-tao-test/pull/375
* https://github.com/oat-sa/extension-tao-testtaker/pull/190