### PR TITLE
fix: correct version mismatch in November release

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -236,9 +236,9 @@ return [
     ],
     'constants' => [
         #TAO version number
-        'TAO_VERSION' => '2021.10',
+        'TAO_VERSION' => '2021.11',
         #TAO version label
-        'TAO_VERSION_NAME' => '2021.10',
+        'TAO_VERSION_NAME' => '2021.11',
         #the name to display
         'PRODUCT_NAME' => 'TAO',
         #TAO release status, use to add specific footer to TAO, available alpha, beta, demo, stable


### PR DESCRIPTION
Related Issue: https://oat-sa.atlassian.net/browse/AUT-1280

Version mismatch in November release.


SETPS to test:
• Checkout to branch: fix/AUT-1280/november-release-version-mismatch
•  Footer version should be November release like below: 
![image](https://user-images.githubusercontent.com/60346520/138679278-2d75c35d-e966-492a-a0f5-890fc152f60f.png)


Current result: version in footer is October release.
