### PR TITLE
AUT-1034 move requestTimeout to cypress.json configs

### DIFF
--- a/views/cypress.json
+++ b/views/cypress.json
@@ -8,6 +8,7 @@
   "videosFolder": "cypress/videos",
   "defaultCommandTimeout": 35000,
   "pageLoadTimeout": 30000,
+  "requestTimeout": 10000,
   "env": {
     "configFile": "cypress/envs/env.json"
   },

--- a/views/cypress/support/commands.js
+++ b/views/cypress/support/commands.js
@@ -44,9 +44,7 @@ Cypress.Commands.add('loginAttempt', (username, password) => {
     cy.get('#login', { timeout: 10000 }).type(username);
     cy.get('#password').type(password);
     cy.get('#connect').click();
-    cy.wait('@login', {
-        requestTimeout: 10000
-    });
+    cy.wait('@login');
 });
 
 // Preserve session cookies to stay logged in to TAO during tests

--- a/views/cypress/support/resourceTree.js
+++ b/views/cypress/support/resourceTree.js
@@ -31,9 +31,9 @@ Cypress.Commands.add('addClass', (
         .intercept('POST', `**/${ addSubClassUrl }`).as('addSubClass')
         .get('[data-context=resource][data-action=subClass]')
         .click()
-        .wait('@addSubClass', { requestTimeout: 10000 })
-        .wait('@treeRender', { requestTimeout: 10000 })
-        .wait('@editClassLabel', { requestTimeout: 10000 })
+        .wait('@addSubClass')
+        .wait('@treeRender')
+        .wait('@editClassLabel')
         .get(formSelector).should('exist');
 });
 
@@ -48,7 +48,7 @@ Cypress.Commands.add('addClassToRoot', (
     cy.log('COMMAND: addClassToRoot', name)
         .getSettled(`${rootSelector} a:nth(0)`)
         .click()
-        .wait('@editClassLabel', { requestTimeout: 10000 })
+        .wait('@editClassLabel')
         .addClass(formSelector, treeRenderUrl, addSubClassUrl)
         .renameSelectedClass(formSelector, name);
 });
@@ -63,12 +63,12 @@ Cypress.Commands.add('moveClass', (
     cy.log('COMMAND: moveClass', name)
         .getSettled(`li[title="${name}"] a:nth(0)`)
         .click()
-        .wait('@editClassLabel', { requestTimeout: 10000 })
+        .wait('@editClassLabel')
         .intercept('GET', `**/${ restResourceGetAll }**`).as('classToMove')
         .get('#feedback-2, #feedback-1').should('not.exist')
         .getSettled(moveSelector)
         .click()
-        .wait('@classToMove', { requestTimeout: 10000 })
+        .wait('@classToMove')
         .getSettled(`.destination-selector a[title="${nameWhereMove}"]`)
         .click()
         .get('.actions button')
@@ -90,7 +90,7 @@ Cypress.Commands.add('moveClassFromRoot', (
         .get('#feedback-1, #feedback-2').should('not.exist')
         .getSettled(`${rootSelector} a:nth(0)`)
         .click()
-        .wait('@editClassLabel', { requestTimeout: 10000 })
+        .wait('@editClassLabel')
         .get(`${rootSelector} li[title="${name}"] a`)
         .moveClass(moveSelector, moveConfirmSelector, name, nameWhereMove, restResourceGetAll)
 });
@@ -120,7 +120,7 @@ Cypress.Commands.add('deleteClass', (
     cy.intercept('POST', `**/${ deleteClassUrl }`).as('deleteClass')
     cy.get(confirmSelector)
       .click();
-    cy.wait('@deleteClass', { requestTimeout: 10000 })
+    cy.wait('@deleteClass')
 });
 
 Cypress.Commands.add('deleteClassFromRoot', (
@@ -164,7 +164,7 @@ Cypress.Commands.add('deleteNode', (
         .intercept('POST', `**/${ editUrl }`).as('editUrl')
         .getSettled(`${rootSelector} a`)
         .contains('a', name).click()
-        .wait('@editUrl', { requestTimeout: 10000 })
+        .wait('@editUrl')
         .getSettled(deleteSelector).click()
         .getSettled('[data-control="ok"]').click()
         .getSettled(`${rootSelector} a`)
@@ -193,7 +193,7 @@ Cypress.Commands.add('renameSelectedItem', (formSelector, editItemUrl, newName) 
         .type(newName)
         .get('button[id="Save"]')
         .click()
-        .wait('@editItem', { requestTimeout: 10000 })
+        .wait('@editItem')
         .get('#feedback-1, #feedback-2').should('not.exist')
         .get(formSelector).should('exist')
         .get(`${ formSelector } ${labelSelector}`).should('have.value', newName)
@@ -207,7 +207,7 @@ Cypress.Commands.add('renameSelectedTest', (formSelector, editTestUrl, newName) 
         .type(newName)
         .get('button[id="Save"]')
         .click()
-        .wait('@editTest', { requestTimeout: 10000 })
+        .wait('@editTest')
         .get('#feedback-1, #feedback-2').should('not.exist')
         .get(formSelector).should('exist')
         .get(`${ formSelector } ${labelSelector}`).should('have.value', newName)
@@ -233,7 +233,7 @@ Cypress.Commands.add('addPropertyToClass', (
     cy.get(propertyEdit).find('select[class="property-listvalues property"]').select('Boolean');
     cy.intercept('POST', `**/${ editClassUrl }`).as('editClass');
     cy.get('button[type="submit"]').click();
-    cy.wait('@editClass', { requestTimeout: 10000 });
+    cy.wait('@editClass');
 });
 
 Cypress.Commands.add('assignValueToProperty', (
@@ -247,5 +247,5 @@ Cypress.Commands.add('assignValueToProperty', (
     cy.getSettled(itemForm).find(selectTrue).check();
     cy.intercept('GET', `**/${ treeRenderUrl }/getOntologyData**`).as('treeRender')
     cy.getSettled('button[type="submit"]').click();
-    cy.wait('@treeRender', { requestTimeout: 10000 })
+    cy.wait('@treeRender')
 });

--- a/views/cypress/support/userManagement.js
+++ b/views/cypress/support/userManagement.js
@@ -65,9 +65,7 @@ Cypress.Commands.add('deleteUser', (userData) => {
     cy.intercept('GET', `**/Users/**/*filterquery=${userData.login}`).as('usersData')
     cy.get(`${selectors.manageUserTable} .filter input[name=filter]`)
         .type(`${userData.login}{enter}`);
-    cy.wait('@usersData', {
-        requestTimeout: 10000
-    });
+    cy.wait('@usersData');
 
     cy.get(`${selectors.manageUserTable} table`)
         .contains('td', userData.login)

--- a/views/cypress/tests/item-author-role.spec.js
+++ b/views/cypress/tests/item-author-role.spec.js
@@ -30,15 +30,11 @@ describe('Item Author Role', () => {
         tryToDeleteUser(users.user_item_author);
         cy.intercept('GET', '**/add*').as('add');
         cy.visit(urls.addUser);
-        cy.wait('@add', {
-            requestTimeout: 10000
-        });
+        cy.wait('@add');
         cy.addUser(selectors.addUserForm, users.user_item_author, userRoles.itemAuthor);
         cy.intercept('GET', '**/logout*').as('logout');
         cy.logoutAttempt();
-        cy.wait('@logout', {
-            requestTimeout: 10000
-        });
+        cy.wait('@logout');
     });
 
     describe('Login', () => {
@@ -62,9 +58,7 @@ describe('Item Author Role', () => {
 
         it('Has access to resource tree', function() {
             cy.intercept('GET', '**/taoItems/Items/*').as('treeItems');
-            cy.wait('@treeItems', {
-                requestTimeout: 10000
-            });
+            cy.wait('@treeItems');
             cy.get('#tree-manage_items').should('be.visible');
             cy.get('#tree-manage_items > ul > li')
         });
@@ -81,9 +75,7 @@ describe('Item Author Role', () => {
             cy.get('.lft.main-menu > li > a .icon-media');
             cy.intercept('GET', '**/taoMediaManager/MediaManager/*').as('mediaData');
             cy.visit(urls.mediaManager);
-            cy.wait('@mediaData', {
-                requestTimeout: 10000
-            });
+            cy.wait('@mediaData');
         });
 
         it('Has access to resource tree', function() {

--- a/views/cypress/tests/test-author-role.spec.js
+++ b/views/cypress/tests/test-author-role.spec.js
@@ -30,15 +30,11 @@ import { tryToDeleteUser } from '../utils/cleanup';
         tryToDeleteUser(users.user_test_author);
         cy.intercept('GET', '**/add*').as('add');
         cy.visit(urls.addUser);
-        cy.wait('@add', {
-            requestTimeout: 10000
-        });
+        cy.wait('@add');
         cy.addUser(selectors.addUserForm, users.user_test_author, [userRoles.itemAuthor, userRoles.testAuthor]);
         cy.intercept('GET', '**/logout*').as('logout');
         cy.logoutAttempt();
-        cy.wait('@logout', {
-            requestTimeout: 10000
-        });
+        cy.wait('@logout');
     });
 
     describe('Login', () => {
@@ -62,11 +58,9 @@ import { tryToDeleteUser } from '../utils/cleanup';
 
         it('Has access to resource tree', function() {
             cy.intercept('GET', '**/taoItems/Items/*').as('treeItems');
-            cy.wait('@treeItems', {
-                requestTimeout: 10000
-            });
+            cy.wait('@treeItems');
             cy.get('#tree-manage_items').should('be.visible');
-            cy.get('#tree-manage_items > ul > li')
+            cy.get('#tree-manage_items > ul > li');
         });
 
         it('Has access to resource actions', function() {
@@ -81,9 +75,7 @@ import { tryToDeleteUser } from '../utils/cleanup';
             cy.get('.lft.main-menu > li > a .icon-media');
             cy.intercept('GET', '**/taoMediaManager/MediaManager/*').as('mediaData');
             cy.visit(urls.mediaManager);
-            cy.wait('@mediaData', {
-                requestTimeout: 10000
-            });
+            cy.wait('@mediaData');
         });
 
         it('Has access to resource tree', function() {
@@ -103,9 +95,7 @@ import { tryToDeleteUser } from '../utils/cleanup';
             cy.get('.lft > :nth-child(2) > a .icon-test');
             cy.intercept('GET', '**/taoTests/Tests/*').as('testsData');
             cy.visit(urls.testsManager);
-            cy.wait('@testsData', {
-                requestTimeout: 10000
-            });
+            cy.wait('@testsData');
         });
 
         it('Has access to resource tree', function() {

--- a/views/cypress/tests/test-taker-role.spec.js
+++ b/views/cypress/tests/test-taker-role.spec.js
@@ -30,15 +30,11 @@ describe('Test Taker Role', () => {
         tryToDeleteUser(users.user_test_taker);
         cy.intercept('GET', '**/add*').as('add');
         cy.visit(urls.addUser);
-        cy.wait('@add', {
-            requestTimeout: 10000
-        });
+        cy.wait('@add');
         cy.addUser(selectors.addUserForm, users.user_test_taker, userRoles.testTaker);
         cy.intercept('GET', '**/logout*').as('logout');
         cy.logoutAttempt();
-        cy.wait('@logout', {
-            requestTimeout: 10000
-        });
+        cy.wait('@logout');
     });
 
     describe('Login', () => {

--- a/views/cypress/tests/user-management.spec.js
+++ b/views/cypress/tests/user-management.spec.js
@@ -28,9 +28,7 @@ describe('User Management', () => {
             cy.intercept('GET', '**/add*').as('add');
             cy.visit(urls.addUser);
 
-            cy.wait('@add', {
-                requestTimeout: 10000
-            });
+            cy.wait('@add');
         });
 
         describe('Visit add users page', () => {
@@ -54,9 +52,7 @@ describe('User Management', () => {
         before(() => {
             cy.loginAsAdmin();
             cy.intercept('GET', '**/Users/data*').as('usersData')
-            cy.wait('@usersData', {
-                requestTimeout: 10000
-            });
+            cy.wait('@usersData');
         });
 
         describe('Visit manage users page', () => {

--- a/views/cypress/utils/cleanup.js
+++ b/views/cypress/utils/cleanup.js
@@ -28,9 +28,7 @@ export function tryToDeleteUser(user) {
     cy.intercept('GET', `**/Users/**/*filterquery=${user.login}`).as('usersData');
     cy.get(`${selectors.manageUserTable} .filter input[name=filter]`)
         .type(`${user.login}{enter}`);
-    cy.wait('@usersData', {
-        requestTimeout: 10000
-    }).then((interception) => {
+    cy.wait('@usersData').then((interception) => {
         if (interception.response.body.data) {
             cy.get(`${selectors.manageUserTable} table`)
                 .contains('td', user.login)


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1034

We have explicitly defined a specific time for most of our request interception/waiting. 
i.e: .wait('@editItem', { requestTimeout: 10000 }) 

We should make this requestTimeout of 10000ms the norm by defining it as a default in cypress.json and removing each explicit mention of it in our .wait() function calls.

**How to test:**
Run cypress and check that all updated tests pass without errors after updating default request timeout.