### PR TITLE
Feature/AUT-800/Disable the text to wrap pictures

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -60,6 +60,7 @@ use oat\tao\scripts\install\RegisterValueCollectionServices;
 use oat\tao\scripts\install\SetClientLoggerConfig;
 use oat\tao\scripts\install\SetContainerService;
 use oat\tao\scripts\install\SetDefaultCSPHeader;
+use oat\tao\scripts\install\SetImageAligmentConfig;
 use oat\tao\scripts\install\SetLocaleNumbersConfig;
 use oat\tao\scripts\install\SetServiceFileStorage;
 use oat\tao\scripts\install\SetServiceState;
@@ -159,7 +160,8 @@ return [
             RegisterTaoUpdateEventListener::class,
             RegisterActionAccessControl::class,
             RegisterRtlLocales::class,
-            RegisterSearchServices::class
+            RegisterSearchServices::class,
+            SetImageAligmentConfig::class
         ],
     ],
     'update' => Updater::class,

--- a/migrations/Version202108051320552234_tao.php
+++ b/migrations/Version202108051320552234_tao.php
@@ -23,7 +23,10 @@ final class Version202108051320552234_tao extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addReport(
-            $this->propagate(new SetImageAligmentConfig())([false])
+            $this->propagate(
+                new SetImageAligmentConfig())(
+                    ['mediaAlignment' => false]
+            )
         );
     }
 

--- a/migrations/Version202108051320552234_tao.php
+++ b/migrations/Version202108051320552234_tao.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\install\SetImageAligmentConfig;
+use oat\tao\model\ClientLibConfigRegistry;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202108051320552234_tao extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Set Image Aligment disabled in Authoring';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->propagate(new SetImageAligmentConfig())([false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        ClientLibConfigRegistry::getRegistry()->remove('ui/image/ImgStateActive');
+    }
+}

--- a/migrations/Version202108051320552234_tao.php
+++ b/migrations/Version202108051320552234_tao.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Schema;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 use oat\tao\scripts\install\SetImageAligmentConfig;
 use oat\tao\model\ClientLibConfigRegistry;
-
+use common_report_Report as Report;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
@@ -22,11 +22,14 @@ final class Version202108051320552234_tao extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->propagate(new SetImageAligmentConfig())([false]);
+        $this->addReport(
+            $this->propagate(new SetImageAligmentConfig())([false])
+        );
     }
 
     public function down(Schema $schema): void
     {
         ClientLibConfigRegistry::getRegistry()->remove('ui/image/ImgStateActive');
+        $this->addReport(new Report(Report::TYPE_SUCCESS, 'Remove configurations for ui/image/ImgStateActive'));
     }
 }

--- a/scripts/install/SetImageAligmentConfig.php
+++ b/scripts/install/SetImageAligmentConfig.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+namespace oat\tao\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use common_ext_ExtensionsManager as ExtensionsManager;
+use common_report_Report as Report;
+use oat\tao\model\ClientLibConfigRegistry;
+
+/**
+ * Set Image Aligment disabled in Authoring
+ */
+class SetImageAligmentConfig extends InstallAction
+{
+    /**
+     * @inheritdoc
+     *
+     * Set Image Aligment disabled in Authoring
+     *
+     * @param mixed $params
+     *
+     * @return Report
+     */
+    public function __invoke($params = [false])
+    {
+        ClientLibConfigRegistry::getRegistry()->register(
+            'ui/image/ImgStateActive',
+            [
+                'mediaAlignment' => $params[0]
+            ]
+        );
+
+        return new Report(Report::TYPE_SUCCESS, 'Set Image Aligment disabled in Authoring');
+    }
+}

--- a/scripts/install/SetImageAligmentConfig.php
+++ b/scripts/install/SetImageAligmentConfig.php
@@ -39,7 +39,7 @@ class SetImageAligmentConfig extends InstallAction
      *
      * @return Report
      */
-    public function __invoke($params = [false])
+    public function __invoke($params = ['mediaAlignment' => false])
     {
         ClientLibConfigRegistry::getRegistry()->register(
             'ui/image/ImgStateActive',

--- a/scripts/install/SetImageAligmentConfig.php
+++ b/scripts/install/SetImageAligmentConfig.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 namespace oat\tao\scripts\install;
@@ -48,6 +48,6 @@ class SetImageAligmentConfig extends InstallAction
             ]
         );
 
-        return new Report(Report::TYPE_SUCCESS, 'Set Image Aligment disabled in Authoring');
+        return new Report(Report::TYPE_SUCCESS, 'Set Image Aligment plugin '.($params[0] ? 'enabled' : 'disabled').' in Authoring');
     }
 }

--- a/scripts/install/SetImageAligmentConfig.php
+++ b/scripts/install/SetImageAligmentConfig.php
@@ -48,6 +48,6 @@ class SetImageAligmentConfig extends InstallAction
             ]
         );
 
-        return new Report(Report::TYPE_SUCCESS, 'Set Image Aligment plugin '.($params[0] ? 'enabled' : 'disabled').' in Authoring');
+        return new Report(Report::TYPE_SUCCESS, 'Set Image Aligment plugin '.($params['mediaAlignment'] ? 'enabled' : 'disabled').' in Authoring');
     }
 }

--- a/scripts/install/SetImageAligmentConfig.php
+++ b/scripts/install/SetImageAligmentConfig.php
@@ -44,7 +44,7 @@ class SetImageAligmentConfig extends InstallAction
         ClientLibConfigRegistry::getRegistry()->register(
             'ui/image/ImgStateActive',
             [
-                'mediaAlignment' => $params[0]
+                'mediaAlignment' => $params['mediaAlignment']
             ]
         );
 

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -703,9 +703,8 @@
             "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.29.0.tgz",
-            "integrity": "sha512-+jbRmRi6D5UrY/21DuZRET9lxKYNRWHHELs5Upw66auN0QNc5w3sS9rovSwpcUhTQoDKXZKS4lLzYSTmBJlQEw=="
+            "version": "git://github.com/oat-sa/tao-core-ui-fe.git#65311c8a15cbb6888294ec4e52b2c82ef5db6204",
+            "from": "git://github.com/oat-sa/tao-core-ui-fe.git#feature/AUT-800/image-aligment-flag"
         },
         "@samverschueren/stream-to-observable": {
             "version": "0.3.1",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -703,8 +703,9 @@
             "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "git://github.com/oat-sa/tao-core-ui-fe.git#65311c8a15cbb6888294ec4e52b2c82ef5db6204",
-            "from": "git://github.com/oat-sa/tao-core-ui-fe.git#feature/AUT-800/image-aligment-flag"
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.30.0.tgz",
+            "integrity": "sha512-WuztyBzJEzLWBFg5d0ccxF1lWfmKQ4AbYxOWRFcAL/bNpQew7S2Y6ny64kypUvLfgT+lnka39/cixyNDekEkCQ=="
         },
         "@samverschueren/stream-to-observable": {
             "version": "0.3.1",

--- a/views/package.json
+++ b/views/package.json
@@ -18,7 +18,7 @@
         "@oat-sa/tao-core-libs": "0.4.3",
         "@oat-sa/tao-core-sdk": "1.15.0",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
-        "@oat-sa/tao-core-ui": "1.29.0",
+        "@oat-sa/tao-core-ui": "git://github.com/oat-sa/tao-core-ui-fe.git#feature/AUT-800/image-aligment-flag",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",

--- a/views/package.json
+++ b/views/package.json
@@ -18,7 +18,7 @@
         "@oat-sa/tao-core-libs": "0.4.3",
         "@oat-sa/tao-core-sdk": "1.15.0",
         "@oat-sa/tao-core-shared-libs": "1.0.3",
-        "@oat-sa/tao-core-ui": "git://github.com/oat-sa/tao-core-ui-fe.git#feature/AUT-800/image-aligment-flag",
+        "@oat-sa/tao-core-ui": "1.30.0",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-800

Disable `mediaAlignment` plugin  by configuration.

**After merge https://github.com/oat-sa/tao-core-ui-fe/pull/336 package.json and package-lock.json should be updated.**

How to test:
- use branch, run `php ./tao/scripts/taoUpdate.php`
- check that mediaAlignment plugin is disabled
- set in `config/tao/client_lib_config_registry.conf.php` configs
```
        'ui/image/ImgStateActive' => array(
            'mediaAlignment' => true
        ),
```
- check that mediaAlignment plugin is displayed
- remove config, check that by default mediaAlignment plugin is disabled

![image](https://user-images.githubusercontent.com/25976342/128342118-05339ef6-01f4-402d-a411-e79eb8d86a52.png) ![image](https://user-images.githubusercontent.com/25976342/128341966-1d5e7ec4-2d2d-4d29-8bb2-10b462f71030.png) 
