### PR TITLE
feat/TR-2853/media-inline-source

### DIFF
--- a/models/classes/media/TaoMediaResolver.php
+++ b/models/classes/media/TaoMediaResolver.php
@@ -22,6 +22,7 @@
 namespace oat\tao\model\media;
 
 use oat\tao\model\media\sourceStrategy\HttpSource;
+use oat\tao\model\media\sourceStrategy\InlineSource;
 use oat\oatbox\service\ServiceManager;
 
 /**
@@ -30,7 +31,7 @@ use oat\oatbox\service\ServiceManager;
  */
 class TaoMediaResolver
 {
-    
+
     /**
      * Resolve a taomedia url to a media asset
      *
@@ -46,6 +47,8 @@ class TaoMediaResolver
             $mediaSource = $mediaService->getMediaSource($urlParts['host']);
             $mediaId = (isset($urlParts['path'])) ? trim($urlParts['path'], '/') : '';
             return new MediaAsset($mediaSource, $mediaId);
+        } elseif (isset($urlParts['scheme']) && $urlParts['scheme'] === 'data') {
+            return new MediaAsset(new InlineSource(), $url);
         } elseif (isset($urlParts['scheme']) && in_array($urlParts['scheme'], ['http','https'])) {
             return new MediaAsset(new HttpSource(), $url);
         } else {

--- a/models/classes/media/sourceStrategy/InlineSource.php
+++ b/models/classes/media/sourceStrategy/InlineSource.php
@@ -26,10 +26,11 @@ use GuzzleHttp\Psr7\Stream;
 use League\MimeTypeDetection\GeneratedExtensionToMimeTypeMap;
 use oat\tao\model\media\MediaBrowser;
 use oat\tao\model\media\mediaSource\DirectorySearchQuery;
+use RuntimeException;
 
 class InlineSource implements MediaBrowser
 {
-    const FILENAME_MASK = 'inline-media-%s';
+    public const FILENAME_PREFIX = 'inline-media-';
 
     public function getDirectories(DirectorySearchQuery $params): array
     {
@@ -48,7 +49,9 @@ class InlineSource implements MediaBrowser
 
     public function download($link)
     {
-        return stream_get_contents($this->getFileStream($link));
+        $stream = $this->getFileStream($link);
+
+        return $stream->getContents();
     }
 
     public function getFileStream($link)
@@ -58,19 +61,40 @@ class InlineSource implements MediaBrowser
 
     public function getBaseName($link)
     {
-        return sprintf(self::FILENAME_MASK, md5($link)) . '.' . $this->detectFileExtension($link);
+        return self::FILENAME_PREFIX . md5($link) . '.' . $this->detectFileExtension($link);
     }
 
     private function detectFileExtension($link): ?string
     {
-        $fp = $this->createResource($link);
-        $meta = stream_get_meta_data($fp);
+        $stream = $this->getFileStream($link);
+        $mimetype = $stream->getMetadata('mediatype');
+        $extension = array_search($mimetype, GeneratedExtensionToMimeTypeMap::MIME_TYPES_FOR_EXTENSIONS);
+        if (!$extension) {
+            throw new RuntimeException(
+                sprintf('Could not determined inline asset file extension from the mime type: %s.', $mimetype)
+            );
+        }
 
-        return array_search($meta['mediatype'], GeneratedExtensionToMimeTypeMap::MIME_TYPES_FOR_EXTENSIONS);
+        return $extension;
     }
 
     private function createResource($link)
     {
-        return fopen($link, 'r');
+        $this->verifyDataUrlScheme($link);
+
+        $resource = @fopen($link, 'r');
+        if (!$resource) {
+            throw new RuntimeException('Invalid Data URL, could not create a resource.');
+        }
+
+        return $resource;
+    }
+
+    private function verifyDataUrlScheme($link): void
+    {
+        $urlScheme = parse_url($link, PHP_URL_SCHEME);
+        if ($urlScheme !== 'data') {
+            throw new RuntimeException('Provided URL should match the Data (RFC 2397) scheme.');
+        }
     }
 }

--- a/models/classes/media/sourceStrategy/InlineSource.php
+++ b/models/classes/media/sourceStrategy/InlineSource.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\media\sourceStrategy;
+
+use common_Exception;
+use GuzzleHttp\Psr7\Stream;
+use League\MimeTypeDetection\GeneratedExtensionToMimeTypeMap;
+use oat\tao\model\media\MediaBrowser;
+use oat\tao\model\media\mediaSource\DirectorySearchQuery;
+
+class InlineSource implements MediaBrowser
+{
+    const FILENAME_MASK = 'inline-media-%s';
+
+    public function getDirectories(DirectorySearchQuery $params): array
+    {
+        throw new common_Exception(__FUNCTION__ . ' not implemented');
+    }
+
+    public function getDirectory($parentLink = '/', $acceptableMime = [], $depth = 1)
+    {
+        throw new common_Exception(__FUNCTION__ . ' not implemented');
+    }
+
+    public function getFileInfo($link)
+    {
+        throw new common_Exception(__FUNCTION__ . ' not implemented');
+    }
+
+    public function download($link)
+    {
+        return stream_get_contents($this->getFileStream($link));
+    }
+
+    public function getFileStream($link)
+    {
+        return new Stream($this->createResource($link));
+    }
+
+    public function getBaseName($link)
+    {
+        return sprintf(self::FILENAME_MASK, md5($link)) . '.' . $this->detectFileExtension($link);
+    }
+
+    private function detectFileExtension($link): ?string
+    {
+        $fp = $this->createResource($link);
+        $meta = stream_get_meta_data($fp);
+
+        return array_search($meta['mediatype'], GeneratedExtensionToMimeTypeMap::MIME_TYPES_FOR_EXTENSIONS);
+    }
+
+    private function createResource($link)
+    {
+        return fopen($link, 'r');
+    }
+}

--- a/test/unit/models/classes/media/InlineSourceTest.php
+++ b/test/unit/models/classes/media/InlineSourceTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+
+namespace oat\tao\test\unit\models\classes\media;
+
+use oat\generis\test\GenerisTestCase;
+use oat\tao\model\media\mediaSource\DirectorySearchQuery;
+use oat\tao\model\media\sourceStrategy\InlineSource;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+class InlineSourceTest extends GenerisTestCase
+{
+    /** @var InlineSource $sut */
+    private $sut;
+
+    protected function setUp(): void
+    {
+        $this->sut = new InlineSource();
+    }
+
+    public function testGetFileStream_WhenInlineAssetUrlIsCorrect_ThenStreamIsReturned()
+    {
+        $stream = $this->sut->getFileStream($this->inlineAssetDataUrlFixture());
+        $this->assertInstanceOf(StreamInterface::class, $stream);
+    }
+
+    /**
+     * @dataProvider invalidUrlProvider
+     */
+    public function testGetFileStream_WhenInlineAssetUrlIsInvalid_ThenExceptionThrown($url)
+    {
+        $this->expectException(RuntimeException::class);
+        $stream = $this->sut->getFileStream($url);
+    }
+
+    public function testDownload_WhenDataUrlProvided_ThenContentsAreReturned()
+    {
+        $contents = $this->sut->download($this->inlineAssetDataUrlFixture());
+
+        $this->assertEquals(base64_decode($this->base64EncodedImageFixture()), $contents);
+    }
+
+    public function testGetBaseName_WhenFileExtensionCanNotBeDetermined_ThenExceptionIsThrown()
+    {
+        $this->expectException(RuntimeException::class);
+        $urlWithFakeMimeType = "data://text/invalid;base64,dGVzdA==";
+        $this->sut->getBaseName($urlWithFakeMimeType);
+    }
+
+    public function testGetBaseName_WhenDataUrlIsProvided_ThenFilenameWithAHashIsReturned()
+    {
+        $name = $this->sut->getBaseName($this->inlineAssetDataUrlFixture());
+        $this->assertEquals('inline-media-b9f1078dff938f6a9ffbbf12f994b577.bmp', $name);
+    }
+
+    public function testGetFileInfo_WhenInvoked_ThenExceptionThrown()
+    {
+        $this->expectException(\common_Exception::class);
+        $this->sut->getFileInfo('');
+    }
+
+    public function testGetDirectories_WhenInvoked_ThenExceptionThrown()
+    {
+        $this->expectException(\common_Exception::class);
+        $this->sut->getDirectories($this->createMock(DirectorySearchQuery::class));
+    }
+
+    public function testGetDirectory_WhenInvoked_ThenExceptionThrown()
+    {
+        $this->expectException(\common_Exception::class);
+        $this->sut->getDirectory();
+    }
+
+    private function inlineAssetDataUrlFixture()
+    {
+        return 'data:image/bmp;base64,' . $this->base64EncodedImageFixture();
+    }
+
+    private function base64EncodedImageFixture()
+    {
+        return 'Qk1yAAAAAAAAAD4AAAAoAAAADgAAAA0AAAABAAEAAAAAADQAAADEDgAAxA4AAAIAAAACAAAA////AAAAAAAAAAAAAAAOAAAApgAHwLQAHGD0ADAw5gBgGLYAAgAAAAAAAAAQIAAAAAAAAAACAAAAAwq3';
+    }
+
+    public function invalidUrlProvider(): array
+    {
+        return [
+            'Invalid mime type' => [
+                "data://invalid;base64,"
+            ],
+            'Invalid encoding' => [
+                "data://text/plain;invalid,"
+            ],
+            'Invalid scheme' => [
+                "invalid://text/plain;base64,dGVzdA=="
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Inline media source type
 
Related to : https://oat-sa.atlassian.net/browse/TR-2853
 
Created new type, `oat\tao\model\media\sourceStrategy\InlineSource` to handle base64 encoded item assets.
 
  
#### How to test
 
Described in accompanying PR https://github.com/oat-sa/extension-tao-itemqti/pull/1961
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-itemqti/pull/1961
 - [ ] https://github.com/oat-sa/extension-tao-item/pull/550