### PR TITLE
ADF-635: E2E testing - Group renameSelected command

### DIFF
--- a/views/cypress/support/resourceTree.js
+++ b/views/cypress/support/resourceTree.js
@@ -266,10 +266,10 @@ Cypress.Commands.add('renameSelectedClass', (formSelector, newName) => {
 Cypress.Commands.add('renameSelectedNode', (formSelector, editUrl, newName) => {
     cy.log('COMMAND: renameSelectedNode', newName)
         .intercept('POST', `**${editUrl}`).as('edit')
-        .get(`${formSelector} ${labelSelector}`)
+        .getSettled(`${formSelector} ${labelSelector}`)
         .clear()
         .type(newName)
-        .get('button[id="Save"]')
+        .getSettled('button[id="Save"]')
         .click()
         .wait('@edit')
         .get('#feedback-1, #feedback-2').should('not.exist')


### PR DESCRIPTION
Jira task: https://oat-sa.atlassian.net/browse/ADF-635

Turns out that the `renameSelected` command had already been refactored in task https://oat-sa.atlassian.net/browse/AUT-1035. But two tests were failing after that, so this is now the fix of that refactor.

PR related to: https://github.com/oat-sa/extension-tao-itemqti/pull/1890