### PR TITLE
[Feature] ADF-507 - E2E user roles

### DIFF
--- a/views/cypress.json
+++ b/views/cypress.json
@@ -10,5 +10,7 @@
   "pageLoadTimeout": 30000,
   "env": {
     "configFile": "cypress/envs/env.json"
-  }
+  },
+  "viewportHeight": 720,
+  "viewportWidth": 1200
 }

--- a/views/cypress/support/commands.js
+++ b/views/cypress/support/commands.js
@@ -19,6 +19,7 @@
 import '@oat-sa/e2e-runner/support/auth';
 import '@oat-sa/e2e-runner/support/lti.js';
 import './resourceTree'
+import './userManagement'
 import urls from '../utils/urls';
 
 Cypress.Commands.add('loginAsUser', (username, password) => {
@@ -30,6 +31,22 @@ Cypress.Commands.add('loginAsAdmin', () => {
     const password = Cypress.env('adminPass');
 
     cy.loginAsUser(username, password);
+});
+
+// Logs out using the UI
+Cypress.Commands.add('logoutAttempt', () => {
+    cy.get('#logout').click()
+});
+
+// Creates a UI login attempt with provided data
+Cypress.Commands.add('loginAttempt', (username, password) => {
+    cy.intercept('POST', '**/login*').as('login');
+    cy.get('#login', { timeout: 10000 }).type(username);
+    cy.get('#password').type(password);
+    cy.get('#connect').click();
+    cy.wait('@login', {
+        requestTimeout: 10000
+    });
 });
 
 // Preserve session cookies to stay logged in to TAO during tests

--- a/views/cypress/support/userManagement.js
+++ b/views/cypress/support/userManagement.js
@@ -21,13 +21,14 @@ import userRoles from "../utils/userRoles";
 
 /**
  * Fills user properties in form while checking that login field does not already exist
+ * @param {String} targetForm - contains selector targeting the Form to fill
  * @param {Object} userData - contains user details to fill form
  * @param {Array<string>} roles - contains each role that needs to be applied to user
  */
-Cypress.Commands.add('addUser', (userData, roles) => {
+Cypress.Commands.add('addUser', (targetForm, userData, roles) => {
     cy.log('COMMAND: addUser');
 
-    cy.get(selectors.addUserForm)
+    cy.get(targetForm)
         .within(() => {
             cy.get('input[name*=label]')
                 .clear()
@@ -37,8 +38,10 @@ Cypress.Commands.add('addUser', (userData, roles) => {
             cy.get('input[name*=login]')
                 .clear()
                 .type(userData.login);
-            cy.get('.form_checklst input')
-                .check(roles || userRoles.itemAuthor, { force: true });
+            if (roles) {
+                cy.get('.form_checklst input')
+                    .check(roles || userRoles.itemAuthor, { force: true });
+            }
             cy.get('input[name*=password1]')
                 .clear()
                 .type(userData.password);
@@ -46,7 +49,7 @@ Cypress.Commands.add('addUser', (userData, roles) => {
                 .clear()
                 .type(userData.password);
             cy.get('.login-info.ui-state-error').should('not.exist')
-            cy.get('button').click();
+            cy.get('button[type=submit]').click();
         });
 });
 

--- a/views/cypress/support/userManagement.js
+++ b/views/cypress/support/userManagement.js
@@ -1,0 +1,83 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+import selectors from "../utils/selectors";
+import userRoles from "../utils/userRoles";
+
+/**
+ * Fills user properties in form while checking that login field does not already exist
+ * @param {Object} userData - contains user details to fill form
+ * @param {Array<string>} roles - contains each role that needs to be applied to user
+ */
+Cypress.Commands.add('addUser', (userData, roles) => {
+    cy.log('COMMAND: addUser');
+
+    cy.get(selectors.addUserForm)
+        .within(() => {
+            cy.get('input[name*=label]')
+                .clear()
+                .type(userData.label);
+            cy.get('select[name*=userUILg]')
+                .select(userData.language);
+            cy.get('input[name*=login]')
+                .clear()
+                .type(userData.login);
+            cy.get('.form_checklst input')
+                .check(roles || userRoles.itemAuthor, { force: true });
+            cy.get('input[name*=password1]')
+                .clear()
+                .type(userData.password);
+            cy.get('input[name*=password2]')
+                .clear()
+                .type(userData.password);
+            cy.get('.login-info.ui-state-error').should('not.exist')
+            cy.get('button').click();
+        });
+});
+
+/**
+ * Search for user in table using search input[name=filter]
+ * Triggers delete action by clicking remove button
+ * Confirms action in modal
+ * @param {Object} userData - contains user details
+ */
+Cypress.Commands.add('deleteUser', (userData) => {
+    cy.log('COMMAND: deleteUser');
+
+    cy.intercept('GET', `**/Users/**/*filterquery=${userData.login}`).as('usersData')
+    cy.get(`${selectors.manageUserTable} .filter input[name=filter]`)
+        .type(`${userData.login}{enter}`);
+    cy.wait('@usersData', {
+        requestTimeout: 10000
+    });
+
+    cy.get(`${selectors.manageUserTable} table`)
+        .contains('td', userData.login)
+        .siblings('.actions')
+        .find('.remove')
+        .should('not.have.class', 'disabled')
+        .click()
+
+    cy.get('.modal-body').then((body) => {
+        if (body.find('label[for=confirm]').length) {
+            cy.get('label[for=confirm]').click();
+        }
+
+        cy.get(selectors.deleteConfirm).click();
+    });
+});

--- a/views/cypress/support/userManagement.js
+++ b/views/cypress/support/userManagement.js
@@ -39,7 +39,7 @@ Cypress.Commands.add('addUser', (targetForm, userData, roles) => {
                 .clear()
                 .type(userData.login);
             if (roles) {
-                cy.get('.form_checklst input')
+                cy.get('input[type=checkbox][name*="userRoles"]')
                     .check(roles || userRoles.itemAuthor, { force: true });
             }
             cy.get('input[name*=password1]')

--- a/views/cypress/support/userManagement.js
+++ b/views/cypress/support/userManagement.js
@@ -16,8 +16,8 @@
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
 
-import selectors from "../utils/selectors";
-import userRoles from "../utils/userRoles";
+import selectors from '../utils/selectors';
+import userRoles from '../utils/userRoles';
 
 /**
  * Fills user properties in form while checking that login field does not already exist

--- a/views/cypress/tests/item-author-role.spec.js
+++ b/views/cypress/tests/item-author-role.spec.js
@@ -1,0 +1,106 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+import urls from '../utils/urls';
+import users from '../utils/users';
+import userRoles from '../utils/userRoles';
+
+describe('Item Author Role', () => {
+    const userLogin = users.user_item_author.login;
+    const userPassword = users.user_item_author.password;
+
+    before(() => {
+        cy.loginAsAdmin();
+        cy.intercept('GET', '**/add*').as('add');
+        cy.visit(urls.addUser);
+        cy.wait('@add', {
+            requestTimeout: 10000
+        });
+        cy.addUser(users.user_item_author, userRoles.itemAuthor);
+        cy.intercept('GET', '**/logout*').as('logout');
+        cy.logoutAttempt();
+        cy.wait('@logout', {
+            requestTimeout: 10000
+        });
+    });
+
+    describe('Login', () => {
+        it('Logged in successfully', function() {
+            cy.loginAttempt(userLogin, userPassword);
+            cy.get('#user_settings .username').should('have.text', users.user_item_author.login);
+            cy.get('#logout');
+        });
+
+        it('Pass splash-screen if present', function() {
+            if (cy.get('#splash-screen')) {
+                cy.get(':nth-child(1) > :nth-child(1) > .block').click();
+                cy.get('#splash-close-btn').click();
+            }
+        });
+    });
+
+    describe('Check Item tab', () => {
+        it('Has access to items tab', function() {
+            cy.get('.lft.main-menu > :nth-child(1) > a .icon-item');
+        });
+
+        it('Has access to resource tree', function() {
+            cy.intercept('GET', '**/taoItems/Items/*').as('treeItems');
+            cy.wait('@treeItems', {
+                requestTimeout: 10000
+            });
+            cy.get('#tree-manage_items').should('be.visible');
+            cy.get('#tree-manage_items > ul > li')
+        });
+
+        it('Has access to resource actions', function() {
+            cy.get('.tree-action-bar-box > .plain')
+                .should('be.visible')
+                .children().its('length').should('be.gt', 0);
+        });
+    });
+
+    describe('Check Assets tab', () => {
+        it('Has access to Assets tab', function() {
+            cy.get('.lft.main-menu > li > a .icon-media');
+            cy.intercept('GET', '**/taoMediaManager/MediaManager/*').as('mediaData');
+            cy.visit(urls.mediaManager);
+            cy.wait('@mediaData', {
+                requestTimeout: 10000
+            });
+        });
+
+        it('Has access to resource tree', function() {
+            cy.get('#tree-media_manager').should('be.visible');
+            cy.get('#tree-media_manager > ul > li');
+        });
+
+        it('Has access to resource actions', function() {
+            cy.get('.tree-action-bar-box > .plain')
+                .should('be.visible')
+                .children().its('length').should('be.gt', 0);
+        });
+    });
+
+    after(() => {
+        cy.logoutAttempt();
+        cy.loginAsAdmin();
+        cy.visit(urls.manageUsers);
+        cy.deleteUser(users.user_item_author);
+    });
+})
+

--- a/views/cypress/tests/item-author-role.spec.js
+++ b/views/cypress/tests/item-author-role.spec.js
@@ -18,6 +18,7 @@
 import urls from '../utils/urls';
 import users from '../utils/users';
 import userRoles from '../utils/userRoles';
+import selectors from '../utils/selectors';
 
 describe('Item Author Role', () => {
     const userLogin = users.user_item_author.login;
@@ -30,7 +31,7 @@ describe('Item Author Role', () => {
         cy.wait('@add', {
             requestTimeout: 10000
         });
-        cy.addUser(users.user_item_author, userRoles.itemAuthor);
+        cy.addUser(selectors.addUserForm, users.user_item_author, userRoles.itemAuthor);
         cy.intercept('GET', '**/logout*').as('logout');
         cy.logoutAttempt();
         cy.wait('@logout', {
@@ -102,5 +103,4 @@ describe('Item Author Role', () => {
         cy.visit(urls.manageUsers);
         cy.deleteUser(users.user_item_author);
     });
-})
-
+});

--- a/views/cypress/tests/item-author-role.spec.js
+++ b/views/cypress/tests/item-author-role.spec.js
@@ -19,6 +19,7 @@ import urls from '../utils/urls';
 import users from '../utils/users';
 import userRoles from '../utils/userRoles';
 import selectors from '../utils/selectors';
+import { tryToDeleteUser } from '../utils/cleanup';
 
 describe('Item Author Role', () => {
     const userLogin = users.user_item_author.login;
@@ -26,6 +27,7 @@ describe('Item Author Role', () => {
 
     before(() => {
         cy.loginAsAdmin();
+        tryToDeleteUser(users.user_item_author);
         cy.intercept('GET', '**/add*').as('add');
         cy.visit(urls.addUser);
         cy.wait('@add', {
@@ -46,11 +48,10 @@ describe('Item Author Role', () => {
             cy.get('#logout');
         });
 
-        it('Pass splash-screen if present', function() {
-            if (cy.get('#splash-screen')) {
-                cy.get(':nth-child(1) > :nth-child(1) > .block').click();
-                cy.get('#splash-close-btn').click();
-            }
+        it('Pass splash-screen', function() {
+            cy.get('#splash-screen');
+            cy.get(':nth-child(1) > :nth-child(1) > .block').click();
+            cy.get('#splash-close-btn').click();
         });
     });
 
@@ -95,12 +96,5 @@ describe('Item Author Role', () => {
                 .should('be.visible')
                 .children().its('length').should('be.gt', 0);
         });
-    });
-
-    after(() => {
-        cy.logoutAttempt();
-        cy.loginAsAdmin();
-        cy.visit(urls.manageUsers);
-        cy.deleteUser(users.user_item_author);
     });
 });

--- a/views/cypress/tests/login.spec.js
+++ b/views/cypress/tests/login.spec.js
@@ -20,17 +20,9 @@ import urls from '../utils/urls';
 
 
 describe('Login', () => {
-    // helper that creates a login attempt with provided data
-    const loginAttempt = (username, password) => {
-        cy.get('#login', { timeout: 10000 }).type(username);
-        cy.get('#password').type(password);
-
-        cy.get('#connect').click();
-    };
-
     it('cannot login with invalid user', function () {
         cy.visit(urls.login);
-        loginAttempt('invalid', '123');
+        cy.loginAttempt('invalid', '123');
 
         cy.get('.feedback[role=alert]').should('exist');
         cy.location('pathname').should('eq', urls.login);
@@ -41,7 +33,7 @@ describe('Login', () => {
         const password = Cypress.env('adminPass');
 
         cy.visit(urls.login);
-        loginAttempt(username, password);
+        cy.loginAttempt(username, password);
 
         cy.location('pathname').should('eq', urls.index);
     });

--- a/views/cypress/tests/test-author-role.spec.js
+++ b/views/cypress/tests/test-author-role.spec.js
@@ -19,6 +19,7 @@ import urls from '../utils/urls';
 import users from '../utils/users';
 import userRoles from '../utils/userRoles';
 import selectors from '../utils/selectors';
+import { tryToDeleteUser } from '../utils/cleanup';
 
  describe('Item Author Role', () => {
     const userLogin = users.user_test_author.login;
@@ -26,6 +27,7 @@ import selectors from '../utils/selectors';
 
     before(() => {
         cy.loginAsAdmin();
+        tryToDeleteUser(users.user_test_author);
         cy.intercept('GET', '**/add*').as('add');
         cy.visit(urls.addUser);
         cy.wait('@add', {
@@ -46,11 +48,10 @@ import selectors from '../utils/selectors';
             cy.get('#logout');
         });
 
-        it('Pass splash-screen if present', function() {
-            if (cy.get('#splash-screen')) {
-                cy.get(':nth-child(1) > :nth-child(1) > .block').click();
-                cy.get('#splash-close-btn').click();
-            }
+        it('Pass splash-screen', function() {
+            cy.get('#splash-screen');
+            cy.get(':nth-child(1) > :nth-child(1) > .block').click();
+            cy.get('#splash-close-btn').click();
         });
     });
 
@@ -117,12 +118,5 @@ import selectors from '../utils/selectors';
                 .should('be.visible')
                 .children().its('length').should('be.gt', 0);
         });
-    });
-
-    after(() => {
-        cy.logoutAttempt();
-        cy.loginAsAdmin();
-        cy.visit(urls.manageUsers);
-        cy.deleteUser(users.user_test_author);
     });
 });

--- a/views/cypress/tests/test-author-role.spec.js
+++ b/views/cypress/tests/test-author-role.spec.js
@@ -1,0 +1,128 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+ import urls from '../utils/urls';
+ import users from '../utils/users';
+ import userRoles from '../utils/userRoles';
+
+ describe('Item Author Role', () => {
+     const userLogin = users.user_test_author.login;
+     const userPassword = users.user_test_author.password;
+
+     before(() => {
+         cy.loginAsAdmin();
+         cy.intercept('GET', '**/add*').as('add');
+         cy.visit(urls.addUser);
+         cy.wait('@add', {
+             requestTimeout: 10000
+         });
+         cy.addUser(users.user_test_author, [userRoles.itemAuthor, userRoles.testAuthor]);
+         cy.intercept('GET', '**/logout*').as('logout');
+         cy.logoutAttempt();
+         cy.wait('@logout', {
+             requestTimeout: 10000
+         });
+     });
+
+     describe('Login', () => {
+         it('Logged in successfully', function() {
+             cy.loginAttempt(userLogin, userPassword);
+             cy.get('#user_settings .username').should('have.text', users.user_test_author.login);
+             cy.get('#logout');
+         });
+
+         it('Pass splash-screen if present', function() {
+             if (cy.get('#splash-screen')) {
+                 cy.get(':nth-child(1) > :nth-child(1) > .block').click();
+                 cy.get('#splash-close-btn').click();
+             }
+         });
+     });
+
+     describe('Check Item tab', () => {
+         it('Has access to items tab', function() {
+             cy.get('.lft.main-menu > :nth-child(1) > a .icon-item');
+         });
+
+         it('Has access to resource tree', function() {
+             cy.intercept('GET', '**/taoItems/Items/*').as('treeItems');
+             cy.wait('@treeItems', {
+                 requestTimeout: 10000
+             });
+             cy.get('#tree-manage_items').should('be.visible');
+             cy.get('#tree-manage_items > ul > li')
+         });
+
+         it('Has access to resource actions', function() {
+             cy.get('.tree-action-bar-box > .plain')
+                 .should('be.visible')
+                 .children().its('length').should('be.gt', 0);
+         });
+     });
+
+     describe('Check Assets tab', () => {
+         it('Has access to Assets tab', function() {
+             cy.get('.lft.main-menu > li > a .icon-media');
+             cy.intercept('GET', '**/taoMediaManager/MediaManager/*').as('mediaData');
+             cy.visit(urls.mediaManager);
+             cy.wait('@mediaData', {
+                 requestTimeout: 10000
+             });
+         });
+
+         it('Has access to resource tree', function() {
+             cy.get('#tree-media_manager').should('be.visible');
+             cy.get('#tree-media_manager > ul > li');
+         });
+
+         it('Has access to resource actions', function() {
+             cy.get('.tree-action-bar-box > .plain')
+                 .should('be.visible')
+                 .children().its('length').should('be.gt', 0);
+         });
+     });
+
+     describe('Check Tests tab', () => {
+        it('Has access to Tests tab', function() {
+            cy.get('.lft > :nth-child(2) > a .icon-test');
+            cy.intercept('GET', '**/taoTests/Tests/*').as('testsData');
+            cy.visit(urls.testsManager);
+            cy.wait('@testsData', {
+                requestTimeout: 10000
+            });
+        });
+
+        it('Has access to resource tree', function() {
+            cy.get('#tree-manage_tests').should('be.visible');
+            cy.get('#tree-manage_tests > ul > li');
+        });
+
+        it('Has access to resource actions', function() {
+            cy.get('.tree-action-bar-box > .plain')
+                .should('be.visible')
+                .children().its('length').should('be.gt', 0);
+        });
+    });
+
+     after(() => {
+         cy.logoutAttempt();
+         cy.loginAsAdmin();
+         cy.visit(urls.manageUsers);
+         cy.deleteUser(users.user_test_author);
+     });
+ })
+

--- a/views/cypress/tests/test-author-role.spec.js
+++ b/views/cypress/tests/test-author-role.spec.js
@@ -18,6 +18,7 @@
  import urls from '../utils/urls';
  import users from '../utils/users';
  import userRoles from '../utils/userRoles';
+import selectors from '../utils/selectors';
 
  describe('Item Author Role', () => {
      const userLogin = users.user_test_author.login;
@@ -30,7 +31,7 @@
          cy.wait('@add', {
              requestTimeout: 10000
          });
-         cy.addUser(users.user_test_author, [userRoles.itemAuthor, userRoles.testAuthor]);
+         cy.addUser(selectors.addUserForm, users.user_test_author, [userRoles.itemAuthor, userRoles.testAuthor]);
          cy.intercept('GET', '**/logout*').as('logout');
          cy.logoutAttempt();
          cy.wait('@logout', {
@@ -124,5 +125,4 @@
          cy.visit(urls.manageUsers);
          cy.deleteUser(users.user_test_author);
      });
- })
-
+ });

--- a/views/cypress/tests/test-author-role.spec.js
+++ b/views/cypress/tests/test-author-role.spec.js
@@ -15,89 +15,89 @@
  *
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
- import urls from '../utils/urls';
- import users from '../utils/users';
- import userRoles from '../utils/userRoles';
+import urls from '../utils/urls';
+import users from '../utils/users';
+import userRoles from '../utils/userRoles';
 import selectors from '../utils/selectors';
 
  describe('Item Author Role', () => {
-     const userLogin = users.user_test_author.login;
-     const userPassword = users.user_test_author.password;
+    const userLogin = users.user_test_author.login;
+    const userPassword = users.user_test_author.password;
 
-     before(() => {
-         cy.loginAsAdmin();
-         cy.intercept('GET', '**/add*').as('add');
-         cy.visit(urls.addUser);
-         cy.wait('@add', {
-             requestTimeout: 10000
-         });
-         cy.addUser(selectors.addUserForm, users.user_test_author, [userRoles.itemAuthor, userRoles.testAuthor]);
-         cy.intercept('GET', '**/logout*').as('logout');
-         cy.logoutAttempt();
-         cy.wait('@logout', {
-             requestTimeout: 10000
-         });
-     });
+    before(() => {
+        cy.loginAsAdmin();
+        cy.intercept('GET', '**/add*').as('add');
+        cy.visit(urls.addUser);
+        cy.wait('@add', {
+            requestTimeout: 10000
+        });
+        cy.addUser(selectors.addUserForm, users.user_test_author, [userRoles.itemAuthor, userRoles.testAuthor]);
+        cy.intercept('GET', '**/logout*').as('logout');
+        cy.logoutAttempt();
+        cy.wait('@logout', {
+            requestTimeout: 10000
+        });
+    });
 
-     describe('Login', () => {
-         it('Logged in successfully', function() {
-             cy.loginAttempt(userLogin, userPassword);
-             cy.get('#user_settings .username').should('have.text', users.user_test_author.login);
-             cy.get('#logout');
-         });
+    describe('Login', () => {
+        it('Logged in successfully', function() {
+            cy.loginAttempt(userLogin, userPassword);
+            cy.get('#user_settings .username').should('have.text', users.user_test_author.login);
+            cy.get('#logout');
+        });
 
-         it('Pass splash-screen if present', function() {
-             if (cy.get('#splash-screen')) {
-                 cy.get(':nth-child(1) > :nth-child(1) > .block').click();
-                 cy.get('#splash-close-btn').click();
-             }
-         });
-     });
+        it('Pass splash-screen if present', function() {
+            if (cy.get('#splash-screen')) {
+                cy.get(':nth-child(1) > :nth-child(1) > .block').click();
+                cy.get('#splash-close-btn').click();
+            }
+        });
+    });
 
-     describe('Check Item tab', () => {
-         it('Has access to items tab', function() {
-             cy.get('.lft.main-menu > :nth-child(1) > a .icon-item');
-         });
+    describe('Check Item tab', () => {
+        it('Has access to items tab', function() {
+            cy.get('.lft.main-menu > :nth-child(1) > a .icon-item');
+        });
 
-         it('Has access to resource tree', function() {
-             cy.intercept('GET', '**/taoItems/Items/*').as('treeItems');
-             cy.wait('@treeItems', {
-                 requestTimeout: 10000
-             });
-             cy.get('#tree-manage_items').should('be.visible');
-             cy.get('#tree-manage_items > ul > li')
-         });
+        it('Has access to resource tree', function() {
+            cy.intercept('GET', '**/taoItems/Items/*').as('treeItems');
+            cy.wait('@treeItems', {
+                requestTimeout: 10000
+            });
+            cy.get('#tree-manage_items').should('be.visible');
+            cy.get('#tree-manage_items > ul > li')
+        });
 
-         it('Has access to resource actions', function() {
-             cy.get('.tree-action-bar-box > .plain')
-                 .should('be.visible')
-                 .children().its('length').should('be.gt', 0);
-         });
-     });
+        it('Has access to resource actions', function() {
+            cy.get('.tree-action-bar-box > .plain')
+                .should('be.visible')
+                .children().its('length').should('be.gt', 0);
+        });
+    });
 
-     describe('Check Assets tab', () => {
-         it('Has access to Assets tab', function() {
-             cy.get('.lft.main-menu > li > a .icon-media');
-             cy.intercept('GET', '**/taoMediaManager/MediaManager/*').as('mediaData');
-             cy.visit(urls.mediaManager);
-             cy.wait('@mediaData', {
-                 requestTimeout: 10000
-             });
-         });
+    describe('Check Assets tab', () => {
+        it('Has access to Assets tab', function() {
+            cy.get('.lft.main-menu > li > a .icon-media');
+            cy.intercept('GET', '**/taoMediaManager/MediaManager/*').as('mediaData');
+            cy.visit(urls.mediaManager);
+            cy.wait('@mediaData', {
+                requestTimeout: 10000
+            });
+        });
 
-         it('Has access to resource tree', function() {
-             cy.get('#tree-media_manager').should('be.visible');
-             cy.get('#tree-media_manager > ul > li');
-         });
+        it('Has access to resource tree', function() {
+            cy.get('#tree-media_manager').should('be.visible');
+            cy.get('#tree-media_manager > ul > li');
+        });
 
-         it('Has access to resource actions', function() {
-             cy.get('.tree-action-bar-box > .plain')
-                 .should('be.visible')
-                 .children().its('length').should('be.gt', 0);
-         });
-     });
+        it('Has access to resource actions', function() {
+            cy.get('.tree-action-bar-box > .plain')
+                .should('be.visible')
+                .children().its('length').should('be.gt', 0);
+        });
+    });
 
-     describe('Check Tests tab', () => {
+    describe('Check Tests tab', () => {
         it('Has access to Tests tab', function() {
             cy.get('.lft > :nth-child(2) > a .icon-test');
             cy.intercept('GET', '**/taoTests/Tests/*').as('testsData');
@@ -119,10 +119,10 @@ import selectors from '../utils/selectors';
         });
     });
 
-     after(() => {
-         cy.logoutAttempt();
-         cy.loginAsAdmin();
-         cy.visit(urls.manageUsers);
-         cy.deleteUser(users.user_test_author);
-     });
- });
+    after(() => {
+        cy.logoutAttempt();
+        cy.loginAsAdmin();
+        cy.visit(urls.manageUsers);
+        cy.deleteUser(users.user_test_author);
+    });
+});

--- a/views/cypress/tests/test-taker-role.spec.js
+++ b/views/cypress/tests/test-taker-role.spec.js
@@ -19,6 +19,7 @@ import urls from '../utils/urls';
 import users from '../utils/users';
 import userRoles from '../utils/userRoles';
 import selectors from '../utils/selectors';
+import { tryToDeleteUser } from '../utils/cleanup';
 
 describe('Test Taker Role', () => {
     const userLogin = users.user_test_taker.login;
@@ -26,6 +27,7 @@ describe('Test Taker Role', () => {
 
     before(() => {
         cy.loginAsAdmin();
+        tryToDeleteUser(users.user_test_taker);
         cy.intercept('GET', '**/add*').as('add');
         cy.visit(urls.addUser);
         cy.wait('@add', {
@@ -48,23 +50,16 @@ describe('Test Taker Role', () => {
     });
 
     describe('Only has access to deliveries', () => {
-    it('Is in delivery scope', function() {
-        cy.get('body').should('have.class', 'delivery-scope')
-    });
+        it('Is in delivery scope', function() {
+            cy.get('body').should('have.class', 'delivery-scope')
+        });
 
-    it('Doesn\'t have access to tabs', function() {
-        cy.get('.lft.main-menu').should('not.exist');
-    });
+        it('Doesn\'t have access to tabs', function() {
+            cy.get('.lft.main-menu').should('not.exist');
+        });
 
-    it('Can see listing of deliveries', () => {
-        cy.get('.test-listing');
-    });
-});
-
-    after(() => {
-        cy.logoutAttempt();
-        cy.loginAsAdmin();
-        cy.visit(urls.manageUsers);
-        cy.deleteUser(users.user_test_taker);
+        it('Can see listing of deliveries', () => {
+            cy.get('.test-listing');
+        });
     });
 });

--- a/views/cypress/tests/test-taker-role.spec.js
+++ b/views/cypress/tests/test-taker-role.spec.js
@@ -48,11 +48,11 @@
      });
 
      describe('Only has access to deliveries', () => {
-        it("Is in delivery scope", function() {
+        it('Is in delivery scope', function() {
             cy.get('body').should('have.class', 'delivery-scope')
         });
 
-        it("Doesn't have access to tabs", function() {
+        it('Doesn\'t have access to tabs', function() {
             cy.get('.lft.main-menu').should('not.exist');
         });
 

--- a/views/cypress/tests/test-taker-role.spec.js
+++ b/views/cypress/tests/test-taker-role.spec.js
@@ -15,55 +15,39 @@
  *
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
-import urls from '../utils/urls';
-import users from '../utils/users';
-import selectors from '../utils/selectors';
+ import urls from '../utils/urls';
+ import users from '../utils/users';
+ import userRoles from '../utils/userRoles';
+ import selectors from '../utils/selectors';
 
-describe('Test Taker Role', () => {
-    const userLogin = users.user_test_taker.login;
-    const userPassword = users.user_test_taker.password;
+ describe('Test Taker Role', () => {
+     const userLogin = users.user_test_taker.login;
+     const userPassword = users.user_test_taker.password;
 
-    before(() => {
-        cy.loginAsAdmin();
-    });
+     before(() => {
+         cy.loginAsAdmin();
+         cy.intercept('GET', '**/add*').as('add');
+         cy.visit(urls.addUser);
+         cy.wait('@add', {
+             requestTimeout: 10000
+         });
+         cy.addUser(selectors.addUserForm, users.user_test_taker, userRoles.testTaker);
+         cy.intercept('GET', '**/logout*').as('logout');
+         cy.logoutAttempt();
+         cy.wait('@logout', {
+             requestTimeout: 10000
+         });
+     });
 
-    describe('Create test taker user', () => {
-        it('Admin can manage test takers', function() {
-            cy.intercept('GET', '/taoTestTaker/TestTaker/*').as('testTakerTree');
-            cy.visit(urls.testTakersManager);
-            cy.wait('@testTakerTree', {
-                requestTimeout: 10000
-            });
-        });
+     describe('Login', () => {
+         it('Logged in successfully', function() {
+             cy.loginAttempt(userLogin, userPassword);
+             cy.contains('.settings-menu li', users.user_test_taker.login);
+             cy.get('#logout');
+         });
+     });
 
-        it('Admin can create test taker', function() {
-            cy.intercept('POST', '/taoTestTaker/TestTaker/addInstance').as('addTestTaker');
-            cy.get('#testtaker-new').click();
-            cy.wait('@addTestTaker', {
-                requestTimeout: 10000
-            }).its('response.body.success').should('eq', true);
-            cy.intercept('POST', '/tao/GenerisTree/getData').as('testTakerData');
-            cy.wait('@testTakerData', {
-                requestTimeout: 10000
-            });
-            cy.addUser(selectors.addTestTakerForm, users.user_test_taker);
-        });
-    });
-
-    describe('Login as test taker user', () => {
-        it('Login Successfully', function() {
-            cy.intercept('GET', '**/logout*').as('logout');
-            cy.logoutAttempt();
-            cy.wait('@logout', {
-                requestTimeout: 10000
-            });
-            cy.loginAttempt(userLogin, userPassword);
-            cy.contains('.settings-menu li', users.user_test_taker.login);
-            cy.get('#logout');
-        });
-    });
-
-    describe('Only has access to deliveries', () => {
+     describe('Only has access to deliveries', () => {
         it("Is in delivery scope", function() {
             cy.get('body').should('have.class', 'delivery-scope')
         });
@@ -77,10 +61,10 @@ describe('Test Taker Role', () => {
         });
     });
 
-    after(() => {
-        cy.logoutAttempt();
-        cy.loginAsAdmin();
-        cy.visit(urls.manageUsers);
-        cy.deleteUser(users.user_test_taker);
-    });
-});
+     after(() => {
+         cy.logoutAttempt();
+         cy.loginAsAdmin();
+         cy.visit(urls.manageUsers);
+         cy.deleteUser(users.user_test_taker);
+     });
+ });

--- a/views/cypress/tests/test-taker-role.spec.js
+++ b/views/cypress/tests/test-taker-role.spec.js
@@ -1,0 +1,86 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+import urls from '../utils/urls';
+import users from '../utils/users';
+import selectors from '../utils/selectors';
+
+describe('Test Taker Role', () => {
+    const userLogin = users.user_test_taker.login;
+    const userPassword = users.user_test_taker.password;
+
+    before(() => {
+        cy.loginAsAdmin();
+    });
+
+    describe('Create test taker user', () => {
+        it('Admin can manage test takers', function() {
+            cy.intercept('GET', '/taoTestTaker/TestTaker/*').as('testTakerTree');
+            cy.visit(urls.testTakersManager);
+            cy.wait('@testTakerTree', {
+                requestTimeout: 10000
+            });
+        });
+
+        it('Admin can create test taker', function() {
+            cy.intercept('POST', '/taoTestTaker/TestTaker/addInstance').as('addTestTaker');
+            cy.get('#testtaker-new').click();
+            cy.wait('@addTestTaker', {
+                requestTimeout: 10000
+            }).its('response.body.success').should('eq', true);
+            cy.intercept('POST', '/tao/GenerisTree/getData').as('testTakerData');
+            cy.wait('@testTakerData', {
+                requestTimeout: 10000
+            });
+            cy.addUser(selectors.addTestTakerForm, users.user_test_taker);
+        });
+    });
+
+    describe('Login as test taker user', () => {
+        it('Login Successfully', function() {
+            cy.intercept('GET', '**/logout*').as('logout');
+            cy.logoutAttempt();
+            cy.wait('@logout', {
+                requestTimeout: 10000
+            });
+            cy.loginAttempt(userLogin, userPassword);
+            cy.contains('.settings-menu li', users.user_test_taker.login);
+            cy.get('#logout');
+        });
+    });
+
+    describe('Only has access to deliveries', () => {
+        it("Is in delivery scope", function() {
+            cy.get('body').should('have.class', 'delivery-scope')
+        });
+
+        it("Doesn't have access to tabs", function() {
+            cy.get('.lft.main-menu').should('not.exist');
+        });
+
+        it('Can see listing of deliveries', () => {
+            cy.get('.test-listing');
+        });
+    });
+
+    after(() => {
+        cy.logoutAttempt();
+        cy.loginAsAdmin();
+        cy.visit(urls.manageUsers);
+        cy.deleteUser(users.user_test_taker);
+    });
+});

--- a/views/cypress/tests/test-taker-role.spec.js
+++ b/views/cypress/tests/test-taker-role.spec.js
@@ -15,56 +15,56 @@
  *
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
  */
- import urls from '../utils/urls';
- import users from '../utils/users';
- import userRoles from '../utils/userRoles';
- import selectors from '../utils/selectors';
+import urls from '../utils/urls';
+import users from '../utils/users';
+import userRoles from '../utils/userRoles';
+import selectors from '../utils/selectors';
 
- describe('Test Taker Role', () => {
-     const userLogin = users.user_test_taker.login;
-     const userPassword = users.user_test_taker.password;
+describe('Test Taker Role', () => {
+    const userLogin = users.user_test_taker.login;
+    const userPassword = users.user_test_taker.password;
 
-     before(() => {
-         cy.loginAsAdmin();
-         cy.intercept('GET', '**/add*').as('add');
-         cy.visit(urls.addUser);
-         cy.wait('@add', {
-             requestTimeout: 10000
-         });
-         cy.addUser(selectors.addUserForm, users.user_test_taker, userRoles.testTaker);
-         cy.intercept('GET', '**/logout*').as('logout');
-         cy.logoutAttempt();
-         cy.wait('@logout', {
-             requestTimeout: 10000
-         });
-     });
-
-     describe('Login', () => {
-         it('Logged in successfully', function() {
-             cy.loginAttempt(userLogin, userPassword);
-             cy.contains('.settings-menu li', users.user_test_taker.login);
-             cy.get('#logout');
-         });
-     });
-
-     describe('Only has access to deliveries', () => {
-        it('Is in delivery scope', function() {
-            cy.get('body').should('have.class', 'delivery-scope')
+    before(() => {
+        cy.loginAsAdmin();
+        cy.intercept('GET', '**/add*').as('add');
+        cy.visit(urls.addUser);
+        cy.wait('@add', {
+            requestTimeout: 10000
         });
-
-        it('Doesn\'t have access to tabs', function() {
-            cy.get('.lft.main-menu').should('not.exist');
-        });
-
-        it('Can see listing of deliveries', () => {
-            cy.get('.test-listing');
+        cy.addUser(selectors.addUserForm, users.user_test_taker, userRoles.testTaker);
+        cy.intercept('GET', '**/logout*').as('logout');
+        cy.logoutAttempt();
+        cy.wait('@logout', {
+            requestTimeout: 10000
         });
     });
 
-     after(() => {
-         cy.logoutAttempt();
-         cy.loginAsAdmin();
-         cy.visit(urls.manageUsers);
-         cy.deleteUser(users.user_test_taker);
-     });
- });
+    describe('Login', () => {
+        it('Logged in successfully', function() {
+            cy.loginAttempt(userLogin, userPassword);
+            cy.contains('.settings-menu li', users.user_test_taker.login);
+            cy.get('#logout');
+        });
+    });
+
+    describe('Only has access to deliveries', () => {
+    it('Is in delivery scope', function() {
+        cy.get('body').should('have.class', 'delivery-scope')
+    });
+
+    it('Doesn\'t have access to tabs', function() {
+        cy.get('.lft.main-menu').should('not.exist');
+    });
+
+    it('Can see listing of deliveries', () => {
+        cy.get('.test-listing');
+    });
+});
+
+    after(() => {
+        cy.logoutAttempt();
+        cy.loginAsAdmin();
+        cy.visit(urls.manageUsers);
+        cy.deleteUser(users.user_test_taker);
+    });
+});

--- a/views/cypress/tests/user-management.spec.js
+++ b/views/cypress/tests/user-management.spec.js
@@ -19,6 +19,7 @@
 import selectors from '../utils/selectors';
 import urls from '../utils/urls';
 import users from '../utils/users';
+import userRoles from '../utils/userRoles';
 
 describe('User Management', () => {
     describe('Add User', () => {
@@ -44,7 +45,7 @@ describe('User Management', () => {
 
         describe('Can create user', () => {
             it('fill user form', function () {
-                cy.addUser(users.user_cypress)
+                cy.addUser(selectors.addUserForm, users.user_cypress, userRoles.itemAuthor)
             });
         })
     });

--- a/views/cypress/tests/user-management.spec.js
+++ b/views/cypress/tests/user-management.spec.js
@@ -1,0 +1,77 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+import selectors from '../utils/selectors';
+import urls from '../utils/urls';
+import users from '../utils/users';
+
+describe('User Management', () => {
+    describe('Add User', () => {
+        before(() => {
+            cy.loginAsAdmin();
+            cy.intercept('GET', '**/add*').as('add');
+            cy.visit(urls.addUser);
+
+            cy.wait('@add', {
+                requestTimeout: 10000
+            });
+        });
+
+        describe('Visit add users page', () => {
+            it('should be Users settings menu button', function () {
+                cy.get('.setting-menu-container .settings-menu .active.li-users').should('have.length', 1);
+            });
+
+            it('should be form with properties', function () {
+                cy.get('section.content-container').find('form').should('have.length', 1);
+            });
+        });
+
+        describe('Can create user', () => {
+            it('fill user form', function () {
+                cy.addUser(users.user_cypress)
+            });
+        })
+    });
+
+    describe('Delete User', () => {
+        before(() => {
+            cy.loginAsAdmin();
+            cy.intercept('GET', '**/Users/data*').as('usersData')
+            cy.wait('@usersData', {
+                requestTimeout: 10000
+            });
+        });
+
+        describe('Visit manage users page', () => {
+            it('should be Users settings menu button', function () {
+                cy.get('.setting-menu-container .settings-menu .active.li-users').should('have.length', 1);
+            });
+
+            it('should be table with actions', function () {
+                cy.get(`${selectors.manageUserTable} table td.actions`)
+            });
+        });
+
+        describe('Can delete user', () => {
+            it('Find and delete user', function() {
+                cy.deleteUser(users.user_cypress)
+            })
+        })
+    });
+});

--- a/views/cypress/utils/cleanup.js
+++ b/views/cypress/utils/cleanup.js
@@ -1,0 +1,54 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 Open Assessment Technologies SA ;
+ */
+
+import selectors from './selectors';
+import urls from './urls';
+
+/**
+ *
+ * @param {Object} user - Tries to delete user with given credentials as cleanup process
+ */
+
+export function tryToDeleteUser(user) {
+    cy.visit(urls.manageUsers);
+    cy.intercept('GET', `**/Users/**/*filterquery=${user.login}`).as('usersData');
+    cy.get(`${selectors.manageUserTable} .filter input[name=filter]`)
+        .type(`${user.login}{enter}`);
+    cy.wait('@usersData', {
+        requestTimeout: 10000
+    }).then((interception) => {
+        if (interception.response.body.data) {
+            cy.get(`${selectors.manageUserTable} table`)
+                .contains('td', user.login)
+                .siblings('.actions')
+                .find('.remove')
+                .should('not.have.class', 'disabled')
+                .click();
+
+            cy.get('.modal-body').then((body) => {
+                if (body.find('label[for=confirm]').length) {
+                    cy.get('label[for=confirm]').click();
+                }
+
+                cy.get(selectors.deleteConfirm).click();
+            });
+        } else {
+            return true;
+        }
+    });
+}

--- a/views/cypress/utils/cleanup.js
+++ b/views/cypress/utils/cleanup.js
@@ -19,9 +19,8 @@
 import selectors from './selectors';
 import urls from './urls';
 
-/**
- *
- * @param {Object} user - Tries to delete user with given credentials as cleanup process
+/** Tries to delete user with given credentials as cleanup process
+ * @param {Object} user - contains user details
  */
 
 export function tryToDeleteUser(user) {
@@ -51,4 +50,4 @@ export function tryToDeleteUser(user) {
             return true;
         }
     });
-}
+};

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -1,0 +1,11 @@
+export default {
+    deleteTest: '[data-context="resource"][data-action="removeNode"]',
+    deleteClass: '[data-context="resource"][data-action="removeNode"]',
+    addTest: '[data-context="resource"][data-action="instanciate"]',
+    addUserForm: 'form[action="/tao/Users/add"]',
+    // TODO: Replace update selector when data-testid attributes will be aded
+    manageUserTable: '#user-list',
+    testClassForm: 'form[action="/taoTests/Tests/editClassLabel"]',
+    deleteConfirm: '[data-control="ok"]',
+    root: '[data-uri="http://www.tao.lu/Ontologies/TAOTest.rdf#Test"]'
+};

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -3,6 +3,7 @@ export default {
     deleteClass: '[data-context="resource"][data-action="removeNode"]',
     addTest: '[data-context="resource"][data-action="instanciate"]',
     addUserForm: 'form[action="/tao/Users/add"]',
+    addTestTakerForm: 'form[action="/taoTestTaker/TestTaker/editSubject"]',
     // TODO: Replace update selector when data-testid attributes will be aded
     manageUserTable: '#user-list',
     testClassForm: 'form[action="/taoTests/Tests/editClassLabel"]',

--- a/views/cypress/utils/urls.js
+++ b/views/cypress/utils/urls.js
@@ -1,4 +1,8 @@
 export default {
     index: '/tao/Main/index',
-    login: '/tao/Main/login'
+    login: '/tao/Main/login',
+    addUser: '/tao/Main/index?structure=users&ext=tao&section=add_user',
+    manageUsers: '/tao/Main/index?structure=users&ext=tao&section=list_users',
+    mediaManager: '/tao/Main/index?structure=taoMediaManager&ext=taoMediaManager&section=media_manager',
+    testsManager: '/tao/Main/index?structure=tests&ext=taoTests&section=manage_tests'
 };

--- a/views/cypress/utils/urls.js
+++ b/views/cypress/utils/urls.js
@@ -4,5 +4,6 @@ export default {
     addUser: '/tao/Main/index?structure=users&ext=tao&section=add_user',
     manageUsers: '/tao/Main/index?structure=users&ext=tao&section=list_users',
     mediaManager: '/tao/Main/index?structure=taoMediaManager&ext=taoMediaManager&section=media_manager',
-    testsManager: '/tao/Main/index?structure=tests&ext=taoTests&section=manage_tests'
+    testsManager: '/tao/Main/index?structure=tests&ext=taoTests&section=manage_tests',
+    testTakersManager: '/tao/Main/index?structure=TestTaker&ext=taoTestTaker&section=manage_test_takers'
 };

--- a/views/cypress/utils/userRoles.js
+++ b/views/cypress/utils/userRoles.js
@@ -4,4 +4,4 @@ export default {
     itemAuthor: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAOItem_0_rdf_3_ItemAuthor",
     testAuthor: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAOItem_0_rdf_3_TestAuthor",
     testTaker: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_DeliveryRole"
-}
+};

--- a/views/cypress/utils/userRoles.js
+++ b/views/cypress/utils/userRoles.js
@@ -1,0 +1,7 @@
+export default {
+    dataAccessAdministrator: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_DacAdministrator",
+    globalManager: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_GlobalManagerRole",
+    itemAuthor: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAOItem_0_rdf_3_ItemAuthor",
+    testAuthor: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAOItem_0_rdf_3_TestAuthor",
+    testTaker: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_DeliveryRole"
+}

--- a/views/cypress/utils/userRoles.js
+++ b/views/cypress/utils/userRoles.js
@@ -1,7 +1,7 @@
 export default {
-    dataAccessAdministrator: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_DacAdministrator",
-    globalManager: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_GlobalManagerRole",
-    itemAuthor: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAOItem_0_rdf_3_ItemAuthor",
-    testAuthor: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAOItem_0_rdf_3_TestAuthor",
-    testTaker: "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_DeliveryRole"
+    dataAccessAdministrator: 'http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_DacAdministrator',
+    globalManager: 'http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_GlobalManagerRole',
+    itemAuthor: 'http_2_www_0_tao_0_lu_1_Ontologies_1_TAOItem_0_rdf_3_ItemAuthor',
+    testAuthor: 'http_2_www_0_tao_0_lu_1_Ontologies_1_TAOItem_0_rdf_3_TestAuthor',
+    testTaker: 'http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_DeliveryRole'
 };

--- a/views/cypress/utils/users.js
+++ b/views/cypress/utils/users.js
@@ -16,5 +16,11 @@ export default {
         "label": "User test author",
         "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
         "password": "User.12345"
+    },
+    user_test_taker: {
+        "login": "user_test_taker",
+        "label": "User test taker",
+        "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
+        "password": "User.12345"
     }
 };

--- a/views/cypress/utils/users.js
+++ b/views/cypress/utils/users.js
@@ -1,0 +1,20 @@
+export default {
+    user_cypress: {
+        "login": "user_cypress",
+        "label": "User cypress",
+        "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
+        "password": "User.12345"
+    },
+    user_item_author: {
+        "login": "user_item_author",
+        "label": "User item author",
+        "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
+        "password": "User.12345"
+    },
+    user_test_author: {
+        "login": "user_test_author",
+        "label": "User test author",
+        "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
+        "password": "User.12345"
+    }
+}

--- a/views/cypress/utils/users.js
+++ b/views/cypress/utils/users.js
@@ -1,26 +1,26 @@
 export default {
     user_cypress: {
-        "login": "user_cypress",
-        "label": "User cypress",
-        "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
-        "password": "User.12345"
+        'login': 'user_cypress',
+        'label': 'User cypress',
+        'language': 'http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US',
+        'password': 'User.12345'
     },
     user_item_author: {
-        "login": "user_item_author",
-        "label": "User item author",
-        "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
-        "password": "User.12345"
+        'login': 'user_item_author',
+        'label': 'User item author',
+        'language': 'http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US',
+        'password': 'User.12345'
     },
     user_test_author: {
-        "login": "user_test_author",
-        "label": "User test author",
-        "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
-        "password": "User.12345"
+        'login': 'user_test_author',
+        'label': 'User test author',
+        'language': 'http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US',
+        'password': 'User.12345'
     },
     user_test_taker: {
-        "login": "user_test_taker",
-        "label": "User test taker",
-        "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
-        "password": "User.12345"
+        'login': 'user_test_taker',
+        'label': 'User test taker',
+        'language': 'http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US',
+        'password': 'User.12345'
     }
 };

--- a/views/cypress/utils/users.js
+++ b/views/cypress/utils/users.js
@@ -17,4 +17,4 @@ export default {
         "language": "http_2_www_0_tao_0_lu_1_Ontologies_1_TAO_0_rdf_3_Langen-US",
         "password": "User.12345"
     }
-}
+};


### PR DESCRIPTION
**Jira task**
https://oat-sa.atlassian.net/browse/ADF-507

**Description**
Cover by e2e testing screens authentication into the platform with various users, having different user roles:

- Admin
- Item Author
- Test Author
- Test Taker

**How to run locally:**

- Add admin's credentials in env-local.json in root of cypress/
- Set local TAO address in cypress.json file (baseUrl option)
- npm run cy:open - to run in browser
- or npm run cy:run - for headless execution