### PR TITLE
[Fix] ADF-534 AdSearch: Last searching result doesn't refresh after re-login

### DIFF
--- a/views/js/controller/login.js
+++ b/views/js/controller/login.js
@@ -42,13 +42,6 @@ define([
     };
 
     /**
-     * Clear store from previous session
-     */
-    const clearStore = function clearStore() {
-        store('search').then(s => s.clear());
-    };
-
-    /**
      * The login controller
      */
     return {
@@ -65,7 +58,6 @@ define([
                 loadingBar.start();
             }).after('render', function() {
                 versionWarning.init();
-                clearStore();
                 loadingBar.stop();
             }).on('submit.login', function() {
                 loadingBar.start();

--- a/views/js/layout/search.js
+++ b/views/js/layout/search.js
@@ -29,8 +29,8 @@ define([
     'layout/actions/binder'
 ], function ($, actionManager, searchModal, store, context, urlHelper, binder) {
     /**
-     * Seach bar component for TAO action bar. It exposes
-     * the container, the indexeddb store that manages
+     * Seach bar component for TAO action bar. It clears the store and
+     * exposes the container, the indexeddb store that manages
      * search results, and @init function
      */
     const searchComponent = {
@@ -39,6 +39,7 @@ define([
         init() {
             store('search')
                 .then(store => {
+                    store.clear();
                     searchComponent.searchStore = store;
                     initializeEvents();
                     manageSearchStoreUpdate();


### PR DESCRIPTION
**Ticket**
https://oat-sa.atlassian.net/browse/ADF-534

**What was done**

It turns out that this issue still persisted due to the fact that the client has a different login/logout functionality then where the [previous fix](https://github.com/oat-sa/tao-core/pull/2801) was developed. So in order to completely fix this issue the logic to clear the search store has been moved from the login component to the search component itself. It will now be triggered on every initialisation.