### PR TITLE
fix: gracefull fallback if no configured mapping has been provided

### DIFF
--- a/helpers/form/AbstractFeatureFlagFormPropertyMapper.php
+++ b/helpers/form/AbstractFeatureFlagFormPropertyMapper.php
@@ -34,7 +34,7 @@ abstract class AbstractFeatureFlagFormPropertyMapper extends ConfigurableService
     {
         $excludedProperties = [];
 
-        foreach ($this->getOption(self::OPTION_FEATURE_FLAG_FORM_FIELDS) as $field => $featureFlags) {
+        foreach ($this->getOption(self::OPTION_FEATURE_FLAG_FORM_FIELDS, []) as $field => $featureFlags) {
             foreach ($featureFlags as $featureFlag) {
                 if (!$this->getFeatureFlagChecker()->isEnabled($featureFlag)) {
                     $excludedProperties[] = $field;


### PR DESCRIPTION
Prevents hidden fatal errors and unpredictable behavior whenever no options have been specified in the configuration