### PR TITLE
Fix/ADF-865/Return empty dependencies list if feature flag is disabled

### DIFF
--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -486,7 +486,7 @@
              */
             async function checkForDependency(propertyUri, $groupNode) {
                 if (!context.featureFlags.FEATURE_FLAG_LISTS_DEPENDENCY_ENABLED) {
-                    return;
+                    return [];
                 }
 
                 const typeSelectVal = $groupNode.find('select[id$="type"]').val();
@@ -513,7 +513,7 @@
 
             async function getPropertyRemovalConfirmation($groupNode, uri) {
                 const dependencies = await checkForDependency(uri, $groupNode);
-                const dependsOnValue = $($groupNode).find('select[id$="_depends-on-property"]').val();
+                const dependsOnValue = $($groupNode).find('select[id$="_depends-on-property"]').val() || ' ';
 
                 return new Promise((resolve, reject) => {
                     if (!dependencies.length && dependsOnValue === ' ') {


### PR DESCRIPTION
# [ADF-865](https://oat-sa.atlassian.net/browse/ADF-865)

## Changes
* Method `checkForDependency` will return an empty array if feature flag is disabled.
* If there's no `depends on property` value - use `' '` as a default value.

## How to test
1. Disable FEATURE_FLAG_LISTS_DEPENDENCY_ENABLED feature flag;
2. Create a new class or select an existing one;
3. Open schema managements;
4. Create new property;
5. Try to delete it.

**Previous behavior:** _nothing happens, property is not deleted, no errors, no calls on Network tab of Devtools._
**Current behavior:** _the confirmation pop-up message opens, property is removed after clicking `OK`._