### PR TITLE
[Fix] ADF-789: List values are replaced with URIs if validation of 'not empty' property failed in Item Properties

### DIFF
--- a/helpers/form/elements/xhtml/AbstractXhtmlSearchElement.php
+++ b/helpers/form/elements/xhtml/AbstractXhtmlSearchElement.php
@@ -101,7 +101,12 @@ require(['jquery'], function ($) {
     var getPropertyDataAndParseUri = function(callback, initialSelection, multiple) {
         $.ajax({
             url: '$searchUrl',
-            data: createRequestData('   '),
+            data: {
+                propertyUri: '$this->name',
+                subject: '   ',
+                exclude: [],
+                parentListValues: getParentListValues()
+            },
             global: false,
             success: function(response) {
                 let parsedResponse = normalizeResponse(response).results;
@@ -181,7 +186,7 @@ var getParentListValues = function () {
     return primaryPropUri ? $('#' + primaryPropUri).val().split(',') : '';
 }
 
-var createRequestData = function (term) {
+var createRequestData = function (term, exclude) {
     return {
         propertyUri: '$this->name',
         subject: term,

--- a/helpers/form/elements/xhtml/AbstractXhtmlSearchElement.php
+++ b/helpers/form/elements/xhtml/AbstractXhtmlSearchElement.php
@@ -142,14 +142,13 @@ require(['jquery'], function ($) {
         },
         initSelection: function (element, callback) {
             let initialSelection = $initSelection;
-
             if (initialSelection) {
                 if (Array.isArray(initialSelection)) {
                     initialSelection.find(function (selection) {
                         return selection.id === selection.text;
-                    }) ? successCallback(callback, initialSelection, true) : callback(initialSelection);
+                    }) ? successCallback(callback, initialSelection, $multipleValue) : callback(initialSelection);
                 } else {
-                    initialSelection.id === initialSelection.text ? successCallback(callback, initialSelection) : callback(initialSelection);
+                    initialSelection.id === initialSelection.text ? successCallback(callback, initialSelection, $multipleValue) : callback(initialSelection);
                 }
             }
         }

--- a/helpers/form/elements/xhtml/AbstractXhtmlSearchElement.php
+++ b/helpers/form/elements/xhtml/AbstractXhtmlSearchElement.php
@@ -98,7 +98,7 @@ abstract class AbstractXhtmlSearchElement extends AbstractSearchElement
 require(['jquery'], function ($) {
     $baseVariables
 
-    var successCallback = function(callback, initialSelection, multiple) {
+    var getPropertyDataAndParseUri = function(callback, initialSelection, multiple) {
         $.ajax({
             url: '$searchUrl',
             data: createRequestData('   '),
@@ -142,14 +142,15 @@ require(['jquery'], function ($) {
         },
         initSelection: function (element, callback) {
             let initialSelection = $initSelection;
+
             if (initialSelection) {
-                if (Array.isArray(initialSelection)) {
-                    initialSelection.find(function (selection) {
-                        return selection.id === selection.text;
-                    }) ? successCallback(callback, initialSelection, $multipleValue) : callback(initialSelection);
-                } else {
-                    initialSelection.id === initialSelection.text ? successCallback(callback, initialSelection, $multipleValue) : callback(initialSelection);
+                if ((Array.isArray(initialSelection)
+                    && initialSelection.find(selection => selection.id === selection.text))
+                    || initialSelection.id === initialSelection.text) {
+                        return getPropertyDataAndParseUri(callback, initialSelection, $multipleValue);
                 }
+
+                callback(initialSelection);
             }
         }
     });

--- a/helpers/form/elements/xhtml/AbstractXhtmlSearchElement.php
+++ b/helpers/form/elements/xhtml/AbstractXhtmlSearchElement.php
@@ -98,6 +98,29 @@ abstract class AbstractXhtmlSearchElement extends AbstractSearchElement
 require(['jquery'], function ($) {
     $baseVariables
 
+    var successCallback = function(callback, initialSelection, multiple) {
+        $.ajax({
+            url: '$searchUrl',
+            data: createRequestData('   '),
+            global: false,
+            success: function(response) {
+                let parsedResponse = normalizeResponse(response).results;
+
+                if (multiple) {
+                    initialSelection.forEach(selection => {
+                        let index = parsedResponse.findIndex(parsedSelection => parsedSelection.id === selection.id);
+                        if (index !== -1) {
+                            selection.text = parsedResponse[index].text;
+                        }
+                    });
+                } else {
+                    initialSelection.text = parsedResponse.find(selection => selection.id === initialSelection.id).text;
+                }
+                callback(initialSelection);
+            }
+        });
+    }
+
     \$input.select2({
         width: '100%',
         multiple: $multipleValue,
@@ -118,7 +141,17 @@ require(['jquery'], function ($) {
                 : `<span class="invalid-choice">\${choice.text}</span>`;
         },
         initSelection: function (element, callback) {
-            callback($initSelection);
+            let initialSelection = $initSelection;
+
+            if (initialSelection) {
+                if (Array.isArray(initialSelection)) {
+                    initialSelection.find(function (selection) {
+                        return selection.id === selection.text;
+                    }) ? successCallback(callback, initialSelection, true) : callback(initialSelection);
+                } else {
+                    initialSelection.id === initialSelection.text ? successCallback(callback, initialSelection) : callback(initialSelection);
+                }
+            }
         }
     });
 
@@ -156,6 +189,7 @@ var createRequestData = function (term) {
         parentListValues: getParentListValues()
     }
 };
+
 javascript;
     }
 


### PR DESCRIPTION
### [ADF-789](https://oat-sa.atlassian.net/browse/ADF-789)

**Preconditions:** A class with 2 properties of Search Input type and one of the properties has 'not empty' option checked; an item created under this class;

Steps to reproduce:

- Go to items tab

- Click on item from Preconditions

- Assign list value for the property that is allowed to be empty in Item Properties

- Leave the property with 'not empty' restriction without any value

- Click 'Save'

**Actual result:** The value in the property without restriction replaced with it's URI.
**Expected result:** The value keeps it's label and is not replaced with URI.