### PR TITLE
prevent perpetual loading when accessing taskQueue while loading othe…

### DIFF
--- a/views/templates/blocks/header-main-navi.tpl
+++ b/views/templates/blocks/header-main-navi.tpl
@@ -123,7 +123,7 @@ $userLabel    = get_data('userLabel');
                         <a id="<?= $entry->getId() ?>" <?php
                             if (!is_null($entry->getBinding())): ?> href="#" data-action="<?= $entry->getBinding() ?>"
                             <?php else : ?>
-                            href="<?= $entry->getUrl() ?>"
+                            href="<?php if($entry->getId()!= 'taskqueue'): ?><?= $entry->getUrl() ?><?php else : ?>#<?php endif ?>"
                             <?php endif ?> title="<?= __($entry->getName()) ?>">
 
                             <?= is_null($entry->getIcon()) ? '' : Layout::renderIcon($entry->getIcon(), 'icon-extension') ?>

--- a/views/templates/blocks/header-main-navi.tpl
+++ b/views/templates/blocks/header-main-navi.tpl
@@ -121,13 +121,11 @@ $userLabel    = get_data('userLabel');
                     : 'li-' . $entry->getId();?>
                     <li class="<?= $className ?>">
                         <a id="<?= $entry->getId() ?>" <?php
-                            if (!is_null($entry->getBinding())): ?> href="#" data-action="<?= $entry->getBinding() ?>"
-                            <?php else : ?>
-                            href="<?php if($entry->getId()!= 'taskqueue'): ?><?= $entry->getUrl() ?><?php else : ?>#<?php endif ?>"
-                            <?php endif ?> title="<?= __($entry->getName()) ?>">
 
+                            if (!is_null($entry->getBinding())): ?> href="#" data-action="<?= $entry->getBinding() ?>"<?php
+                                else : ?> href="<?= $entry->getId()!= 'taskqueue' ? $entry->getUrl() : "#" ?>"<?php
+                            endif ?> title="<?= __($entry->getName()) ?>">
                             <?= is_null($entry->getIcon()) ? '' : Layout::renderIcon($entry->getIcon(), 'icon-extension') ?>
-
                             <?php $description = $entry->getDescription();
                             if ($description): ?>
                             <?= __($description) ?>


### PR DESCRIPTION
**Related Issue:** https://oat-sa.atlassian.net/browse/AUT-4
Perpetual loading when pressing an icon in the header and then the Task Queue icon before the previous one finishes charging. It creates an infinite loading loop 

**SETPS to test:**

- Checkout to branch fix/AUT-4/Perpetual-loading-when-env-accesses-section=taskqueue
- login the env
- press any menu icon (extensions manager is a good choice for proximity).
- click on task queue before the previous extension has finished loading.
- try this few times with different icons.
- Navegation should be normal with no issues.

**Actual result**: it creates an url that doesn't exist and therfore an infinite loop.
**Expected result:** You can navegate from one extension to other without any loading issues.

Testing env: http://test-silvia.playground.kitchen.it.taocloud.org:41441/