### PR TITLE
Clicking 'Save' in Manage schema removes the chosen List from the added property

### DIFF
--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -320,11 +320,7 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
         $groups = $myForm->getGroups();
         
         foreach ($data['properties'] as $prop) {
-            if (empty($prop['range'])) {
-                continue;
-            }
-
-            if (empty($prop['range']) && empty($prop['uri'])) {
+            if (empty($prop['range']) || empty($prop['uri'])) {
                 continue;
             }
 

--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -304,33 +304,41 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
                 //save all properties values
                 if (isset($data['properties'])) {
                     $this->saveProperties($data);
-                    
-                    $elementRangeArray = [];
-                    $groups = $myForm->getGroups();
-                    if (isset($data['properties'])) {
-                        foreach ($data['properties'] as $prop) {
-                            if (!empty($prop['range'])) {
-                                $index = strstr($groups['property_' . $prop['uri']]['elements'][0], '_', true);
-                                $elementRangeArray[$index . '_range_list'] = $prop['range'];
-                            }
-                        }
-                    }
-                    
-                    foreach ($myForm->getElements() as $element) {
-                        if (
-                            $element instanceof tao_helpers_form_elements_xhtml_Combobox
-                            && array_key_exists($element->getName(), $elementRangeArray)
-                        ) {
-                            $element->setValue($elementRangeArray[$element->getName()]);
-                        }
-                        $elements[] = $element;
-                    }
-
-                    $myForm->setElements($elements);
+                    $this->populateSubmittedProperties($myForm, $data);
                 }
             }
         }
         return $myForm;
+    }
+
+    private function populateSubmittedProperties($myForm, $data): void
+    {
+        $elementRangeArray = [];
+        $groups = $myForm->getGroups();
+        if (isset($data['properties'])) {
+            foreach ($data['properties'] as $prop) {
+                if (!empty($prop['range'])) {
+                    $elementUri = $groups['property_' . $prop['uri']]['elements'][0];
+                    if (isset($elementUri)) {
+                        $index = strstr($elementUri, '_', true);
+                        $elementRangeArray[$index . '_range_list'] = $prop['range'];
+                    }
+                }
+            }
+        }
+
+        $elements = [];
+        foreach ($myForm->getElements() as $element) {
+            if (
+                $element instanceof tao_helpers_form_elements_xhtml_Combobox
+                && array_key_exists($element->getName(), $elementRangeArray)
+            ) {
+                $element->setValue($elementRangeArray[$element->getName()]);
+            }
+            $elements[] = $element;
+        }
+
+        $myForm->setElements($elements);
     }
 
     /**

--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -281,6 +281,7 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
     public function getClassForm(core_kernel_classes_Class $class): tao_helpers_form_Form
     {
         $data = $this->getRequestParameters();
+        // print_r($data);die;
         $classData = $this->extractClassData($data);
         $propertyData = $this->extractPropertyData($data);
         $formContainer = new tao_actions_form_Clazz($class, $classData, $propertyData, $this->isElasticSearchEnabled());
@@ -313,17 +314,25 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
 
     private function populateSubmittedProperties($myForm, $data): void
     {
+        if (empty($data['properties'])) {
+            return;
+        }
         $elementRangeArray = [];
         $groups = $myForm->getGroups();
-        if (isset($data['properties'])) {
-            foreach ($data['properties'] as $prop) {
-                if (!empty($prop['range'])) {
-                    $elementUri = $groups['property_' . $prop['uri']]['elements'][0];
-                    if (isset($elementUri)) {
-                        $index = strstr($elementUri, '_', true);
-                        $elementRangeArray[$index . '_range_list'] = $prop['range'];
-                    }
-                }
+        
+        foreach ($data['properties'] as $prop) {
+            if (empty($prop['range'])) {
+                continue;
+            }
+            if (empty($prop['range']) && empty($prop['uri'])) {
+                continue;
+            }
+
+            $elementUri = $groups['property_' . $prop['uri']]['elements'][0] ?? null;
+
+            if (isset($elementUri)) {
+                $index = strstr($elementUri, '_', true);
+                $elementRangeArray[$index . '_range_list'] = $prop['range'];
             }
         }
 

--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -304,6 +304,29 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
                 //save all properties values
                 if (isset($data['properties'])) {
                     $this->saveProperties($data);
+                    
+                    $elementRangeArray = [];
+                    $groups = $myForm->getGroups();
+                    if (isset($data['properties'])) {
+                        foreach ($data['properties'] as $prop) {
+                            if ($prop['range'] != "") {
+                                $index = strstr($groups['property_' . $prop["uri"]]['elements'][0], '_', true);
+                                $elementRangeArray[$index . "_range_list"] = $prop["range"];
+                            }
+                        }
+                    }
+                    
+                    foreach ($myForm->getElements() as $element) {
+                        if (
+                            $element instanceof tao_helpers_form_elements_xhtml_Combobox &&
+                            array_key_exists($element->getName(), $elementRangeArray)
+                        ) {
+                            $element->setValue($elementRangeArray[$element->getName()]);
+                        }
+                        $elements[] = $element;
+                    }
+
+                    $myForm->setElements($elements);
                 }
             }
         }

--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -309,17 +309,17 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
                     $groups = $myForm->getGroups();
                     if (isset($data['properties'])) {
                         foreach ($data['properties'] as $prop) {
-                            if ($prop['range'] != "") {
-                                $index = strstr($groups['property_' . $prop["uri"]]['elements'][0], '_', true);
-                                $elementRangeArray[$index . "_range_list"] = $prop["range"];
+                            if (!empty($prop['range'])) {
+                                $index = strstr($groups['property_' . $prop['uri']]['elements'][0], '_', true);
+                                $elementRangeArray[$index . '_range_list'] = $prop['range'];
                             }
                         }
                     }
                     
                     foreach ($myForm->getElements() as $element) {
                         if (
-                            $element instanceof tao_helpers_form_elements_xhtml_Combobox &&
-                            array_key_exists($element->getName(), $elementRangeArray)
+                            $element instanceof tao_helpers_form_elements_xhtml_Combobox
+                            && array_key_exists($element->getName(), $elementRangeArray)
                         ) {
                             $element->setValue($elementRangeArray[$element->getName()]);
                         }

--- a/actions/class.PropertiesAuthoring.php
+++ b/actions/class.PropertiesAuthoring.php
@@ -281,7 +281,6 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
     public function getClassForm(core_kernel_classes_Class $class): tao_helpers_form_Form
     {
         $data = $this->getRequestParameters();
-        // print_r($data);die;
         $classData = $this->extractClassData($data);
         $propertyData = $this->extractPropertyData($data);
         $formContainer = new tao_actions_form_Clazz($class, $classData, $propertyData, $this->isElasticSearchEnabled());
@@ -324,6 +323,7 @@ class tao_actions_PropertiesAuthoring extends tao_actions_CommonModule
             if (empty($prop['range'])) {
                 continue;
             }
+
             if (empty($prop['range']) && empty($prop['uri'])) {
                 continue;
             }


### PR DESCRIPTION
**Relates to** https://oat-sa.atlassian.net/browse/ADF-550
**Description**
Whenever user adds a property in manage schema, choose it's type then sets the list for it and clicks 'Save' first time, list set for this property is removed and user has to set it up again in order to save added property. Second click on 'Save' button saves the list.