### PR TITLE
fix(e2e): adjust deleteClass handling for asset

### DIFF
--- a/views/cypress/support/resourceTree.js
+++ b/views/cypress/support/resourceTree.js
@@ -174,6 +174,7 @@ Cypress.Commands.add('moveClassFromRoot', (
  * @param {String} deleteClassUrl - url for the deleting class POST request
  * @param {String} name - name of the class which will be deleted
  * @param {Boolean} isConfirmCheckbox = false - if true also checks confirmation checkbox
+ * @param {Boolean} isAsset = false - if true handles confirmation checkbox differently (works different for asset)
  */
 Cypress.Commands.add('deleteClass', (
     rootSelector,
@@ -182,7 +183,8 @@ Cypress.Commands.add('deleteClass', (
     confirmSelector,
     deleteClassUrl,
     name,
-    isConfirmCheckbox = false
+    isConfirmCheckbox = false,
+    isAsset = false
 ) => {
     cy.log('COMMAND: deleteClass', name)
         .getSettled(`${rootSelector} a:nth(0)`)
@@ -192,16 +194,23 @@ Cypress.Commands.add('deleteClass', (
     cy.get(deleteSelector).click();
 
     if (isConfirmCheckbox) {
-        cy.get('.modal-body label[for=confirm]')
-            .click();
+        if(isAsset){
+            cy.get('button[data-control="ok"]')
+                .click();
+            cy.intercept('POST', `**/${deleteClassUrl}`).as('deleteClass')
+            cy.intercept('POST', '**/edit*').as('edit')
+            cy.wait('@edit');
+        } else {
+            cy.get('.modal-body label[for=confirm]')
+                .click();
+            cy.intercept('POST', `**/${deleteClassUrl}`).as('deleteClass')
+            cy.intercept('POST', '**/edit*').as('edit')
+            cy.get(confirmSelector)
+                .click();
+            cy.wait('@deleteClass');
+            cy.wait('@edit');
+        }
     }
-
-    cy.intercept('POST', `**/${deleteClassUrl}`).as('deleteClass')
-    cy.intercept('POST', '**/edit*').as('edit')
-    cy.get(confirmSelector)
-        .click();
-    cy.wait('@deleteClass');
-    cy.wait('@edit');
 });
 
 /**
@@ -213,6 +222,7 @@ Cypress.Commands.add('deleteClass', (
  * @param {String} deleteClassUrl - url for the deleting class POST request
  * @param {String} name - name of the class which will be deleted
  * @param {Boolean} isConfirmCheckbox = false - if true also checks confirmation checkbox
+ * @param {Boolean} isAsset = false - if true handles confirmation checkbox differently (works different for asset)
  */
 Cypress.Commands.add('deleteClassFromRoot', (
     rootSelector,
@@ -221,7 +231,8 @@ Cypress.Commands.add('deleteClassFromRoot', (
     confirmSelector,
     name,
     deleteClassUrl,
-    isConfirmCheckbox
+    isConfirmCheckbox,
+    isAsset
 ) => {
 
     cy.log('COMMAND: deleteClassFromRoot', name)
@@ -230,7 +241,7 @@ Cypress.Commands.add('deleteClassFromRoot', (
         .click()
         .get(`li[title="${name}"] a`)
         .wait('@edit')
-        .deleteClass(rootSelector, formSelector, deleteSelector, confirmSelector, deleteClassUrl, name, isConfirmCheckbox)
+        .deleteClass(rootSelector, formSelector, deleteSelector, confirmSelector, deleteClassUrl, name, isConfirmCheckbox, isAsset)
 });
 
 /**

--- a/views/cypress/support/resourceTree.js
+++ b/views/cypress/support/resourceTree.js
@@ -197,20 +197,19 @@ Cypress.Commands.add('deleteClass', (
         if(isAsset){
             cy.get('button[data-control="ok"]')
                 .click();
-            cy.intercept('POST', `**/${deleteClassUrl}`).as('deleteClass')
-            cy.intercept('POST', '**/edit*').as('edit')
-            cy.wait('@edit');
         } else {
             cy.get('.modal-body label[for=confirm]')
                 .click();
-            cy.intercept('POST', `**/${deleteClassUrl}`).as('deleteClass')
-            cy.intercept('POST', '**/edit*').as('edit')
-            cy.get(confirmSelector)
-                .click();
-            cy.wait('@deleteClass');
-            cy.wait('@edit');
         }
     }
+    cy.intercept('POST', `**/${deleteClassUrl}`).as('deleteClass')
+    cy.intercept('POST', '**/edit*').as('edit')
+    if (!isAsset) {
+        cy.get(confirmSelector)
+            .click();
+        cy.wait('@deleteClass');
+    }
+    cy.wait('@edit');
 });
 
 /**


### PR DESCRIPTION
**End to end testing.**
Related to: https://oat-sa.atlassian.net/browse/AUT-1195
**Depends on :**

- https://github.com/oat-sa/extension-tao-itemqti/pull/1960
- [oat-sa/tao-mediamanager#359](https://github.com/oat-sa/extension-tao-mediamanager/pull/359)

**Description of changes:**
fix for handling deleteClass function for assets related to e2e tests for: Creating and importing passages/asset and adding to prompt and choice of interaction

Checkout to branch `feature/AUT-1195/e2e-add-asset-passage-to-interaction`
in extensions:

- https://github.com/oat-sa/tao-core
- https://github.com/oat-sa/extension-tao-itemqti
- https://github.com/oat-sa/extension-tao-mediamanager

**run tests from tao core extn:**
npm run cy:open - to run in browser
or npm run cy:run - for headless execution
File to test: add-asset-passage-to-interaction.spec.js
All tests should pass: