### PR TITLE
[Backport] Fix: fresh installation failure

### DIFF
--- a/models/classes/AdvancedSearch/AdvancedSearchChecker.php
+++ b/models/classes/AdvancedSearch/AdvancedSearchChecker.php
@@ -36,7 +36,7 @@ class AdvancedSearchChecker extends ConfigurableService
     public function isEnabled(): bool
     {
         return !$this->getFeatureFlagChecker()->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_ADVANCED_SEARCH_DISABLED)
-            && $this->getSearchService()->getAdvancedSearch();
+            && $this->getSearchService()->supportCustomIndex();
     }
 
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface

--- a/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
+++ b/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
@@ -43,7 +43,7 @@ class AdvancedSearchCheckerTest extends TestCase
     public function setUp(): void
     {
         $this->featureFlagChecker = $this->createMock(FeatureFlagChecker::class);
-        $this->search = $this->createMock(SearchProxy::class);
+        $this->search = $this->createMock(SearchInterface::class);
         $this->advancedSearchChecker = new AdvancedSearchChecker();
         $this->advancedSearchChecker->setServiceLocator(
             $this->getServiceLocatorMock(
@@ -58,7 +58,7 @@ class AdvancedSearchCheckerTest extends TestCase
     /**
      * @dataProvider isEnabledDataProvider
      */
-    public function testIsEnabled(bool $advancedSearchDisabled, SearchInterface $advancedSearch, bool $expected): void
+    public function testIsEnabled(bool $advancedSearchDisabled, bool $supportsCustomIndex, bool $expected): void
     {
         $this->featureFlagChecker
             ->expects(static::once())
@@ -66,8 +66,8 @@ class AdvancedSearchCheckerTest extends TestCase
             ->willReturn($advancedSearchDisabled);
 
         $this->search
-            ->method('getAdvancedSearch')
-            ->willReturn($advancedSearch);
+            ->method('supportCustomIndex')
+            ->willReturn($supportsCustomIndex);
 
         $this->assertEquals($expected, $this->advancedSearchChecker->isEnabled());
     }
@@ -77,13 +77,23 @@ class AdvancedSearchCheckerTest extends TestCase
         return [
             [
                 'advancedSearchDisabled' => true,
-                'advancedSearch' => $this->createMock(SearchInterface::class),
+                'supportsCustomIndex' => true,
                 'expected' => false,
             ],
             [
                 'advancedSearchDisabled' => false,
-                'advancedSearch' => $this->createMock(SearchInterface::class),
+                'supportsCustomIndex' => false,
+                'expected' => false,
+            ],
+            [
+                'advancedSearchDisabled' => false,
+                'supportsCustomIndex' => true,
                 'expected' => true,
+            ],
+            [
+                'advancedSearchDisabled' => true,
+                'supportsCustomIndex' => false,
+                'expected' => false,
             ],
         ];
     }


### PR DESCRIPTION
Context: https://oat-sa.atlassian.net/browse/TR-1911

Backport of:
- #3203 

> fix: rely on `oat\tao\model\search\SearchInterface` methods only instead of the concrete implementation ones when checking if Advanced Search is enabled

@wazelin 's fix was merged to `develop` (December) and has been backported to October. This PR is to put it into November while the `2021-11-lts` branch is still unreleased.