### PR TITLE
Counter service

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,6 +41,7 @@ use oat\tao\scripts\install\RegisterClassPropertiesChangedEvent;
 use oat\tao\scripts\install\RegisterClassPropertiesChangedEventListener;
 use oat\tao\scripts\install\RegisterClassPropertyRemovedEvent;
 use oat\tao\scripts\install\RegisterClassPropertyRemovedListener;
+use oat\tao\scripts\install\RegisterCounterService;
 use oat\tao\scripts\install\RegisterDataAccessControlChangedEvent;
 use oat\tao\scripts\install\RegisterDataAccessControlChangedListener;
 use oat\tao\scripts\install\RegisterEvents;
@@ -161,7 +162,8 @@ return [
             RegisterActionAccessControl::class,
             RegisterRtlLocales::class,
             RegisterSearchServices::class,
-            SetImageAligmentConfig::class
+            SetImageAligmentConfig::class,
+            RegisterCounterService::class,
         ],
     ],
     'update' => Updater::class,

--- a/migrations/Version202108081928492234_tao.php
+++ b/migrations/Version202108081928492234_tao.php
@@ -1,38 +1,28 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace oat\tao\migrations;
 
-use common_Exception;
 use Doctrine\DBAL\Schema\Schema;
 use oat\oatbox\service\exception\InvalidServiceManagerException;
-use oat\oatbox\service\ServiceNotFoundException;
 use oat\tao\model\counter\CounterService;
 use oat\tao\scripts\install\RegisterCounterService;
 use oat\tao\scripts\tools\migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version202108081928492234_tao extends AbstractMigration
 {
-
     public function getDescription(): string
     {
         return 'Register ' . CounterService::class;
     }
 
-    /**
-     * @param Schema $schema
-     */
     public function up(Schema $schema): void
     {
         $this->propagate(new RegisterCounterService)();
     }
 
     /**
-     * @param Schema $schema
      * @throws InvalidServiceManagerException
      */
     public function down(Schema $schema): void

--- a/migrations/Version202108081928492234_tao.php
+++ b/migrations/Version202108081928492234_tao.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use common_Exception;
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+use oat\oatbox\service\ServiceNotFoundException;
+use oat\tao\model\counter\CounterService;
+use oat\tao\scripts\install\RegisterCounterService;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version202108081928492234_tao extends AbstractMigration
+{
+
+    public function getDescription(): string
+    {
+        return 'Register ' . CounterService::class;
+    }
+
+    /**
+     * @param Schema $schema
+     * @throws InvalidServiceManagerException
+     * @throws common_Exception
+     * @throws ServiceNotFoundException
+     */
+    public function up(Schema $schema): void
+    {
+        $registerCounterService = new RegisterCounterService();
+        $this->propagate($registerCounterService);
+        $registerCounterService([]);
+    }
+
+    /**
+     * @param Schema $schema
+     * @throws InvalidServiceManagerException
+     */
+    public function down(Schema $schema): void
+    {
+        $this->getServiceManager()->unregister(CounterService::SERVICE_ID);
+    }
+}

--- a/migrations/Version202108081928492234_tao.php
+++ b/migrations/Version202108081928492234_tao.php
@@ -25,15 +25,10 @@ final class Version202108081928492234_tao extends AbstractMigration
 
     /**
      * @param Schema $schema
-     * @throws InvalidServiceManagerException
-     * @throws common_Exception
-     * @throws ServiceNotFoundException
      */
     public function up(Schema $schema): void
     {
-        $registerCounterService = new RegisterCounterService();
-        $this->propagate($registerCounterService);
-        $registerCounterService([]);
+        $this->propagate(new RegisterCounterService)();
     }
 
     /**

--- a/models/classes/counter/CounterService.php
+++ b/models/classes/counter/CounterService.php
@@ -170,10 +170,11 @@ class CounterService extends ConfigurableService
 
     /**
      * @param string $eventFqcn
+     * @param string|null $keyCallbackValue
      * @return int
      * @throws CounterServiceException
      */
-    public function get(string $eventFqcn): int
+    public function get(string $eventFqcn, ?string $keyCallbackValue = null): int
     {
         return (int)$this->getPersistence()->get($this->buildKey($eventFqcn));
     }

--- a/models/classes/counter/CounterService.php
+++ b/models/classes/counter/CounterService.php
@@ -24,7 +24,11 @@ namespace oat\tao\model\counter;
 
 use common_Exception;
 use common_persistence_KeyValuePersistence;
+use oat\oatbox\event\Event;
+use oat\oatbox\event\EventManager;
 use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+use oat\oatbox\service\ServiceNotFoundException;
 
 /**
  *
@@ -34,6 +38,10 @@ class CounterService extends ConfigurableService
     public const SERVICE_ID = 'tao/CounterService';
     public const OPTION_PERSISTENCE = 'persistence';
     public const OPTION_COUNTER_KEY_PREFIX = 'counterKeyPrefix';
+    public const OPTION_EVENTS = 'events';
+    public const DEFAULT_PREFIX = 'tao:counter:';
+    protected const OPTION_CALLBACK = 'keyCallbackMethod';
+    protected const OPTION_SHORT_NAME = 'shortName';
 
     /**
      * @return common_persistence_KeyValuePersistence
@@ -48,58 +56,147 @@ class CounterService extends ConfigurableService
             $msg = "Persistence '${persistenceId}' must be an instance of '";
             $msg .= common_persistence_KeyValuePersistence::class . "', ";
             $msg .= get_class($persistence) . ' persistence given.';
-            throw new CounterServiceException($msg);
+            throw new CounterServiceException($msg, CounterServiceException::CODE_INVALID_PERSISTENCE);
         }
 
         return $persistence;
     }
 
     /**
-     * @param string $counter
-     * @param int $value
+     * @param string $eventFqcn
+     * @param string $shortName
+     * @param string|null $keyCallbackMethod
+     * @throws CounterServiceException
+     * @throws InvalidServiceManagerException
+     * @throws ServiceNotFoundException
+     */
+    public function attach(string $eventFqcn, string $shortName, ?string $keyCallbackMethod = null): void
+    {
+        if (class_exists($eventFqcn)) {
+            /** @var EventManager $eventManager */
+            $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+            $eventManager->attach(
+                $eventFqcn,
+                [
+                    self::SERVICE_ID,
+                    'increment'
+                ]
+            );
+
+            $eventOptions = $this->getOption(self::OPTION_EVENTS);
+            $eventOptions[$eventFqcn] = [
+                self::OPTION_CALLBACK => $keyCallbackMethod,
+                self::OPTION_SHORT_NAME => $shortName
+            ];
+            $this->setOption(self::OPTION_EVENTS, $eventOptions);
+
+            $this->logDebug("CounterService now listening to events with FQCN '${eventFqcn}'");
+        } else {
+            $msg = "No event class found with FQCN '${eventFqcn}' in available code base.";
+            throw new CounterServiceException($msg, CounterServiceException::CODE_UNKNOWN_EVENT_TYPE);
+        }
+    }
+
+    /**
+     * @param string $eventFqcn
+     * @throws InvalidServiceManagerException|CounterServiceException
+     */
+    public function detach(string $eventFqcn): void
+    {
+        $eventOptions = $this->getOption(self::OPTION_EVENTS);
+        if (array_key_exists($eventFqcn, $eventOptions)) {
+            /** @var EventManager $eventManager */
+            $eventManager = $this->getServiceManager(EventManager::SERVICE_ID);
+            $eventManager->detach(
+                $eventFqcn,
+                [
+                    self::SERVICE_ID,
+                    'increment'
+                ]
+            );
+
+            unset($eventOptions[$eventFqcn]);
+
+            $this->setOption(self::OPTION_EVENTS, $eventOptions);
+
+            $this->logDebug("CounterService not listening anymore to events with FQCN '${eventFqcn}'.");
+        } else {
+            $msg = "No event with FQCN '${eventFqcn}' already attached for counting.";
+            throw new CounterServiceException($msg, CounterServiceException::CODE_UNKNOWN_EVENT_TYPE);
+        }
+    }
+
+    /**
+     * @param Event $event
      * @throws CounterServiceException
      */
-    public function increment(string $counter, int $value = 1): void
+    public function increment(Event $event): void
     {
-        $this->getPersistence()->incr($this->buildPrefix($counter));
+        $eventOptions = $this->getOption(self::OPTION_EVENTS);
+        $eventFqcn = get_class($event);
+
+        if (array_key_exists($eventFqcn, $eventOptions)) {
+            $eventOption = $eventOptions[$eventFqcn];
+            $keyCallbackMethod = $eventOption[self::OPTION_CALLBACK];
+            $keyCallbackValue = null;
+
+            if (!empty($keyCallbackMethod)) {
+                $keyCallbackValue = call_user_func([$event, $keyCallbackMethod]);
+            }
+
+            $this->getPersistence()->incr(
+                $this->buildKey(
+                    $eventFqcn,
+                    $keyCallbackValue
+                )
+            );
+        } else {
+            $msg = "Configuration Violation. No event with FQCN '${eventFqcn}' registered while incrementing.";
+            throw new CounterServiceException($msg);
+        }
     }
 
     /**
-     * @param string $counter
-     * @param int $value
+     * @param string $eventFqcn
+     * @param int|null $value
+     * @param string|null $keyCallbackValue
      * @throws CounterServiceException
+     * @throws common_Exception
      */
-    public function decrement(string $counter, int $value = 1): void
+    public function reset(string $eventFqcn, ?int $value = 0, ?string $keyCallbackValue = null): void
     {
-        $this->getPersistence()->decr($this->buildPrefix($counter));
+        $this->getPersistence()->set($this->buildKey($eventFqcn, $keyCallbackValue), $value);
     }
 
     /**
-     * @param string $counter
-     * @param int $value
-     * @throws common_Exception|CounterServiceException
-     */
-    public function set(string $counter, int $value = 0): void
-    {
-        $this->getPersistence()->set($this->buildPrefix($counter), $value);
-    }
-
-    /**
-     * @param string $counter
+     * @param string $eventFqcn
      * @return int
      * @throws CounterServiceException
      */
-    public function get(string $counter): int
+    public function get(string $eventFqcn): int
     {
-        return (int)$this->getPersistence()->get($this->buildPrefix($counter));
+        return (int)$this->getPersistence()->get($this->buildKey($eventFqcn));
     }
 
     /**
-     * @param string $counter
+     * @param string $eventFqcn
+     * @param string|null $keyCallbackValue
      * @return string
      */
-    protected function buildPrefix(string $counter): string
+    protected function buildKey(string $eventFqcn, ?string $keyCallbackValue = null): string
     {
-        return $this->getOption(self::OPTION_COUNTER_KEY_PREFIX) . $counter;
+        $counterIdentifier = $eventFqcn;
+        $eventOption = $this->getOption(self::OPTION_EVENTS);
+
+        if (!empty($eventOption[$eventFqcn][self::OPTION_SHORT_NAME])) {
+            $counterIdentifier = $eventOption[$eventFqcn][self::OPTION_SHORT_NAME];
+        }
+
+        $key = $this->getOption(self::OPTION_COUNTER_KEY_PREFIX) . $counterIdentifier;
+        if (!empty($keyCallbackValue)) {
+            $key .= '_' . $keyCallbackValue;
+        }
+
+        return $key;
     }
 }

--- a/models/classes/counter/CounterService.php
+++ b/models/classes/counter/CounterService.php
@@ -144,21 +144,19 @@ class CounterService extends ConfigurableService
             $keyCallbackValue = $event->$keyCallbackMethod();
         }
 
-        // todo: set key first for kv_sql implementation to use increment
-
         $this->getPersistence()->incr($this->buildKey($eventFqcn, $keyCallbackValue));
     }
 
     /**
      * @param string $eventFqcn
      * @param int|null $value
-     * @param string|null $keyCallbackValue
+     * @param string|null $suffix
      * @throws CounterServiceException
      * @throws common_Exception
      */
-    public function reset(string $eventFqcn, ?int $value = 0, ?string $keyCallbackValue = null): void
+    public function reset(string $eventFqcn, ?int $value = 0, ?string $suffix = null): void
     {
-        $this->getPersistence()->set($this->buildKey($eventFqcn, $keyCallbackValue), $value);
+        $this->getPersistence()->set($this->buildKey($eventFqcn, $suffix), $value);
     }
 
     /**
@@ -174,10 +172,10 @@ class CounterService extends ConfigurableService
 
     /**
      * @param string $eventFqcn
-     * @param string|null $keyCallbackValue
+     * @param string|null $keySuffix
      * @return string
      */
-    protected function buildKey(string $eventFqcn, ?string $keyCallbackValue = null): string
+    protected function buildKey(string $eventFqcn, ?string $keySuffix = null): string
     {
         $counterIdentifier = $eventFqcn;
         $eventOption = $this->getOption(self::OPTION_EVENTS);
@@ -188,8 +186,8 @@ class CounterService extends ConfigurableService
 
         $key = $this->getOption(self::OPTION_COUNTER_KEY_PREFIX) . $counterIdentifier;
 
-        if (!empty($keyCallbackValue)) {
-            $key .= '_' . $keyCallbackValue;
+        if (!empty($keySuffix)) {
+            $key .= '_' . $keySuffix;
         }
 
         return $key;

--- a/models/classes/counter/CounterService.php
+++ b/models/classes/counter/CounterService.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\counter;
+
+use common_Exception;
+use common_persistence_KeyValuePersistence;
+use oat\oatbox\service\ConfigurableService;
+
+/**
+ *
+ */
+class CounterService extends ConfigurableService
+{
+    public const SERVICE_ID = 'tao/CounterService';
+    public const OPTION_PERSISTENCE = 'persistence';
+    public const OPTION_COUNTER_KEY_PREFIX = 'counterKeyPrefix';
+
+    /**
+     * @return common_persistence_KeyValuePersistence
+     * @throws CounterServiceException
+     */
+    protected function getPersistence(): common_persistence_KeyValuePersistence
+    {
+        $persistenceId = $this->getOption(self::OPTION_PERSISTENCE);
+        $persistence = common_persistence_KeyValuePersistence::getPersistence($persistenceId);
+
+        if (!$persistence instanceof common_persistence_KeyValuePersistence) {
+            $msg = "Persistence '${persistenceId}' must be an instance of '";
+            $msg .= common_persistence_KeyValuePersistence::class . "', ";
+            $msg .= get_class($persistence) . ' persistence given.';
+            throw new CounterServiceException($msg);
+        }
+
+        return $persistence;
+    }
+
+    /**
+     * @param string $counter
+     * @param int $value
+     * @throws CounterServiceException
+     */
+    public function increment(string $counter, int $value = 1): void
+    {
+        $this->getPersistence()->incr($this->buildPrefix($counter));
+    }
+
+    /**
+     * @param string $counter
+     * @param int $value
+     * @throws CounterServiceException
+     */
+    public function decrement(string $counter, int $value = 1): void
+    {
+        $this->getPersistence()->decr($this->buildPrefix($counter));
+    }
+
+    /**
+     * @param string $counter
+     * @param int $value
+     * @throws common_Exception|CounterServiceException
+     */
+    public function set(string $counter, int $value = 0): void
+    {
+        $this->getPersistence()->set($this->buildPrefix($counter), $value);
+    }
+
+    /**
+     * @param string $counter
+     * @return int
+     * @throws CounterServiceException
+     */
+    public function get(string $counter): int
+    {
+        return (int)$this->getPersistence()->get($this->buildPrefix($counter));
+    }
+
+    /**
+     * @param string $counter
+     * @return string
+     */
+    protected function buildPrefix(string $counter): string
+    {
+        return $this->getOption(self::OPTION_COUNTER_KEY_PREFIX) . $counter;
+    }
+}

--- a/models/classes/counter/CounterServiceException.php
+++ b/models/classes/counter/CounterServiceException.php
@@ -17,7 +17,7 @@
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
  */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace oat\tao\model\counter;
 
@@ -25,7 +25,6 @@ use Exception;
 
 class CounterServiceException extends Exception
 {
-    public const CODE_UNKNOWN_ERROR = 0;
     public const CODE_INVALID_PERSISTENCE = 1;
     public const CODE_UNKNOWN_EVENT_TYPE = 2;
 }

--- a/models/classes/counter/CounterServiceException.php
+++ b/models/classes/counter/CounterServiceException.php
@@ -15,7 +15,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
- *
  */
 
 declare(strict_types=1);
@@ -23,24 +22,10 @@ declare(strict_types=1);
 namespace oat\tao\model\counter;
 
 use Exception;
-use Throwable;
 
-/**
- *
- */
 class CounterServiceException extends Exception
 {
     public const CODE_UNKNOWN_ERROR = 0;
     public const CODE_INVALID_PERSISTENCE = 1;
     public const CODE_UNKNOWN_EVENT_TYPE = 2;
-
-    /**
-     * @param string $message
-     * @param int $code
-     * @param Throwable|null $previous
-     */
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
-    {
-        parent::__construct($message, $code, $previous);
-    }
 }

--- a/models/classes/counter/CounterServiceException.php
+++ b/models/classes/counter/CounterServiceException.php
@@ -30,7 +30,9 @@ use Throwable;
  */
 class CounterServiceException extends Exception
 {
-    public const CODE_INVALID_PERSISTENCE = 0;
+    public const CODE_UNKNOWN_ERROR = 0;
+    public const CODE_INVALID_PERSISTENCE = 1;
+    public const CODE_UNKNOWN_EVENT_TYPE = 2;
 
     /**
      * @param string $message

--- a/models/classes/counter/CounterServiceException.php
+++ b/models/classes/counter/CounterServiceException.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\counter;
+
+use Exception;
+use Throwable;
+
+/**
+ *
+ */
+class CounterServiceException extends Exception
+{
+    public const CODE_INVALID_PERSISTENCE = 0;
+
+    /**
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/scripts/install/RegisterCounterService.php
+++ b/scripts/install/RegisterCounterService.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\tao\scripts\install;
+
+use common_Exception;
+use oat\generis\persistence\PersistenceManager;
+use oat\oatbox\extension\InstallAction;
+use oat\oatbox\service\exception\InvalidServiceManagerException;
+use oat\oatbox\service\ServiceNotFoundException;
+use oat\tao\model\counter\CounterService;
+
+/**
+ *
+ */
+class RegisterCounterService extends InstallAction
+{
+    private CONST PERSISTENCE_PRECEDENCE = ['redis', 'default_kv'];
+
+    /**
+     * @param $params
+     * @throws InvalidServiceManagerException
+     * @throws ServiceNotFoundException
+     * @throws common_Exception
+     */
+    public function __invoke($params)
+    {
+        $persistence = $this->discoverPersistenceId();
+        $prefix = CounterService::OPTION_COUNTER_KEY_PREFIX;
+
+        $counterService = new CounterService([
+            $prefix => 'tao:counter:',
+            CounterService::OPTION_PERSISTENCE => $persistence
+        ]);
+
+        $this->registerService(
+            CounterService::SERVICE_ID,
+            $counterService
+        );
+
+        $logMsg = "Counter Service registered with persistence '${persistence}' and key prefix '${prefix}'";
+        $this->logInfo($logMsg);
+    }
+
+    /**
+     * @return string|null
+     * @throws ServiceNotFoundException
+     * @throws InvalidServiceManagerException
+     */
+    protected function discoverPersistenceId(): ?string
+    {
+        $persistence = null;
+        /** @var PersistenceManager $persistenceManager */
+        $persistenceManager = $this->getServiceManager()->get(PersistenceManager::SERVICE_ID);
+
+        /**
+         * Search for a suitable persistence. In case of an installation by Seed, or an Update
+         * of an existing infrastructure on the OAT ecosystem, we might find the best fit.
+         *
+         * 1. Most popular Key Value persistence ID in OAT ecosystem is 'redis'. This is the best fit.
+         * 2. As a fail-over, 'default_kv' persistence is implemented in all TAO Setups (See generis/manifest.php).
+         */
+        foreach (self::PERSISTENCE_PRECEDENCE as $possiblePersistence) {
+            if ($persistenceManager->hasPersistence($possiblePersistence)) {
+                $persistence = $possiblePersistence;
+                break;
+            }
+        }
+
+        return $persistence;
+    }
+}

--- a/scripts/install/RegisterCounterService.php
+++ b/scripts/install/RegisterCounterService.php
@@ -44,11 +44,16 @@ class RegisterCounterService extends InstallAction
     public function __invoke($params)
     {
         $persistence = $this->discoverPersistenceId();
-        $prefix = CounterService::OPTION_COUNTER_KEY_PREFIX;
 
+        /**
+         * The default CounterService is registered for client code usage. We expect the client code
+         * to register counters for specific custom needs.
+         */
         $counterService = new CounterService([
-            $prefix => 'tao:counter:',
-            CounterService::OPTION_PERSISTENCE => $persistence
+            CounterService::OPTION_PERSISTENCE => $persistence,
+            CounterService::OPTION_COUNTER_KEY_PREFIX => CounterService::DEFAULT_PREFIX,
+            CounterService::OPTION_EVENTS => []
+
         ]);
 
         $this->registerService(
@@ -56,7 +61,7 @@ class RegisterCounterService extends InstallAction
             $counterService
         );
 
-        $logMsg = "Counter Service registered with persistence '${persistence}' and key prefix '${prefix}'";
+        $logMsg = "Counter Service registered with persistence '${persistence}' and key prefix '" . CounterService::DEFAULT_PREFIX . "'.";
         $this->logInfo($logMsg);
     }
 
@@ -76,7 +81,8 @@ class RegisterCounterService extends InstallAction
          * of an existing infrastructure on the OAT ecosystem, we might find the best fit.
          *
          * 1. Most popular Key Value persistence ID in OAT ecosystem is 'redis'. This is the best fit.
-         * 2. As a fail-over, 'default_kv' persistence is implemented in all TAO Setups (See generis/manifest.php).
+         * 2. As a fail-over, 'default_kv' persistence is implemented in all TAO Setups (See generis/manifest.php's
+         * Registered Installation Actions).
          */
         foreach (self::PERSISTENCE_PRECEDENCE as $possiblePersistence) {
             if ($persistenceManager->hasPersistence($possiblePersistence)) {

--- a/scripts/install/RegisterCounterService.php
+++ b/scripts/install/RegisterCounterService.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -16,8 +15,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
- *
  */
+
+declare(strict_types = 1);
 
 namespace oat\tao\scripts\install;
 
@@ -28,20 +28,17 @@ use oat\oatbox\service\exception\InvalidServiceManagerException;
 use oat\oatbox\service\ServiceNotFoundException;
 use oat\tao\model\counter\CounterService;
 
-/**
- *
- */
 class RegisterCounterService extends InstallAction
 {
-    private CONST PERSISTENCE_PRECEDENCE = ['redis', 'default_kv'];
+    private const PERSISTENCE_PRECEDENCE = ['redis', 'default_kv'];
 
     /**
-     * @param $params
+     * @param array $params
      * @throws InvalidServiceManagerException
      * @throws ServiceNotFoundException
      * @throws common_Exception
      */
-    public function __invoke($params)
+    public function __invoke($params = [])
     {
         $persistence = $this->discoverPersistenceId();
 
@@ -73,6 +70,7 @@ class RegisterCounterService extends InstallAction
     protected function discoverPersistenceId(): ?string
     {
         $persistence = null;
+
         /** @var PersistenceManager $persistenceManager */
         $persistenceManager = $this->getServiceManager()->get(PersistenceManager::SERVICE_ID);
 


### PR DESCRIPTION
Counter service allows counting amount of calls of the event configured in the service.

For example, it used to count every delivery executions creation as well as delivery executions state changes to provide information for another system, for analyzing daily activity.

https://oat-sa.atlassian.net/browse/CGF-445
