### PR TITLE
CUNO-1853 / ADF-695: User without access to assets can save images trough the item

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -772,8 +772,9 @@
             "integrity": "sha512-S6/2ol3NpT99su9ZlZgoVvZHKW+yRVro562Ab1pizyCwv2YfO1r2FbpEDTS/cgfqI2JvgMtuP1V1SjR3T8Avrg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "git://github.com/oat-sa/tao-core-ui-fe.git#1deeddfcb3b5b7733a0067b45a333f7204b12637",
-            "from": "git://github.com/oat-sa/tao-core-ui-fe.git#fix/ADF-695/item-gallery-default"
+            "version": "1.36.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.36.1.tgz",
+            "integrity": "sha512-SIqkSPjY7uORXlcMPm2ZF7S5R9Y4436+flO8NdGyAHt1z6yyy+vI4H48JDfpAj/uEtCNmEWD3FXI8BWqq1JDYw=="
         },
         "@samverschueren/stream-to-observable": {
             "version": "0.3.1",


### PR DESCRIPTION
**Jira issue**
https://oat-sa.atlassian.net/browse/ADF-695

**Related PR**
https://github.com/oat-sa/tao-core-ui-fe/pull/368

**AC**
- Preselect item gallery when user doesn't have access to Assets.
- Preselect Assets when user does have access.
- Make "Add file" button appear without having to click a folder. (If permissions allow it).

**How to test**
- Make access to Assets forbidden for user. (By restricting access only to Global Manager role) (make it recursive)
- Login with user and author an item
- Try to insert media/image