### PR TITLE
Feature/ADF-531/Configure "Depends on property" field to show only remote list properties

### DIFF
--- a/migrations/Version202108170642002234_tao.php
+++ b/migrations/Version202108170642002234_tao.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use oat\oatbox\reporting\Report;
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+final class Version202108170642002234_tao extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Synchronize models to add new "Depends on property" class property';
+    }
+
+    public function up(Schema $schema): void
+    {
+        OntologyUpdater::syncModels();
+
+        $this->addReport(Report::createSuccess('Models were successfully synchronized'));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addReport(Report::createWarning('Nothing to execute'));
+    }
+}

--- a/models/classes/Lists/Business/Service/RemoteSourcedListOntology.php
+++ b/models/classes/Lists/Business/Service/RemoteSourcedListOntology.php
@@ -29,5 +29,7 @@ class RemoteSourcedListOntology
     public const PROPERTY_ITEM_LABEL_PATH = 'http://www.tao.lu/Ontologies/TAO.rdf#RemoteListItemLabelPath';
     public const PROPERTY_DEPENDENCY_ITEM_URI_PATH = 'http://www.tao.lu/Ontologies/TAO.rdf#RemoteListDependencyItemUriPath';
     public const PROPERTY_LIST_TYPE = 'http://www.tao.lu/Ontologies/TAO.rdf#ListType';
+    public const PROPERTY_DEPENDS_ON_PROPERTY = 'http://www.tao.lu/Ontologies/TAO.rdf#DependsOnProperty';
+
     public const LIST_TYPE_REMOTE = 'http://www.tao.lu/Ontologies/TAO.rdf#ListRemote';
 }

--- a/models/classes/Lists/DataAccess/Repository/DependsOnPropertyRepository.php
+++ b/models/classes/Lists/DataAccess/Repository/DependsOnPropertyRepository.php
@@ -23,16 +23,41 @@ declare(strict_types=1);
 namespace oat\tao\model\Lists\DataAccess\Repository;
 
 use core_kernel_classes_Class;
+use oat\tao\model\TaoOntology;
 use core_kernel_classes_Property;
+use tao_helpers_form_GenerisFormFactory;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\Lists\Business\Domain\DependsOnProperty;
+use oat\tao\model\Lists\Business\Service\RemoteSourcedListOntology;
 use oat\tao\model\Lists\Business\Domain\DependsOnPropertyCollection;
-use tao_helpers_form_GenerisFormFactory;
 
 class DependsOnPropertyRepository extends ConfigurableService
 {
     /** @var core_kernel_classes_Property[] */
     private $properties;
+
+    /** @var core_kernel_classes_Class[] */
+    private $ranges = [];
+
+    /** @var core_kernel_classes_Class */
+    private $listsClass;
+
+    /** @var core_kernel_classes_Property */
+    private $listTypeProperty;
+
+    /** @var core_kernel_classes_Property */
+    private $dependsOnProperty;
+
+    public function __construct($options = [])
+    {
+        parent::__construct($options);
+
+        $this->listsClass = new core_kernel_classes_Class(TaoOntology::CLASS_URI_LIST);
+        $this->listTypeProperty = new core_kernel_classes_Property(RemoteSourcedListOntology::PROPERTY_LIST_TYPE);
+        $this->dependsOnProperty = new core_kernel_classes_Property(
+            RemoteSourcedListOntology::PROPERTY_DEPENDS_ON_PROPERTY
+        );
+    }
 
     public function withProperties(array $properties)
     {
@@ -46,7 +71,7 @@ class DependsOnPropertyRepository extends ConfigurableService
         /** @var core_kernel_classes_Property $property */
         $property = $options['property'];
 
-        if (!$property->getDomain()->count()) {
+        if (!$property->getDomain()->count() || !$this->isRemoteListProperty($property)) {
             return $collection;
         }
 
@@ -54,17 +79,16 @@ class DependsOnPropertyRepository extends ConfigurableService
         $class = $property->getDomain()->get(0);
 
         /** @var core_kernel_classes_Property $property */
-        foreach ($this->getProperties($class) as $prop) {
-            /*
-             * @TODO Show only properties, which relates to remote list
-             * @TODO Do not show properties that already depend on the primary property
-             *      A secondary prop cannot have another secondary prop.
-             */
-            if ($property->getUri() === $prop->getUri()) {
+        foreach ($this->getProperties($class) as $classProperty) {
+            if (
+                $property->getUri() === $classProperty->getUri()
+                || !$this->isRemoteListProperty($classProperty)
+                || $this->isDependentProperty($classProperty)
+            ) {
                 continue;
             }
 
-            $collection->append(new DependsOnProperty($prop));
+            $collection->append(new DependsOnProperty($classProperty));
         }
 
         return $collection;
@@ -73,5 +97,38 @@ class DependsOnPropertyRepository extends ConfigurableService
     private function getProperties(core_kernel_classes_Class $class): array
     {
         return $this->properties ?? tao_helpers_form_GenerisFormFactory::getClassProperties($class);
+    }
+
+    private function isRemoteListProperty(core_kernel_classes_Property $property): bool
+    {
+        $range = $this->getPropertyRange($property);
+
+        if ($range === null || !$range->isSubClassOf($this->listsClass)) {
+            return false;
+        }
+
+        $propertyType = $range->getOnePropertyValue($this->listTypeProperty);
+
+        if ($propertyType === null || $propertyType->getUri() !== RemoteSourcedListOntology::LIST_TYPE_REMOTE) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isDependentProperty(core_kernel_classes_Property $property): bool
+    {
+        return $property->getOnePropertyValue($this->dependsOnProperty) !== null;
+    }
+
+    private function getPropertyRange(core_kernel_classes_Property $property): ?core_kernel_classes_Class
+    {
+        $propertyUri = $property->getUri();
+
+        if (!isset($this->ranges[$propertyUri])) {
+            $this->ranges[$propertyUri] = $property->getRange();
+        }
+
+        return $this->ranges[$propertyUri];
     }
 }

--- a/models/ontology/tao.rdf
+++ b/models/ontology/tao.rdf
@@ -62,6 +62,13 @@
       <rdfs:comment xml:lang="en-US"><![CDATA[Remote list dependency source uri path]]></rdfs:comment>
       <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#List"/>
   </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAO.rdf#DependsOnProperty">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Depends on Property]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Depends on Property]]></rdfs:comment>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#List"/>
+  </rdf:Description>
 
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAO.rdf#UpdatedAt">
       <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#TAOObject"/>


### PR DESCRIPTION
**Relates to:** _[ADF-531](https://oat-sa.atlassian.net/browse/ADF-531)_

---

**Changes:**
* Added new class property `Depends on property`
* `Depends on property` field configured to display only properties related to the remote list.

---

❗❗❗
**_As we didn't create and use new endpoint to receive remote lists dependent properties - new property will not display `Depends on property` field until `Manage Schema` form will not be reloaded.  
This was done to disable this field for non-`Remote lists` properties._**
❗❗❗