### PR TITLE
Fix TR-1911 - fresh installation fails

### DIFF
--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -140,7 +140,7 @@ class SearchProxy extends ConfigurableService implements Search
      */
     public function supportCustomIndex()
     {
-        return $this->getIndexSearch()->supportCustomIndex();
+        return $this->getAdvancedSearch() !== null;
     }
 
     public function extendGenerisSearchWhiteList(array $whiteList): void


### PR DESCRIPTION
fix: remove infinite recursive calls of `SearchProxy::supportCustomIndex()`

Fresh installation of the latest version is impossible ATM, let's fix it ASAP.