### PR TITLE
Fix broken tests

### DIFF
--- a/models/classes/validator/PropertyChangedValidator.php
+++ b/models/classes/validator/PropertyChangedValidator.php
@@ -57,11 +57,7 @@ class PropertyChangedValidator extends ConfigurableService
             return true;
         }
 
-        if ($currentPropertyType->getUri() !== $oldPropertyType->getUri()) {
-            return true;
-        }
-
-        return false;
+        return $currentPropertyType->getUri() !== $oldPropertyType->getUri();
     }
 
     public function isRangeChanged(core_kernel_classes_Property $property, OldProperty $oldProperty): bool

--- a/models/classes/validator/PropertyChangedValidator.php
+++ b/models/classes/validator/PropertyChangedValidator.php
@@ -22,11 +22,10 @@ declare(strict_types=1);
 
 namespace oat\tao\model\validator;
 
-use core_kernel_classes_Property;
 use oat\generis\model\WidgetRdf;
-use qtism\data\content\xhtml\lists\Ol;
-use oat\oatbox\service\ConfigurableService;
+use core_kernel_classes_Property;
 use oat\tao\model\dto\OldProperty;
+use oat\oatbox\service\ConfigurableService;
 use oat\tao\helpers\form\ValidationRuleRegistry;
 
 class PropertyChangedValidator extends ConfigurableService
@@ -40,35 +39,37 @@ class PropertyChangedValidator extends ConfigurableService
             || $this->isDependsOnPropertyCollectionChanged($property, $oldProperty);
     }
 
-    public function isRangeChanged(core_kernel_classes_Property $property, OldProperty $oldProperty): bool
-    {
-        return ($property->getRange() ? (string)$property->getRange()->getUri() : null) !== $oldProperty->getRangeUri();
-    }
-
     public function isPropertyTypeChanged(core_kernel_classes_Property $property, OldProperty $oldProperty): bool
     {
-        $currentPropertyType = $property
-            ->getOnePropertyValue(new core_kernel_classes_Property(WidgetRdf::PROPERTY_WIDGET));
+        $currentPropertyType = $property->getOnePropertyValue(
+            $property->getProperty(WidgetRdf::PROPERTY_WIDGET)
+        );
         $oldPropertyType = $oldProperty->getPropertyType();
 
-        if (null === $currentPropertyType && null === $oldPropertyType) {
+        if ($currentPropertyType === null && $oldPropertyType === null) {
             return false;
         }
 
         if (
-            null !== $currentPropertyType && null === $oldPropertyType
-            || null === $currentPropertyType && null !== $oldPropertyType
+            ($currentPropertyType !== null && $oldPropertyType === null)
+            || ($currentPropertyType === null && $oldPropertyType !== null)
         ) {
             return true;
         }
 
-        $currentPropertyTypeUri = $currentPropertyType->getUri();
-
-        if ($currentPropertyTypeUri !== $oldPropertyType->getUri()) {
+        if ($currentPropertyType->getUri() !== $oldPropertyType->getUri()) {
             return true;
         }
 
         return false;
+    }
+
+    public function isRangeChanged(core_kernel_classes_Property $property, OldProperty $oldProperty): bool
+    {
+        $propertyRange = $property->getRange();
+        $propertyRangeUri = $propertyRange ? $propertyRange->getUri() : null;
+
+        return $propertyRangeUri !== $oldProperty->getRangeUri();
     }
 
     public function isValidationRulesChanged(core_kernel_classes_Property $property, OldProperty $oldProperty): bool
@@ -85,7 +86,7 @@ class PropertyChangedValidator extends ConfigurableService
         core_kernel_classes_Property $property,
         OldProperty $oldProperty
     ): bool {
-        return $property->getDependsOnPropertyCollection()->isEqual(
+        return !$property->getDependsOnPropertyCollection()->isEqual(
             $oldProperty->getDependsOnPropertyCollection()
         );
     }

--- a/test/unit/model/validator/PropertyChangedValidatorTest.php
+++ b/test/unit/model/validator/PropertyChangedValidatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -19,76 +20,362 @@
 
 declare(strict_types=1);
 
-use oat\generis\model\WidgetRdf;
-use oat\tao\model\dto\OldProperty;
 use oat\generis\test\TestCase;
+use oat\tao\model\dto\OldProperty;
 use oat\tao\model\validator\PropertyChangedValidator;
 use oat\generis\model\resource\DependsOnPropertyCollection;
 
 class PropertyChangedValidatorTest extends TestCase
 {
     /** @var PropertyChangedValidator  */
-    private $subject;
+    private $sut;
 
     public function setUp(): void
     {
-        $this->subject = new PropertyChangedValidator();
+        $this->sut = new PropertyChangedValidator();
     }
 
     public function testDoNotTriggerIfDoesNotHaveChanges(): void
     {
-        $property = $this->createPropertyMock('');
+        $propertyType = $this->createMock(core_kernel_classes_Resource::class);
+        $propertyType
+            ->expects($this->exactly(2))
+            ->method('getUri')
+            ->willReturn('propertyTypeUri');
 
-        $this->assertFalse($this->subject->isPropertyChanged($property, new OldProperty('', $property)));
+        $range = $this->createMock(core_kernel_classes_Class::class);
+        $range
+            ->expects($this->once())
+            ->method('getUri')
+            ->willReturn('rangeUri');
+
+        $dependsOnPropertyCollection = $this->createMock(DependsOnPropertyCollection::class);
+        $dependsOnPropertyCollection
+            ->expects($this->once())
+            ->method('isEqual')
+            ->willReturn(true);
+
+        $property = $this->createMock(core_kernel_classes_Property::class);
+        $property
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $property
+            ->expects($this->exactly(2))
+            ->method('getProperty')
+            ->willReturn($this->createMock(core_kernel_classes_Property::class));
+        $property
+            ->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->willReturn($propertyType);
+        $property
+            ->expects($this->once())
+            ->method('getRange')
+            ->willReturn($range);
+        $property
+            ->expects($this->once())
+            ->method('getPropertyValues')
+            ->willReturn([]);
+        $property
+            ->expects($this->once())
+            ->method('getDependsOnPropertyCollection')
+            ->willReturn($dependsOnPropertyCollection);
+
+        $oldProperty = $this->createMock(OldProperty::class);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $oldProperty
+            ->expects($this->once())
+            ->method('getPropertyType')
+            ->willReturn($propertyType);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getRangeUri')
+            ->willReturn('rangeUri');
+        $oldProperty
+            ->expects($this->once())
+            ->method('getValidationRules')
+            ->willReturn([]);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getDependsOnPropertyCollection')
+            ->willReturn($dependsOnPropertyCollection);
+
+        $this->assertFalse($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testDoNotTriggerIfDoesNotHavePropertyType(): void
     {
-        $property = $this->createMock(core_kernel_classes_Property::class);
-        $property->expects($this->once())
-            ->method('getOnePropertyValue')
-            ->with(new core_kernel_classes_Property(WidgetRdf::PROPERTY_WIDGET))
-            ->willReturn(null);
+        $range = $this->createMock(core_kernel_classes_Class::class);
+        $range
+            ->expects($this->once())
+            ->method('getUri')
+            ->willReturn('rangeUri');
 
-        $this->assertFalse($this->subject->isPropertyChanged($property, new OldProperty('', null)));
+        $dependsOnPropertyCollection = $this->createMock(DependsOnPropertyCollection::class);
+        $dependsOnPropertyCollection
+            ->expects($this->once())
+            ->method('isEqual')
+            ->willReturn(true);
+
+        $property = $this->createMock(core_kernel_classes_Property::class);
+        $property
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $property
+            ->expects($this->exactly(2))
+            ->method('getProperty')
+            ->willReturn($this->createMock(core_kernel_classes_Property::class));
+        $property
+            ->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->willReturn(null);
+        $property
+            ->expects($this->once())
+            ->method('getRange')
+            ->willReturn($range);
+        $property
+            ->expects($this->once())
+            ->method('getPropertyValues')
+            ->willReturn([]);
+        $property
+            ->expects($this->once())
+            ->method('getDependsOnPropertyCollection')
+            ->willReturn($dependsOnPropertyCollection);
+
+        $oldProperty = $this->createMock(OldProperty::class);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $oldProperty
+            ->expects($this->once())
+            ->method('getPropertyType')
+            ->willReturn(null);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getRangeUri')
+            ->willReturn('rangeUri');
+        $oldProperty
+            ->expects($this->once())
+            ->method('getValidationRules')
+            ->willReturn([]);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getDependsOnPropertyCollection')
+            ->willReturn($dependsOnPropertyCollection);
+
+        $this->assertFalse($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testTriggerIfHaveCurrentPropertyTypeButDoesNotHaveOldPropertyType(): void
     {
-        $property = $this->createPropertyMock('');
+        $propertyType = $this->createMock(core_kernel_classes_Resource::class);
+        $propertyType
+            ->expects($this->never())
+            ->method('getUri');
 
-        $this->assertTrue($this->subject->isPropertyChanged($property, new OldProperty('', null)));
+        $property = $this->createMock(core_kernel_classes_Property::class);
+        $property
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $property
+            ->expects($this->once())
+            ->method('getProperty')
+            ->willReturn($this->createMock(core_kernel_classes_Property::class));
+        $property
+            ->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->willReturn($propertyType);
+        $property
+            ->expects($this->never())
+            ->method('getRange');
+        $property
+            ->expects($this->never())
+            ->method('getPropertyValues');
+        $property
+            ->expects($this->never())
+            ->method('getDependsOnPropertyCollection');
+
+        $oldProperty = $this->createMock(OldProperty::class);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $oldProperty
+            ->expects($this->once())
+            ->method('getPropertyType')
+            ->willReturn(null);
+        $oldProperty
+            ->expects($this->never())
+            ->method('getRangeUri');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getValidationRules');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getDependsOnPropertyCollection');
+
+        $this->assertTrue($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testTriggerIfDoesNotHaveCurrentPropertyTypeButHaveOldPropertyType(): void
     {
-        $property = $this->createMock(core_kernel_classes_Property::class);
+        $propertyType = $this->createMock(core_kernel_classes_Resource::class);
+        $propertyType
+            ->expects($this->never())
+            ->method('getUri');
 
-        $this->assertTrue(
-            $this->subject->isPropertyChanged(
-                $property,
-                new OldProperty('', $this->createMock(core_kernel_classes_Property::class))
-            )
-        );
+        $property = $this->createMock(core_kernel_classes_Property::class);
+        $property
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $property
+            ->expects($this->once())
+            ->method('getProperty')
+            ->willReturn($this->createMock(core_kernel_classes_Property::class));
+        $property
+            ->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->willReturn(null);
+        $property
+            ->expects($this->never())
+            ->method('getRange');
+        $property
+            ->expects($this->never())
+            ->method('getPropertyValues');
+        $property
+            ->expects($this->never())
+            ->method('getDependsOnPropertyCollection');
+
+        $oldProperty = $this->createMock(OldProperty::class);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $oldProperty
+            ->expects($this->once())
+            ->method('getPropertyType')
+            ->willReturn($propertyType);
+        $oldProperty
+            ->expects($this->never())
+            ->method('getRangeUri');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getValidationRules');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getDependsOnPropertyCollection');
+
+        $this->assertTrue($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testTriggerIfHasChangesOnLabel(): void
     {
         $property = $this->createMock(core_kernel_classes_Property::class);
+        $property
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('newPropertyLabel');
+        $property
+            ->expects($this->never())
+            ->method('getProperty');
+        $property
+            ->expects($this->never())
+            ->method('getOnePropertyValue');
+        $property
+            ->expects($this->never())
+            ->method('getRange');
+        $property
+            ->expects($this->never())
+            ->method('getPropertyValues');
+        $property
+            ->expects($this->never())
+            ->method('getDependsOnPropertyCollection');
 
-        $this->assertTrue($this->subject->isPropertyChanged($property, new OldProperty('different', $property)));
+        $oldProperty = $this->createMock(OldProperty::class);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('oldPropertyLabel');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getPropertyType');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getRangeUri');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getValidationRules');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getDependsOnPropertyCollection');
+
+        $this->assertTrue($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testTriggerIfHasChangesOnPropertyType(): void
     {
-        $property = $this->createPropertyMock('TextArea');
-
-        $widgetProperty = $this->createMock(core_kernel_classes_Property::class);
-        $widgetProperty->expects($this->once())
+        $newPropertyType = $this->createMock(core_kernel_classes_Resource::class);
+        $newPropertyType
+            ->expects($this->once())
             ->method('getUri')
-            ->willReturn('TextBox');
+            ->willReturn('newPropertyTypeUri');
 
-        $this->assertTrue($this->subject->isPropertyChanged($property, new OldProperty('', $widgetProperty)));
+        $oldPropertyType = $this->createMock(core_kernel_classes_Resource::class);
+        $oldPropertyType
+            ->expects($this->once())
+            ->method('getUri')
+            ->willReturn('oldPropertyTypeUri');
+
+        $property = $this->createMock(core_kernel_classes_Property::class);
+        $property
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $property
+            ->expects($this->once())
+            ->method('getProperty')
+            ->willReturn($this->createMock(core_kernel_classes_Property::class));
+        $property
+            ->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->willReturn($newPropertyType);
+        $property
+            ->expects($this->never())
+            ->method('getRange');
+        $property
+            ->expects($this->never())
+            ->method('getPropertyValues');
+        $property
+            ->expects($this->never())
+            ->method('getDependsOnPropertyCollection');
+
+        $oldProperty = $this->createMock(OldProperty::class);
+        $oldProperty
+            ->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('propertyLabel');
+        $oldProperty
+            ->expects($this->once())
+            ->method('getPropertyType')
+            ->willReturn($oldPropertyType);
+        $oldProperty
+            ->expects($this->never())
+            ->method('getRangeUri');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getValidationRules');
+        $oldProperty
+            ->expects($this->never())
+            ->method('getDependsOnPropertyCollection');
+
+        $this->assertTrue($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testIsRangeChangedIsTrue(): void
@@ -107,7 +394,7 @@ class PropertyChangedValidatorTest extends TestCase
             ->willReturn('uri2');
 
         $this->assertTrue(
-            $this->subject->isRangeChanged(
+            $this->sut->isRangeChanged(
                 $property,
                 $oldProperty
             )
@@ -117,7 +404,7 @@ class PropertyChangedValidatorTest extends TestCase
     public function testIsRangeChangedIsFalse(): void
     {
         $this->assertFalse(
-            $this->subject->isRangeChanged(
+            $this->sut->isRangeChanged(
                 $this->createMock(core_kernel_classes_Property::class),
                 $this->createMock(OldProperty::class)
             )
@@ -145,7 +432,7 @@ class PropertyChangedValidatorTest extends TestCase
             ->method('getValidationRules')
             ->willReturn($oldValidationRules);
 
-        $this->assertEquals($expected, $this->subject->isValidationRulesChanged($property, $oldProperty));
+        $this->assertEquals($expected, $this->sut->isValidationRulesChanged($property, $oldProperty));
     }
 
     /**
@@ -170,7 +457,7 @@ class PropertyChangedValidatorTest extends TestCase
 
         $this->assertEquals(
             $expected,
-            $this->subject->isDependsOnPropertyCollectionChanged($property, $oldProperty)
+            $this->sut->isDependsOnPropertyCollectionChanged($property, $oldProperty)
         );
     }
 
@@ -200,36 +487,16 @@ class PropertyChangedValidatorTest extends TestCase
         return [
             [
                 'isEqual' => false,
-                'expected' => false,
-            ],
-            [
-                'isEqual' => true,
                 'expected' => true,
             ],
             [
-                'isEqual' => false,
+                'isEqual' => true,
                 'expected' => false,
             ],
+            [
+                'isEqual' => false,
+                'expected' => true,
+            ],
         ];
-    }
-
-    private function createPropertyMock(string $widgetPropertyId = null): core_kernel_classes_Property
-    {
-        $property = $this->createMock(core_kernel_classes_Property::class);
-        $property->expects($this->any())->method('getUri')->willReturn('');
-        $property->expects($this->once())
-            ->method('getOnePropertyValue')
-            ->with(new core_kernel_classes_Property(WidgetRdf::PROPERTY_WIDGET))
-            ->willReturnCallback(
-                function () use ($widgetPropertyId): core_kernel_classes_Property {
-                    $widgetProperty = $this->createMock(core_kernel_classes_Property::class);
-                    $widgetProperty->expects($this->any())
-                        ->method('getUri')
-                        ->willReturn($widgetPropertyId);
-
-                    return $widgetProperty;
-                }
-            );
-        return $property;
     }
 }

--- a/test/unit/model/validator/PropertyChangedValidatorTest.php
+++ b/test/unit/model/validator/PropertyChangedValidatorTest.php
@@ -112,11 +112,9 @@ class PropertyChangedValidatorTest extends TestCase
 
     public function testTriggerIfHaveCurrentPropertyTypeButDoesNotHaveOldPropertyType(): void
     {
-        $propertyType = $this->createPropertyTypeMock();
-
         $property = $this->createPropertyMock(
             'propertyLabel',
-            $propertyType,
+            $this->createPropertyTypeMock(),
             null,
             null,
             [

--- a/test/unit/model/validator/PropertyChangedValidatorTest.php
+++ b/test/unit/model/validator/PropertyChangedValidatorTest.php
@@ -22,11 +22,15 @@ declare(strict_types=1);
 
 use oat\generis\test\TestCase;
 use oat\tao\model\dto\OldProperty;
+use PHPUnit\Framework\MockObject\MockObject;
 use oat\tao\model\validator\PropertyChangedValidator;
 use oat\generis\model\resource\DependsOnPropertyCollection;
 
 class PropertyChangedValidatorTest extends TestCase
 {
+    private const DEFAULT_RANGE_URI = 'rangeUri';
+    private const DEFAULT_VALIDATION_RULES = [];
+
     /** @var PropertyChangedValidator  */
     private $sut;
 
@@ -37,343 +41,178 @@ class PropertyChangedValidatorTest extends TestCase
 
     public function testDoNotTriggerIfDoesNotHaveChanges(): void
     {
-        $propertyType = $this->createMock(core_kernel_classes_Resource::class);
-        $propertyType
-            ->expects($this->exactly(2))
-            ->method('getUri')
-            ->willReturn('propertyTypeUri');
+        $propertyType = $this->createPropertyTypeMock(2);
+        $dependsOnPropertyCollection = $this->createDependsOnPropertyCollectionMock(true);
 
-        $range = $this->createMock(core_kernel_classes_Class::class);
-        $range
-            ->expects($this->once())
-            ->method('getUri')
-            ->willReturn('rangeUri');
+        $property = $this->createPropertyMock(
+            'propertyLabel',
+            $propertyType,
+            $this->createRangeMock(),
+            $dependsOnPropertyCollection,
+            [
+                'getLabel' => 1,
+                'getProperty' => 2,
+                'getOnePropertyValue' => 1,
+                'getRange' => 1,
+                'getPropertyValues' => 1,
+                'getDependsOnPropertyCollection' => 1,
+            ]
+        );
 
-        $dependsOnPropertyCollection = $this->createMock(DependsOnPropertyCollection::class);
-        $dependsOnPropertyCollection
-            ->expects($this->once())
-            ->method('isEqual')
-            ->willReturn(true);
-
-        $property = $this->createMock(core_kernel_classes_Property::class);
-        $property
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $property
-            ->expects($this->exactly(2))
-            ->method('getProperty')
-            ->willReturn($this->createMock(core_kernel_classes_Property::class));
-        $property
-            ->expects($this->once())
-            ->method('getOnePropertyValue')
-            ->willReturn($propertyType);
-        $property
-            ->expects($this->once())
-            ->method('getRange')
-            ->willReturn($range);
-        $property
-            ->expects($this->once())
-            ->method('getPropertyValues')
-            ->willReturn([]);
-        $property
-            ->expects($this->once())
-            ->method('getDependsOnPropertyCollection')
-            ->willReturn($dependsOnPropertyCollection);
-
-        $oldProperty = $this->createMock(OldProperty::class);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $oldProperty
-            ->expects($this->once())
-            ->method('getPropertyType')
-            ->willReturn($propertyType);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getRangeUri')
-            ->willReturn('rangeUri');
-        $oldProperty
-            ->expects($this->once())
-            ->method('getValidationRules')
-            ->willReturn([]);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getDependsOnPropertyCollection')
-            ->willReturn($dependsOnPropertyCollection);
+        $oldProperty = $this->createOldPropertyMock(
+            'propertyLabel',
+            $propertyType,
+            $dependsOnPropertyCollection,
+            [
+                'getLabel' => 1,
+                'getPropertyType' => 1,
+                'getRangeUri' => 1,
+                'getValidationRules' => 1,
+                'getDependsOnPropertyCollection' => 1,
+            ]
+        );
 
         $this->assertFalse($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testDoNotTriggerIfDoesNotHavePropertyType(): void
     {
-        $range = $this->createMock(core_kernel_classes_Class::class);
-        $range
-            ->expects($this->once())
-            ->method('getUri')
-            ->willReturn('rangeUri');
+        $dependsOnPropertyCollection = $this->createDependsOnPropertyCollectionMock(true);
 
-        $dependsOnPropertyCollection = $this->createMock(DependsOnPropertyCollection::class);
-        $dependsOnPropertyCollection
-            ->expects($this->once())
-            ->method('isEqual')
-            ->willReturn(true);
+        $property = $this->createPropertyMock(
+            'propertyLabel',
+            null,
+            $this->createRangeMock(),
+            $dependsOnPropertyCollection,
+            [
+                'getLabel' => 1,
+                'getProperty' => 2,
+                'getOnePropertyValue' => 1,
+                'getRange' => 1,
+                'getPropertyValues' => 1,
+                'getDependsOnPropertyCollection' => 1,
+            ]
+        );
 
-        $property = $this->createMock(core_kernel_classes_Property::class);
-        $property
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $property
-            ->expects($this->exactly(2))
-            ->method('getProperty')
-            ->willReturn($this->createMock(core_kernel_classes_Property::class));
-        $property
-            ->expects($this->once())
-            ->method('getOnePropertyValue')
-            ->willReturn(null);
-        $property
-            ->expects($this->once())
-            ->method('getRange')
-            ->willReturn($range);
-        $property
-            ->expects($this->once())
-            ->method('getPropertyValues')
-            ->willReturn([]);
-        $property
-            ->expects($this->once())
-            ->method('getDependsOnPropertyCollection')
-            ->willReturn($dependsOnPropertyCollection);
-
-        $oldProperty = $this->createMock(OldProperty::class);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $oldProperty
-            ->expects($this->once())
-            ->method('getPropertyType')
-            ->willReturn(null);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getRangeUri')
-            ->willReturn('rangeUri');
-        $oldProperty
-            ->expects($this->once())
-            ->method('getValidationRules')
-            ->willReturn([]);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getDependsOnPropertyCollection')
-            ->willReturn($dependsOnPropertyCollection);
+        $oldProperty = $this->createOldPropertyMock(
+            'propertyLabel',
+            null,
+            $dependsOnPropertyCollection,
+            [
+                'getLabel' => 1,
+                'getPropertyType' => 1,
+                'getRangeUri' => 1,
+                'getValidationRules' => 1,
+                'getDependsOnPropertyCollection' => 1,
+            ]
+        );
 
         $this->assertFalse($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testTriggerIfHaveCurrentPropertyTypeButDoesNotHaveOldPropertyType(): void
     {
-        $propertyType = $this->createMock(core_kernel_classes_Resource::class);
-        $propertyType
-            ->expects($this->never())
-            ->method('getUri');
+        $propertyType = $this->createPropertyTypeMock();
 
-        $property = $this->createMock(core_kernel_classes_Property::class);
-        $property
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $property
-            ->expects($this->once())
-            ->method('getProperty')
-            ->willReturn($this->createMock(core_kernel_classes_Property::class));
-        $property
-            ->expects($this->once())
-            ->method('getOnePropertyValue')
-            ->willReturn($propertyType);
-        $property
-            ->expects($this->never())
-            ->method('getRange');
-        $property
-            ->expects($this->never())
-            ->method('getPropertyValues');
-        $property
-            ->expects($this->never())
-            ->method('getDependsOnPropertyCollection');
+        $property = $this->createPropertyMock(
+            'propertyLabel',
+            $propertyType,
+            null,
+            null,
+            [
+                'getLabel' => 1,
+                'getProperty' => 1,
+                'getOnePropertyValue' => 1,
+            ]
+        );
 
-        $oldProperty = $this->createMock(OldProperty::class);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $oldProperty
-            ->expects($this->once())
-            ->method('getPropertyType')
-            ->willReturn(null);
-        $oldProperty
-            ->expects($this->never())
-            ->method('getRangeUri');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getValidationRules');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getDependsOnPropertyCollection');
+        $oldProperty = $this->createOldPropertyMock(
+            'propertyLabel',
+            null,
+            null,
+            [
+                'getLabel' => 1,
+                'getPropertyType' => 1,
+            ]
+        );
 
         $this->assertTrue($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testTriggerIfDoesNotHaveCurrentPropertyTypeButHaveOldPropertyType(): void
     {
-        $propertyType = $this->createMock(core_kernel_classes_Resource::class);
-        $propertyType
-            ->expects($this->never())
-            ->method('getUri');
+        $property = $this->createPropertyMock(
+            'propertyLabel',
+            null,
+            null,
+            null,
+            [
+                'getLabel' => 1,
+                'getProperty' => 1,
+                'getOnePropertyValue' => 1,
+            ]
+        );
 
-        $property = $this->createMock(core_kernel_classes_Property::class);
-        $property
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $property
-            ->expects($this->once())
-            ->method('getProperty')
-            ->willReturn($this->createMock(core_kernel_classes_Property::class));
-        $property
-            ->expects($this->once())
-            ->method('getOnePropertyValue')
-            ->willReturn(null);
-        $property
-            ->expects($this->never())
-            ->method('getRange');
-        $property
-            ->expects($this->never())
-            ->method('getPropertyValues');
-        $property
-            ->expects($this->never())
-            ->method('getDependsOnPropertyCollection');
-
-        $oldProperty = $this->createMock(OldProperty::class);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $oldProperty
-            ->expects($this->once())
-            ->method('getPropertyType')
-            ->willReturn($propertyType);
-        $oldProperty
-            ->expects($this->never())
-            ->method('getRangeUri');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getValidationRules');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getDependsOnPropertyCollection');
+        $oldProperty = $this->createOldPropertyMock(
+            'propertyLabel',
+            $this->createPropertyTypeMock(),
+            null,
+            [
+                'getLabel' => 1,
+                'getPropertyType' => 1,
+            ]
+        );
 
         $this->assertTrue($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testTriggerIfHasChangesOnLabel(): void
     {
-        $property = $this->createMock(core_kernel_classes_Property::class);
-        $property
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('newPropertyLabel');
-        $property
-            ->expects($this->never())
-            ->method('getProperty');
-        $property
-            ->expects($this->never())
-            ->method('getOnePropertyValue');
-        $property
-            ->expects($this->never())
-            ->method('getRange');
-        $property
-            ->expects($this->never())
-            ->method('getPropertyValues');
-        $property
-            ->expects($this->never())
-            ->method('getDependsOnPropertyCollection');
+        $property = $this->createPropertyMock(
+            'newPropertyLabel',
+            null,
+            null,
+            null,
+            [
+                'getLabel' => 1,
+            ]
+        );
 
-        $oldProperty = $this->createMock(OldProperty::class);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('oldPropertyLabel');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getPropertyType');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getRangeUri');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getValidationRules');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getDependsOnPropertyCollection');
+        $oldProperty = $this->createOldPropertyMock(
+            'propertyLabel',
+            null,
+            null,
+            [
+                'getLabel' => 1,
+            ]
+        );
 
         $this->assertTrue($this->sut->isPropertyChanged($property, $oldProperty));
     }
 
     public function testTriggerIfHasChangesOnPropertyType(): void
     {
-        $newPropertyType = $this->createMock(core_kernel_classes_Resource::class);
-        $newPropertyType
-            ->expects($this->once())
-            ->method('getUri')
-            ->willReturn('newPropertyTypeUri');
+        $property = $this->createPropertyMock(
+            'propertyLabel',
+            $this->createPropertyTypeMock(1, 'newPropertyTypeUri'),
+            null,
+            null,
+            [
+                'getLabel' => 1,
+                'getProperty' => 1,
+                'getOnePropertyValue' => 1,
+            ]
+        );
 
-        $oldPropertyType = $this->createMock(core_kernel_classes_Resource::class);
-        $oldPropertyType
-            ->expects($this->once())
-            ->method('getUri')
-            ->willReturn('oldPropertyTypeUri');
-
-        $property = $this->createMock(core_kernel_classes_Property::class);
-        $property
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $property
-            ->expects($this->once())
-            ->method('getProperty')
-            ->willReturn($this->createMock(core_kernel_classes_Property::class));
-        $property
-            ->expects($this->once())
-            ->method('getOnePropertyValue')
-            ->willReturn($newPropertyType);
-        $property
-            ->expects($this->never())
-            ->method('getRange');
-        $property
-            ->expects($this->never())
-            ->method('getPropertyValues');
-        $property
-            ->expects($this->never())
-            ->method('getDependsOnPropertyCollection');
-
-        $oldProperty = $this->createMock(OldProperty::class);
-        $oldProperty
-            ->expects($this->once())
-            ->method('getLabel')
-            ->willReturn('propertyLabel');
-        $oldProperty
-            ->expects($this->once())
-            ->method('getPropertyType')
-            ->willReturn($oldPropertyType);
-        $oldProperty
-            ->expects($this->never())
-            ->method('getRangeUri');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getValidationRules');
-        $oldProperty
-            ->expects($this->never())
-            ->method('getDependsOnPropertyCollection');
+        $oldProperty = $this->createOldPropertyMock(
+            'propertyLabel',
+            $this->createPropertyTypeMock(1, 'oldPropertyTypeUri'),
+            null,
+            [
+                'getLabel' => 1,
+                'getPropertyType' => 1,
+            ]
+        );
 
         $this->assertTrue($this->sut->isPropertyChanged($property, $oldProperty));
     }
@@ -440,20 +279,16 @@ class PropertyChangedValidatorTest extends TestCase
      */
     public function testIsDependsOnPropertyCollectionChanged(bool $isEqual, bool $expected): void
     {
-        $dependsOnPropertyCollection = $this->createMock(DependsOnPropertyCollection::class);
-        $dependsOnPropertyCollection
-            ->method('isEqual')
-            ->willReturn($isEqual);
+        $dependsOnPropertyCollection = $this->createDependsOnPropertyCollectionMock($isEqual);
         $property = $this->createMock(core_kernel_classes_Property::class);
         $property
             ->method('getDependsOnPropertyCollection')
             ->willReturn($dependsOnPropertyCollection);
 
-        $oldDependsOnPropertyCollection = $this->createMock(DependsOnPropertyCollection::class);
         $oldProperty = $this->createMock(OldProperty::class);
         $oldProperty
             ->method('getDependsOnPropertyCollection')
-            ->willReturn($oldDependsOnPropertyCollection);
+            ->willReturn($this->createMock(DependsOnPropertyCollection::class));
 
         $this->assertEquals(
             $expected,
@@ -498,5 +333,156 @@ class PropertyChangedValidatorTest extends TestCase
                 'expected' => true,
             ],
         ];
+    }
+
+    private function createPropertyTypeMock(
+        int $expects = 0,
+        string $uri = 'propertyTypeUri'
+    ): core_kernel_classes_Resource {
+        $propertyType = $this->createMock(core_kernel_classes_Resource::class);
+
+        if ($expects === 0) {
+            $propertyType
+                ->expects($this->never())
+                ->method('getUri');
+        } else {
+            $propertyType
+                ->expects($this->exactly($expects))
+                ->method('getUri')
+                ->willReturn($uri);
+        }
+
+        return $propertyType;
+    }
+
+    private function createRangeMock(): core_kernel_classes_Class
+    {
+        $range = $this->createMock(core_kernel_classes_Class::class);
+        $range
+            ->expects($this->once())
+            ->method('getUri')
+            ->willReturn(self::DEFAULT_RANGE_URI);
+
+        return $range;
+    }
+
+    private function createDependsOnPropertyCollectionMock(bool $isEqual): DependsOnPropertyCollection
+    {
+        $dependsOnPropertyCollection = $this->createMock(DependsOnPropertyCollection::class);
+        $dependsOnPropertyCollection
+            ->expects($this->once())
+            ->method('isEqual')
+            ->willReturn($isEqual);
+
+        return $dependsOnPropertyCollection;
+    }
+
+    private function createPropertyMock(
+        string $propertyLabel,
+        ?core_kernel_classes_Resource $propertyType,
+        ?core_kernel_classes_Class $range,
+        ?DependsOnPropertyCollection $dependsOnPropertyCollection,
+        array $expects = []
+    ): core_kernel_classes_Property {
+        $property = $this->createMock(core_kernel_classes_Property::class);
+
+        $this
+            ->configureMethod(
+                $property,
+                'getLabel',
+                $expects['getLabel'] ?? 0,
+                $propertyLabel
+            )
+            ->configureMethod(
+                $property,
+                'getProperty',
+                $expects['getProperty'] ?? 0,
+                $this->createMock(core_kernel_classes_Property::class)
+            )
+            ->configureMethod(
+                $property,
+                'getOnePropertyValue',
+                $expects['getOnePropertyValue'] ?? 0,
+                $propertyType
+            )
+            ->configureMethod(
+                $property,
+                'getRange',
+                $expects['getRange'] ?? 0,
+                $range
+            )
+            ->configureMethod(
+                $property,
+                'getPropertyValues',
+                $expects['getPropertyValues'] ?? 0,
+                self::DEFAULT_VALIDATION_RULES
+            )
+            ->configureMethod(
+                $property,
+                'getDependsOnPropertyCollection',
+                $expects['getDependsOnPropertyCollection'] ?? 0,
+                $dependsOnPropertyCollection
+            );
+
+        return $property;
+    }
+
+    private function createOldPropertyMock(
+        string $propertyLabel,
+        ?core_kernel_classes_Resource  $propertyType,
+        ?DependsOnPropertyCollection $dependsOnPropertyCollection,
+        array $expects = []
+    ): OldProperty {
+        $oldProperty = $this->createMock(OldProperty::class);
+
+        $this
+            ->configureMethod(
+                $oldProperty,
+                'getLabel',
+                $expects['getLabel'] ?? 0,
+                $propertyLabel
+            )
+            ->configureMethod(
+                $oldProperty,
+                'getPropertyType',
+                $expects['getPropertyType'] ?? 0,
+                $propertyType
+            )
+            ->configureMethod(
+                $oldProperty,
+                'getRangeUri',
+                $expects['getRangeUri'] ?? 0,
+                self::DEFAULT_RANGE_URI
+            )
+            ->configureMethod(
+                $oldProperty,
+                'getValidationRules',
+                $expects['getValidationRules'] ?? 0,
+                self::DEFAULT_VALIDATION_RULES
+            )
+            ->configureMethod(
+                $oldProperty,
+                'getDependsOnPropertyCollection',
+                $expects['getDependsOnPropertyCollection'] ?? 0,
+                $dependsOnPropertyCollection
+            );
+
+        return $oldProperty;
+    }
+
+    private function configureMethod(MockObject $mockObject, string $method, int $expects, $returnValue): self
+    {
+        if ($expects === 0) {
+            $mockObject
+                ->expects($this->never())
+                ->method($method);
+        } else {
+            $mockObject
+                ->expects($this->exactly($expects))
+                ->method($method)
+                ->willReturn($returnValue);
+        }
+
+        return $this;
     }
 }

--- a/test/unit/model/validator/PropertyChangedValidatorTest.php
+++ b/test/unit/model/validator/PropertyChangedValidatorTest.php
@@ -427,7 +427,7 @@ class PropertyChangedValidatorTest extends TestCase
 
     private function createOldPropertyMock(
         string $propertyLabel,
-        ?core_kernel_classes_Resource  $propertyType,
+        ?core_kernel_classes_Resource $propertyType,
         ?DependsOnPropertyCollection $dependsOnPropertyCollection,
         array $expects = []
     ): OldProperty {
@@ -474,12 +474,14 @@ class PropertyChangedValidatorTest extends TestCase
             $mockObject
                 ->expects($this->never())
                 ->method($method);
-        } else {
-            $mockObject
-                ->expects($this->exactly($expects))
-                ->method($method)
-                ->willReturn($returnValue);
+
+            return $this;
         }
+
+        $mockObject
+            ->expects($this->exactly($expects))
+            ->method($method)
+            ->willReturn($returnValue);
 
         return $this;
     }


### PR DESCRIPTION
**Changes:**
* Broken tests where refactored and fixed.
* Method `isDependsOnPropertyCollectionChanged` fixed - it will return reversed boolean value.