### PR TITLE
Backport/tr 1810/add option to disable media player preview

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -62,7 +62,7 @@ return [
     'label' => 'TAO Base',
     'description' => 'TAO meta-extension',
     'license' => 'GPL-2.0',
-    'version' => '45.2.1',
+    'version' => '45.2.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'generis' => '>=13.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -39,9 +39,8 @@
             "integrity": "sha512-HAMEy5L43+Rq3oJd+Sa1cCdYbO9gwBwSlIEs+H4HuGhv8oCBj28KCz0GT2KNllqem/13fIgvfytXVdOX0E08+A=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.6.0.tgz",
-            "integrity": "sha512-kh2iP4c0QpNwhXrdN4UBVd1B3ej+xz0KsxSnprMWJ8wEFv6EhkWebOhPpStRzzTUNUQOrj9jlacKcgvcEeSJ4Q=="
+            "version": "github:oat-sa/tao-core-ui-fe#6d0fdfcba2d279b8f96fcd25726ce7553d845e33",
+            "from": "github:oat-sa/tao-core-ui-fe#backport/TR-1810/add-option-to-disable-media-player-preview"
         },
         "amdefine": {
             "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^0.4.2",
         "@oat-sa/tao-core-sdk": "1.3.0",
         "@oat-sa/tao-core-shared-libs": "1.0.2",
-        "@oat-sa/tao-core-ui": "1.6.0",
+        "@oat-sa/tao-core-ui": "github:oat-sa/tao-core-ui-fe#backport/TR-1810/add-option-to-disable-media-player-preview",
         "async": "0.2.10",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-1810

Requires: 
 - [ ] https://github.com/oat-sa/tao-core-ui-fe/pull/347
 - [ ] Once the companion PR is merged, update the package.json

Backport of #3070  to Sprint 134.5.100

Rework the media player, and add new features:
- option `preview`, active by default: allows to preview the media (especially video). When disabled, the player shows a blank placeholder with a play button and the duration is unknown.
![image](https://user-images.githubusercontent.com/1500098/130093800-fdf8c930-e9c7-4204-9916-c2b9a58c7c2e.png)
- option `debug`, disabled by default: allows to add some verbosity in the console about the player's behavior (essentially at the level of the player implementation).
See the companion PR for more info

**How to test:**
- look at the companion PR