### PR TITLE
fix: Skip calling ElementMapFactory::withInstance() if the instance is not set

### DIFF
--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -112,10 +112,13 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
                 continue;
             }
 
-            //map properties widgets to form elments
-            $element = $this->getElementFactory()
-                ->withInstance($instance)
-                ->create($property);
+            //map properties widgets to form elements
+            $elementFactory = $this->getElementFactory();
+            if($instance != null) {
+                $elementFactory->withInstance($instance);
+            }
+
+            $element = $elementFactory->create($property);
 
             if ($element !== null) {
                 // take instance values to populate the form

--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -17,7 +17,7 @@
  *
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- *               2017-2021 (update and modification) Open Assessment Technologies SA ;
+ *               2017-2021 (update and modification) Open Assessment Technologies SA;
  */
 
 use oat\generis\model\OntologyRdfs;
@@ -112,7 +112,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
 
             //map properties widgets to form elements
             $elementFactory = $this->getElementFactory();
-            if ($instance != null) {
+            if ($instance instanceof core_kernel_classes_Resource) {
                 $elementFactory->withInstance($instance);
             }
 

--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -17,8 +17,7 @@
  *
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- *               2017      (update and modification) Open Assessment Technologies SA ;
- *
+ *               2017-2021 (update and modification) Open Assessment Technologies SA ;
  */
 
 use oat\generis\model\OntologyRdfs;
@@ -38,7 +37,6 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  * @access public
  * @author Bertrand Chevrier, <bertrand.chevrier@tudor.lu>
  * @package tao
-
  */
 class tao_actions_form_Instance extends tao_actions_form_Generis
 {
@@ -114,7 +112,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
 
             //map properties widgets to form elements
             $elementFactory = $this->getElementFactory();
-            if($instance != null) {
+            if ($instance != null) {
                 $elementFactory->withInstance($instance);
             }
 
@@ -179,7 +177,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
             $this->form->addElement($element[0]);
         }
 
-        //add an hidden elt for the class uri
+        // Add a hidden element for the class uri
         $classUriElt = tao_helpers_form_FormFactory::getElement('classUri', 'Hidden');
         $classUriElt->setValue(tao_helpers_Uri::encode($clazz->getUri()));
         $this->form->addElement($classUriElt, true);

--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -178,7 +178,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
             $this->form->addElement($element[0]);
         }
 
-        // Add a hidden element for the class uri
+        //add an hidden elt for the class uri
         $classUriElt = tao_helpers_form_FormFactory::getElement('classUri', 'Hidden');
         $classUriElt->setValue(tao_helpers_Uri::encode($clazz->getUri()));
         $this->form->addElement($classUriElt, true);

--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -112,6 +112,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
 
             //map properties widgets to form elements
             $elementFactory = $this->getElementFactory();
+
             if ($instance instanceof core_kernel_classes_Resource) {
                 $elementFactory->withInstance($instance);
             }

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -225,17 +225,17 @@ class ElementMapFactory extends ConfigurableService
             if ($selectedValue instanceof core_kernel_classes_Literal && !empty($selectedValue->literal)) {
                 $searchRequest->setSelectedValues($selectedValue->literal);
             }
-        }
 
-        if ($parentProperty && $this->instance instanceof core_kernel_classes_Resource) {
-            $parentPropertyValues = [];
+            if ($parentProperty) {
+                $parentPropertyValues = [];
 
-            foreach ($this->instance->getPropertyValuesCollection($parentProperty) as $parentPropertyValue) {
-                $parentPropertyValues[] = (string)$parentPropertyValue;
+                foreach ($this->instance->getPropertyValuesCollection($parentProperty) as $parentPropertyValue) {
+                    $parentPropertyValues[] = (string)$parentPropertyValue;
+                }
+
+                $searchRequest->setPropertyUri($property->getUri());
+                $searchRequest->setParentListValues(...$parentPropertyValues);
             }
-
-            $searchRequest->setPropertyUri($property->getUri());
-            $searchRequest->setParentListValues(...$parentPropertyValues);
         }
 
         return $this->getValueCollectionService()->findAll(new ValueCollectionSearchInput($searchRequest));

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -219,13 +219,15 @@ class ElementMapFactory extends ConfigurableService
     ): ValueCollection {
         $searchRequest = (new ValueCollectionSearchRequest())->setValueCollectionUri($range->getUri());
 
-        $selectedValue = $this->instance->getOnePropertyValue($property);
+        if ($this->instance instanceof core_kernel_classes_Resource) {
+            $selectedValue = $this->instance->getOnePropertyValue($property);
 
-        if ($selectedValue instanceof core_kernel_classes_Literal && !empty($selectedValue->literal)) {
-            $searchRequest->setSelectedValues($selectedValue->literal);
+            if ($selectedValue instanceof core_kernel_classes_Literal && !empty($selectedValue->literal)) {
+                $searchRequest->setSelectedValues($selectedValue->literal);
+            }
         }
 
-        if ($parentProperty && $this->instance) {
+        if ($parentProperty && $this->instance instanceof core_kernel_classes_Resource) {
             $parentPropertyValues = [];
 
             foreach ($this->instance->getPropertyValuesCollection($parentProperty) as $parentPropertyValue) {


### PR DESCRIPTION
**Associated Jira ticket:** [ADF-841](https://oat-sa.atlassian.net/browse/ADF-841)

This fixes calls being made when creating new instances from the remote publishing admin panel, as there is no instance then (and `null` is passed instead). `ElementMapFactory::withInstance()` will fail in such cases, as it expects a non-null parameter.