### PR TITLE
feat: Use Generis search for LTI tabs in settings section

### DIFF
--- a/models/classes/TaoOntology.php
+++ b/models/classes/TaoOntology.php
@@ -36,6 +36,10 @@ interface TaoOntology
     const CLASS_URI_MANAGEMENT_ROLE = 'http://www.tao.lu/Ontologies/TAO.rdf#ManagementRole';
     const CLASS_URI_WORKER_ROLE = 'http://www.tao.lu/Ontologies/TAO.rdf#WorkerRole';
     const CLASS_URI_TAO_USER = 'http://www.tao.lu/Ontologies/TAO.rdf#User';
+    const CLASS_URI_LTI_CONSUMER = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIConsumer';
+    const CLASS_URI_LTI_PROVIDER = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#LTIProvider';
+    const CLASS_URI_LTI_PLATFORM = 'http://www.tao.lu/Ontologies/TAOLTI.rdf#Platform';
+
     const PROPERTY_UPDATED_AT = 'http://www.tao.lu/Ontologies/TAO.rdf#UpdatedAt';
     const PROPERTY_LIST_LEVEL = 'http://www.tao.lu/Ontologies/TAO.rdf#level';
     const PROPERTY_USER_FIRST_TIME = 'http://www.tao.lu/Ontologies/TAO.rdf#FirstTimeInTao';

--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -41,6 +41,9 @@ class SearchProxy extends ConfigurableService implements Search
     private const GENERIS_SEARCH_WHITELIST = [
         GenerisRdf::CLASS_ROLE,
         TaoOntology::CLASS_URI_TAO_USER,
+        TaoOntology::CLASS_URI_LTI_CONSUMER,
+        TaoOntology::CLASS_URI_LTI_PROVIDER,
+        TaoOntology::CLASS_URI_LTI_PLATFORM,
     ];
 
     private const DISABLE_URI_SEARCH_FOR_ROOT_CLASSES = [


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/ADF-242

Description
When user makes a search query on any tab (having AdvSearch) from Settings (e.g. Trees, Remote environments, LTI Consumers/Providers), there are no results found even when searching is done by the exact Label match.