### PR TITLE
fix: getOntology on class will retrive correect tree

### DIFF
--- a/helpers/TreeHelper.php
+++ b/helpers/TreeHelper.php
@@ -51,6 +51,13 @@ class TreeHelper
             foreach ($resource->getTypes() as $type) {
                 $toTest[$type->getUri()] = [];
             }
+
+            $subClassProp = $resource->getOnePropertyValue(
+                $resource->getModel()->getProperty(OntologyRdfs::RDFS_SUBCLASSOF)
+            );
+            if ($subClassProp !== null) {
+                $toTest[$subClassProp->getUri()] = [];
+            }
         }
         $toOpen = [$rootNode->getUri()];
         while (!empty($toTest)) {


### PR DESCRIPTION
When getOntology data has been called in order to provide tree list for class, endpoint will return only root uri as a return. This fix will fix this issue. 

How to check a bug: 

- Expand few classes levels. Select level 2 class. Refresh site. Tree should be kept in place where your class has been selected. 
- When move to is performed on class resource user will see tree rendered on a moved class resource 

https://oat-sa.atlassian.net/browse/AUT-787
