### PR TITLE
Feature/ADF-759/Efficient loading of lists with huge amount of elements

### DIFF
--- a/models/classes/Lists/Business/Domain/ValueCollection.php
+++ b/models/classes/Lists/Business/Domain/ValueCollection.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2021 (original work) Open Assessment Technologies SA;
  *
  * @author Sergei Mikhailov <sergei.mikhailov@taotesting.com>
  */
@@ -25,9 +25,9 @@ declare(strict_types=1);
 namespace oat\tao\model\Lists\Business\Domain;
 
 use Countable;
-use IteratorAggregate;
-use JsonSerializable;
 use Traversable;
+use JsonSerializable;
+use IteratorAggregate;
 
 class ValueCollection implements IteratorAggregate, JsonSerializable, Countable
 {
@@ -36,6 +36,8 @@ class ValueCollection implements IteratorAggregate, JsonSerializable, Countable
 
     /** @var Value[] */
     private $values = [];
+
+    private $totalCount = 0;
 
     public function __construct(string $uri = null, Value ...$values)
     {
@@ -109,6 +111,16 @@ class ValueCollection implements IteratorAggregate, JsonSerializable, Countable
     public function count(): int
     {
         return count($this->values);
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->totalCount;
+    }
+
+    public function setTotalCount(int $totalCount): void
+    {
+        $this->totalCount = $totalCount;
     }
 
     private function ensureValueProperties(Value $value): Value

--- a/models/classes/Lists/Business/Domain/ValueCollectionSearchRequest.php
+++ b/models/classes/Lists/Business/Domain/ValueCollectionSearchRequest.php
@@ -38,6 +38,9 @@ class ValueCollectionSearchRequest
     /** @var string[] */
     private $excluded = [];
 
+    /** @var int */
+    private $offset = 0;
+
     /** @var int|null */
     private $limit;
 
@@ -143,6 +146,23 @@ class ValueCollectionSearchRequest
     public function addExcluded(string $excluded): self
     {
         $this->excluded[] = $excluded;
+
+        return $this;
+    }
+
+    public function hasOffset(): bool
+    {
+        return $this->offset > 0;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function setOffset(int $offset): self
+    {
+        $this->offset = $offset;
 
         return $this;
     }

--- a/models/classes/Lists/Business/Domain/ValueCollectionSearchRequest.php
+++ b/models/classes/Lists/Business/Domain/ValueCollectionSearchRequest.php
@@ -38,8 +38,8 @@ class ValueCollectionSearchRequest
     /** @var string[] */
     private $excluded = [];
 
-    /** @var int */
-    private $offset = 0;
+    /** @var int|null */
+    private $offset;
 
     /** @var int|null */
     private $limit;
@@ -152,10 +152,10 @@ class ValueCollectionSearchRequest
 
     public function hasOffset(): bool
     {
-        return $this->offset > 0;
+        return $this->offset !== null && $this->offset >= 0;
     }
 
-    public function getOffset(): int
+    public function getOffset(): ?int
     {
         return $this->offset;
     }

--- a/models/classes/Lists/Business/Specification/EditableListClassSpecification.php
+++ b/models/classes/Lists/Business/Specification/EditableListClassSpecification.php
@@ -23,26 +23,22 @@ declare(strict_types=1);
 namespace oat\tao\model\Lists\Business\Specification;
 
 use core_kernel_classes_Class;
-use oat\generis\model\GenerisRdf;
+use tao_models_classes_LanguageService;
 use oat\tao\model\Specification\ClassSpecificationInterface;
 
-class LocalListClassSpecification implements ClassSpecificationInterface
+class EditableListClassSpecification implements ClassSpecificationInterface
 {
     /** @var ClassSpecificationInterface */
-    private $remoteListClassSpecification;
+    private $listClassSpecification;
 
-    public function __construct(ClassSpecificationInterface $remoteListClassSpecification)
+    public function __construct(ClassSpecificationInterface $listClassSpecification)
     {
-        $this->remoteListClassSpecification = $remoteListClassSpecification;
+        $this->listClassSpecification = $listClassSpecification;
     }
 
     public function isSatisfiedBy(core_kernel_classes_Class $class): bool
     {
-        return $this->isBoolean($class) || !$this->remoteListClassSpecification->isSatisfiedBy($class);
-    }
-
-    private function isBoolean(core_kernel_classes_Class $class): bool
-    {
-        return $class->getUri() === GenerisRdf::GENERIS_BOOLEAN;
+        return $this->listClassSpecification->isSatisfiedBy($class)
+            && $class->getUri() !== tao_models_classes_LanguageService::CLASS_URI_LANGUAGES;
     }
 }

--- a/models/classes/Lists/Business/Specification/ListClassSpecification.php
+++ b/models/classes/Lists/Business/Specification/ListClassSpecification.php
@@ -23,26 +23,13 @@ declare(strict_types=1);
 namespace oat\tao\model\Lists\Business\Specification;
 
 use core_kernel_classes_Class;
-use oat\generis\model\GenerisRdf;
+use oat\tao\model\TaoOntology;
 use oat\tao\model\Specification\ClassSpecificationInterface;
 
-class LocalListClassSpecification implements ClassSpecificationInterface
+class ListClassSpecification implements ClassSpecificationInterface
 {
-    /** @var ClassSpecificationInterface */
-    private $remoteListClassSpecification;
-
-    public function __construct(ClassSpecificationInterface $remoteListClassSpecification)
-    {
-        $this->remoteListClassSpecification = $remoteListClassSpecification;
-    }
-
     public function isSatisfiedBy(core_kernel_classes_Class $class): bool
     {
-        return $this->isBoolean($class) || !$this->remoteListClassSpecification->isSatisfiedBy($class);
-    }
-
-    private function isBoolean(core_kernel_classes_Class $class): bool
-    {
-        return $class->getUri() === GenerisRdf::GENERIS_BOOLEAN;
+        return $class->isSubClassOf($class->getClass(TaoOntology::CLASS_URI_LIST));
     }
 }

--- a/models/classes/Lists/Business/Specification/LocalListClassSpecification.php
+++ b/models/classes/Lists/Business/Specification/LocalListClassSpecification.php
@@ -25,24 +25,35 @@ namespace oat\tao\model\Lists\Business\Specification;
 use core_kernel_classes_Class;
 use oat\generis\model\GenerisRdf;
 use oat\tao\model\Specification\ClassSpecificationInterface;
+use oat\tao\model\Lists\Business\Service\RemoteSourcedListOntology;
 
 class LocalListClassSpecification implements ClassSpecificationInterface
 {
     /** @var ClassSpecificationInterface */
-    private $remoteListClassSpecification;
+    private $listClassSpecification;
 
-    public function __construct(ClassSpecificationInterface $remoteListClassSpecification)
+    public function __construct(ClassSpecificationInterface $listClassSpecification)
     {
-        $this->remoteListClassSpecification = $remoteListClassSpecification;
+        $this->listClassSpecification = $listClassSpecification;
     }
 
     public function isSatisfiedBy(core_kernel_classes_Class $class): bool
     {
-        return $this->isBoolean($class) || !$this->remoteListClassSpecification->isSatisfiedBy($class);
+        return (
+                $this->listClassSpecification->isSatisfiedBy($class)
+                || $this->isBoolean($class)
+            ) && $this->isNotRemoteList($class);
     }
 
     private function isBoolean(core_kernel_classes_Class $class): bool
     {
         return $class->getUri() === GenerisRdf::GENERIS_BOOLEAN;
+    }
+
+    private function isNotRemoteList(core_kernel_classes_Class $class): bool
+    {
+        $propertyListType = $class->getProperty(RemoteSourcedListOntology::PROPERTY_LIST_TYPE);
+
+        return $class->getOnePropertyValue($propertyListType) === null;
     }
 }

--- a/models/classes/Lists/Business/Specification/RemoteListClassSpecification.php
+++ b/models/classes/Lists/Business/Specification/RemoteListClassSpecification.php
@@ -25,14 +25,13 @@ namespace oat\tao\model\Lists\Business\Specification;
 use core_kernel_classes_Class;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\Specification\ClassSpecificationInterface;
-use oat\tao\model\TaoOntology;
 use oat\tao\model\Lists\Business\Service\RemoteSourcedListOntology;
 
 class RemoteListClassSpecification extends ConfigurableService implements ClassSpecificationInterface
 {
     public function isSatisfiedBy(core_kernel_classes_Class $class): bool
     {
-        if (!$class->isSubClassOf($class->getClass(TaoOntology::CLASS_URI_LIST))) {
+        if (!$this->getListClassSpecification()->isSatisfiedBy($class)) {
             return false;
         }
 
@@ -41,5 +40,10 @@ class RemoteListClassSpecification extends ConfigurableService implements ClassS
         );
 
         return $propertyType !== null && $propertyType->getUri() === RemoteSourcedListOntology::LIST_TYPE_REMOTE;
+    }
+
+    private function getListClassSpecification(): ClassSpecificationInterface
+    {
+        return $this->getServiceManager()->getContainer()->get(ListClassSpecification::class);
     }
 }

--- a/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepository.php
+++ b/models/classes/Lists/DataAccess/Repository/RdfValueCollectionRepository.php
@@ -283,7 +283,7 @@ class RdfValueCollectionRepository extends InjectionAwareService implements Valu
         $query->addOrderBy('element.id');
     }
 
-    private function enrichWithSelect(ValueCollectionSearchRequest $searchRequest, QueryBuilder $query): QueryBuilder
+    private function enrichWithSelect(ValueCollectionSearchRequest $searchRequest, QueryBuilder $query): void
     {
         $query->select(
             'collection.object as collection_uri',
@@ -293,11 +293,13 @@ class RdfValueCollectionRepository extends InjectionAwareService implements Valu
             'element.l_language as datalanguage'
         );
 
+        if ($searchRequest->hasOffset()) {
+            $query->setFirstResult($searchRequest->getOffset());
+        }
+
         if ($searchRequest->hasLimit()) {
             $query->setMaxResults($searchRequest->getLimit());
         }
-
-        return $query;
     }
 
     private function enrichQueryWithPropertySearchConditions(

--- a/models/classes/Lists/ServiceProvider/ListsServiceProvider.php
+++ b/models/classes/Lists/ServiceProvider/ListsServiceProvider.php
@@ -25,17 +25,19 @@ namespace oat\tao\model\Lists\ServiceProvider;
 use oat\generis\model\data\Ontology;
 use oat\generis\persistence\PersistenceManager;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
-use oat\tao\model\Lists\Business\Specification\LocalListClassSpecification;
 use oat\tao\model\Lists\Business\Validation\PropertyListValidator;
 use oat\tao\model\Lists\Business\Validation\PropertyTypeValidator;
 use oat\tao\model\Lists\DataAccess\Repository\DependencyRepository;
+use oat\tao\model\Lists\Business\Specification\ListClassSpecification;
 use oat\tao\model\Lists\Business\Validation\DependsOnPropertyValidator;
 use oat\tao\model\Lists\DataAccess\Repository\DependsOnPropertyRepository;
+use oat\tao\model\Lists\Business\Specification\LocalListClassSpecification;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\tao\model\Lists\Business\Specification\PrimaryPropertySpecification;
 use oat\tao\model\Lists\Business\Specification\RemoteListClassSpecification;
 use oat\tao\model\Lists\DataAccess\Repository\DependentPropertiesRepository;
 use oat\tao\model\Lists\Business\Specification\DependentPropertySpecification;
+use oat\tao\model\Lists\Business\Specification\EditableListClassSpecification;
 use oat\tao\model\Lists\Business\Specification\SecondaryPropertySpecification;
 use oat\tao\model\Lists\Business\Specification\RemoteListPropertySpecification;
 use oat\tao\model\Lists\DataAccess\Repository\ParentPropertyListCachedRepository;
@@ -131,7 +133,12 @@ class ListsServiceProvider implements ContainerServiceProviderInterface
 
         $services
             ->set(LocalListClassSpecification::class, LocalListClassSpecification::class)
-            ->public();
+            ->public()
+            ->args(
+                [
+                    service(RemoteListClassSpecification::class),
+                ]
+            );
 
         $services
             ->set(DependsOnPropertyFormFieldFactory::class, DependsOnPropertyFormFieldFactory::class)
@@ -140,6 +147,19 @@ class ListsServiceProvider implements ContainerServiceProviderInterface
                 [
                     service(FeatureFlagChecker::class),
                     service(DependsOnPropertyRepository::class),
+                ]
+            );
+
+        $services
+            ->set(ListClassSpecification::class, ListClassSpecification::class)
+            ->public();
+
+        $services
+            ->set(EditableListClassSpecification::class, EditableListClassSpecification::class)
+            ->public()
+            ->args(
+                [
+                    service(ListClassSpecification::class),
                 ]
             );
     }

--- a/models/classes/Lists/ServiceProvider/ListsServiceProvider.php
+++ b/models/classes/Lists/ServiceProvider/ListsServiceProvider.php
@@ -136,7 +136,7 @@ class ListsServiceProvider implements ContainerServiceProviderInterface
             ->public()
             ->args(
                 [
-                    service(RemoteListClassSpecification::class),
+                    service(ListClassSpecification::class),
                 ]
             );
 

--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -743,6 +743,7 @@
                         type: 'GET',
                         data: {
                             listUri: classUri,
+                            limit: 0,
                         },
                         success: function (response) {
                             let html = '<ul class="form-elt-list">',

--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -737,14 +737,12 @@
 
                 if (classUri && classUri.trim()) {
                     $this.parent('div').children('div.form-error').remove();
-                    const isRemoteList = !!$this.find('option:selected').attr('data-remote-list');
 
                     $.ajax({
                         url: context.root_url + 'taoBackOffice/Lists/getListElements',
                         type: 'GET',
                         data: {
                             listUri: classUri,
-                            limit: 0,
                         },
                         success: function (response) {
                             let html = '<ul class="form-elt-list">',
@@ -758,7 +756,7 @@
                                 html += `<li>${encode.html(response.data.elements[property].label)}</li>`;
                             }
 
-                            if (isRemoteList && response.data.totalCount > response.data.elements.length) {
+                            if (response.data.totalCount > response.data.elements.length) {
                                 html += `<li>...</li>`;
                             }
 

--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -737,6 +737,7 @@
 
                 if (classUri && classUri.trim()) {
                     $this.parent('div').children('div.form-error').remove();
+                    const isRemoteList = !!$this.find('option:selected').attr('data-remote-list');
 
                     $.ajax({
                         url: context.root_url + 'taoBackOffice/Lists/getListElements',
@@ -749,12 +750,16 @@
                             let html = '<ul class="form-elt-list">',
                                 property;
 
-                            for (property in response) {
-                                if(!response.hasOwnProperty(property)) {
+                            for (property in response.data.elements) {
+                                if (!response.data.elements.hasOwnProperty(property)) {
                                     continue;
                                 }
 
-                                html += '<li>' + encode.html(response[property]) + '</li>';
+                                html += `<li>${encode.html(response.data.elements[property].label)}</li>`;
+                            }
+
+                            if (isRemoteList && response.data.totalCount > response.data.elements.length) {
+                                html += `<li>...</li>`;
                             }
 
                             html += '</ul>';

--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -749,7 +749,7 @@
                                 property;
 
                             for (property in response.data.elements) {
-                                if (!response.data.elements.hasOwnProperty(property)) {
+                                if (!Object.prototype.hasOwnProperty.call(response.data.elements, property)) {
                                     continue;
                                 }
 

--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -728,28 +728,34 @@
              */
             function showPropertyListValues() {
                 const $this = $(this);
-                const elt = $this.parent("div");
+                const elt = $this.parent('div');
                 let classUri;
 
                 //load the instances and display them (the list items)
-                $(elt).parent("div").children("ul.form-elt-list").remove();
+                $(elt).parent('div').children('ul.form-elt-list').remove();
                 classUri = $this.val();
+
                 if (classUri && classUri.trim()) {
-                    $this.parent("div").children("div.form-error").remove();
+                    $this.parent('div').children('div.form-error').remove();
+
                     $.ajax({
                         url: context.root_url + 'taoBackOffice/Lists/getListElements',
-                        type: "POST",
-                        data: {listUri: classUri},
-                        dataType: 'json',
+                        type: 'GET',
+                        data: {
+                            listUri: classUri,
+                        },
                         success: function (response) {
-                            let html = "<ul class='form-elt-list'>",
+                            let html = '<ul class="form-elt-list">',
                                 property;
+
                             for (property in response) {
                                 if(!response.hasOwnProperty(property)) {
                                     continue;
                                 }
+
                                 html += '<li>' + encode.html(response[property]) + '</li>';
                             }
+
                             html += '</ul>';
                             $(elt).after(html);
                         }


### PR DESCRIPTION
# [ADF-759](https://oat-sa.atlassian.net/browse/ADF-759)

## Companion PRs
* https://github.com/oat-sa/extension-tao-backoffice/pull/116

## Changes
* Added `setTotalCount`/`getTotalCount` methods to `ValueCollection`;
* Added `hasOffset`/`setOffset`/`getOffset` methods to `ValueCollectionsSearchRequest`;
* Added new specification to check if class is editable or not;
* Added new specification to check if class is list or not;
* Added possibility to filter result (tested on local/remote list elements) by offset;
* Changed request to get list elements:
  * Now method is `GET` instead of `POST`;
  * Now `...` element is adding on FE side by checking for the list type (remote or not);
  * Now request is using new response.

## Tasks
- [ ] Add/update unit tests