### PR TITLE
feat/AUT-973/e2e tests: update cypress to v9

### DIFF
--- a/views/cypress/support/commands.js
+++ b/views/cypress/support/commands.js
@@ -112,7 +112,7 @@ Cypress.Commands.add('getSettled', (selector, opts = {}) => {
  * @return {Boolean}
  */
 Cypress.Commands.add('isElementPresent', (selector, opts = {}) => {
-    const timeout = opts.timeout || 5000;
+    const timeout = opts.timeout || 10000;
     const delay = opts.delay || 500;
 
     const isPresent = (resolve) => {

--- a/views/cypress/support/resourceProperties.js
+++ b/views/cypress/support/resourceProperties.js
@@ -38,7 +38,8 @@
         .get(formSelector).should('exist')
         .get(`${formSelector} ${selectors.labelSelector}`).should('have.value', newName)
         .wait('@treeRender')
-        .wait('@editClassLabel');
+        .wait('@editClassLabel')
+        .getSettled(`li[title="${newName}"]`);
 });
 
 /**
@@ -62,6 +63,7 @@ Cypress.Commands.add('renameSelectedNode', (formSelector, editUrl, newName) => {
         .wait('@treeRender')
         .wait('@edit')
         .get(`${formSelector} ${selectors.labelSelector}`).should('have.value', newName)
+        .getSettled(`li[title="${newName}"]`);
 });
 
 /**

--- a/views/cypress/support/resourceTree.js
+++ b/views/cypress/support/resourceTree.js
@@ -127,8 +127,8 @@ Cypress.Commands.add('moveClass', (
         .getSettled(moveSelector)
         .click()
         .wait('@classToMove')
-        .getSettled(`.destination-selector a[title="${nameWhereMove}"]`)
-        .click()
+        .getSettled(`.destination-selector a[title="${nameWhereMove}"]`).last()
+        .click({force: true})
         .intercept('POST', `**/${moveClassUrl}*`).as('moveClass')
         .intercept('GET', '**/getOntologyData*').as('treeRenderAfterMove')
         .get('.actions button')
@@ -136,7 +136,8 @@ Cypress.Commands.add('moveClass', (
         .get(moveConfirmSelector)
         .click()
         .wait('@moveClass').its('response.body').its('success').should('eq', true)
-        .wait('@treeRenderAfterMove');
+        .wait('@treeRenderAfterMove')
+        .getSettled(`.section-trees li[title="${name}"]`);
 });
 
 /**
@@ -187,9 +188,8 @@ Cypress.Commands.add('deleteClass', (
     isAsset = false
 ) => {
     cy.log('COMMAND: deleteClass', name)
-        .getSettled(`${rootSelector} a:nth(0)`)
-        .get(`li[title="${name}"] a:nth(0)`).click()
-        .get(formSelector)
+        .getSettled(`li[title="${name}"] > a`).last().click()
+        .getSettled(`${formSelector} input[value="${name}"]`)
         .should('exist')
     cy.get(deleteSelector).click();
 
@@ -236,9 +236,9 @@ Cypress.Commands.add('deleteClassFromRoot', (
 
     cy.log('COMMAND: deleteClassFromRoot', name)
         .intercept('POST', '**/edit*').as('edit')
-        .getSettled(`${rootSelector} a:nth(0)`)
+        .getSettled(`${rootSelector} > a`)
         .click()
-        .get(`li[title="${name}"] a`)
+        .get(`li[title="${name}"] > a`)
         .wait('@edit')
         .deleteClass(rootSelector, formSelector, deleteSelector, confirmSelector, deleteClassUrl, name, isConfirmCheckbox, isAsset)
 });

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -14,51 +14,18 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.15.3",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-            "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+            "version": "7.16.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+            "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
             "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
         },
-        "@cypress/listr-verbose-renderer": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
-            "integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "cli-cursor": "^1.0.2",
-                "date-fns": "^1.27.2",
-                "figures": "^1.7.0"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
-        },
         "@cypress/request": {
-            "version": "2.88.6",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
-            "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
+            "version": "2.88.10",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+            "integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
             "dev": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
@@ -68,8 +35,7 @@
                 "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
                 "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
+                "http-signature": "~1.3.6",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
@@ -116,9 +82,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -144,10 +110,19 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.5",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+                    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
                 }
             }
         },
@@ -163,9 +138,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -183,9 +158,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -203,9 +178,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -222,9 +197,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -241,9 +216,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -260,9 +235,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -280,9 +255,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -299,9 +274,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -318,9 +293,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -337,9 +312,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -356,9 +331,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -375,9 +350,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -394,9 +369,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -413,9 +388,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -432,9 +407,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -451,9 +426,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -470,9 +445,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -489,9 +464,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -509,9 +484,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -528,9 +503,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -547,9 +522,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -566,9 +541,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -585,9 +560,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -604,9 +579,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -644,9 +619,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -664,9 +639,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -683,9 +658,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -707,9 +682,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -726,23 +701,22 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
         },
         "@oat-sa/e2e-runner": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/e2e-runner/-/e2e-runner-1.2.1.tgz",
-            "integrity": "sha512-Ggc+CnM/EwLOXxezeog2Ah3cz7YKtVPLUMhj7Goxe/zG7GKXQSkA+Mr0hiEtL9f0zBdo62l/nUT4xTiX8qEdaA==",
+            "version": "git://github.com/oat-sa/e2e-runner.git#26810f756d1e523bee970bca1d6e9d60be3cc0b5",
+            "from": "git://github.com/oat-sa/e2e-runner.git#feat/AUT-973/update-cypress",
             "dev": true,
             "requires": {
-                "cypress": "^6.6.0",
-                "cypress-file-upload": "^5.0.7",
+                "cypress": "^9.0.0",
+                "cypress-file-upload": "^5.0.8",
                 "cypress-plugin-snapshots": "^1.4.4",
-                "fs-extra": "^9.1.0",
+                "fs-extra": "^10.0.0",
                 "oauth-sign": "^0.9.0"
             }
         },
@@ -776,25 +750,16 @@
             "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.47.0.tgz",
             "integrity": "sha512-WBwAn4XYH171om3Up+o/xnr+aMG+OkNdudcK4vyG46CLO2D3siCb9wPYdKaDUdLy75xpSwDq2Rf1P5+0jOfgHg=="
         },
-        "@samverschueren/stream-to-observable": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
-            "integrity": "sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==",
-            "dev": true,
-            "requires": {
-                "any-observable": "^0.3.0"
-            }
-        },
         "@types/node": {
-            "version": "12.12.50",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.50.tgz",
-            "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==",
+            "version": "14.18.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.3.tgz",
+            "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==",
             "dev": true
         },
         "@types/sinonjs__fake-timers": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
-            "integrity": "sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
+            "integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
             "dev": true
         },
         "@types/sizzle": {
@@ -802,6 +767,16 @@
             "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
             "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
             "dev": true
+        },
+        "@types/yauzl": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+            "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "abbrev": {
             "version": "1.1.1",
@@ -825,16 +800,14 @@
             "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
             "dev": true
         },
-        "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+        "aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
             }
         },
         "amdefine": {
@@ -843,34 +816,40 @@
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
             "optional": true
         },
-        "ansi-escapes": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+        "ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true
         },
+        "ansi-escapes": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+            "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+            "dev": true,
+            "requires": {
+                "type-fest": "^0.21.3"
+            }
+        },
         "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true
         },
         "ansi-styles": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^2.0.1"
+            }
         },
         "any-base": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
             "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
-            "dev": true
-        },
-        "any-observable": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-            "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
             "dev": true
         },
         "arch": {
@@ -886,9 +865,9 @@
             "dev": true
         },
         "asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
             "dev": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
@@ -900,10 +879,16 @@
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
             "dev": true
         },
+        "astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true
+        },
         "async": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
-            "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+            "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
             "dev": true
         },
         "asynckit": {
@@ -1053,13 +1038,13 @@
                 "supports-color": "^7.1.0"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^2.0.1"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -1071,18 +1056,24 @@
             "dev": true
         },
         "ci-info": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+            "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
+            "dev": true
+        },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "dev": true
         },
         "cli-cursor": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-            "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
             "dev": true,
             "requires": {
-                "restore-cursor": "^1.0.1"
+                "restore-cursor": "^3.1.0"
             }
         },
         "cli-table3": {
@@ -1097,42 +1088,14 @@
             }
         },
         "cli-truncate": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
-            "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+            "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
             "dev": true,
             "requires": {
-                "slice-ansi": "0.0.4",
-                "string-width": "^1.0.1"
-            },
-            "dependencies": {
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "dev": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "dev": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                }
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
             }
-        },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "dev": true
         },
         "codemirror": {
             "version": "5.62.3",
@@ -1152,6 +1115,12 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "colorette": {
+            "version": "2.0.16",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+            "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
             "dev": true
         },
         "colors": {
@@ -1177,9 +1146,9 @@
             "dev": true
         },
         "common-tags": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+            "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
             "dev": true
         },
         "component-bind": {
@@ -1205,18 +1174,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
-        },
-        "concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            }
         },
         "cookie": {
             "version": "0.4.1",
@@ -1256,63 +1213,70 @@
             }
         },
         "cypress": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.9.1.tgz",
-            "integrity": "sha512-/RVx6sOhsyTR9sd9v0BHI4tnDZAhsH9rNat7CIKCUEr5VPWxyfGH0EzK4IHhAqAH8vjFcD4U14tPiJXshoUrmQ==",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.2.0.tgz",
+            "integrity": "sha512-Jn26Tprhfzh/a66Sdj9SoaYlnNX6Mjfmj5PHu2a7l3YHXhrgmavM368wjCmgrxC6KHTOv9SpMQGhAJn+upDViA==",
             "dev": true,
             "requires": {
-                "@cypress/listr-verbose-renderer": "^0.4.1",
-                "@cypress/request": "^2.88.5",
+                "@cypress/request": "^2.88.10",
                 "@cypress/xvfb": "^1.2.4",
-                "@types/node": "12.12.50",
-                "@types/sinonjs__fake-timers": "^6.0.1",
+                "@types/node": "^14.14.31",
+                "@types/sinonjs__fake-timers": "^6.0.2",
                 "@types/sizzle": "^2.3.2",
-                "arch": "^2.1.2",
-                "blob-util": "2.0.2",
-                "bluebird": "^3.7.2",
+                "arch": "^2.2.0",
+                "blob-util": "^2.0.2",
+                "bluebird": "3.7.2",
                 "cachedir": "^2.3.0",
                 "chalk": "^4.1.0",
                 "check-more-types": "^2.24.0",
+                "cli-cursor": "^3.1.0",
                 "cli-table3": "~0.6.0",
                 "commander": "^5.1.0",
                 "common-tags": "^1.8.0",
-                "dayjs": "^1.9.3",
-                "debug": "4.3.2",
-                "eventemitter2": "^6.4.2",
-                "execa": "^4.0.2",
+                "dayjs": "^1.10.4",
+                "debug": "^4.3.2",
+                "enquirer": "^2.3.6",
+                "eventemitter2": "^6.4.3",
+                "execa": "4.1.0",
                 "executable": "^4.1.1",
-                "extract-zip": "^1.7.0",
-                "fs-extra": "^9.0.1",
+                "extract-zip": "2.0.1",
+                "figures": "^3.2.0",
+                "fs-extra": "^9.1.0",
                 "getos": "^3.2.1",
-                "is-ci": "^2.0.0",
-                "is-installed-globally": "^0.3.2",
+                "is-ci": "^3.0.0",
+                "is-installed-globally": "~0.4.0",
                 "lazy-ass": "^1.6.0",
-                "listr": "^0.14.3",
-                "lodash": "^4.17.19",
+                "listr2": "^3.8.3",
+                "lodash": "^4.17.21",
                 "log-symbols": "^4.0.0",
                 "minimist": "^1.2.5",
-                "moment": "^2.29.1",
                 "ospath": "^1.2.2",
-                "pretty-bytes": "^5.4.1",
-                "ramda": "~0.27.1",
+                "pretty-bytes": "^5.6.0",
+                "proxy-from-env": "1.0.0",
                 "request-progress": "^3.0.0",
-                "supports-color": "^7.2.0",
+                "supports-color": "^8.1.1",
                 "tmp": "~0.2.1",
                 "untildify": "^4.0.0",
                 "url": "^0.11.0",
                 "yauzl": "^2.10.0"
             },
             "dependencies": {
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+                    "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
                 "lodash": {
                     "version": "4.17.21",
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
                     "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-                    "dev": true
-                },
-                "moment": {
-                    "version": "2.29.1",
-                    "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-                    "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
                     "dev": true
                 }
             }
@@ -1421,22 +1385,16 @@
                 "assert-plus": "^1.0.0"
             }
         },
-        "date-fns": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-            "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
-            "dev": true
-        },
         "dayjs": {
-            "version": "1.10.6",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
-            "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==",
+            "version": "1.10.7",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+            "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==",
             "dev": true
         },
         "debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+            "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
             "dev": true,
             "requires": {
                 "ms": "2.1.2"
@@ -1499,12 +1457,6 @@
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
             }
-        },
-        "elegant-spinner": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-            "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
-            "dev": true
         },
         "emoji-regex": {
             "version": "8.0.0",
@@ -1595,6 +1547,15 @@
                 "has-binary2": "~1.0.2"
             }
         },
+        "enquirer": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^4.1.1"
+            }
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1606,9 +1567,9 @@
             "from": "git://github.com/adobe-webplatform/eve.git#eef80ed"
         },
         "eventemitter2": {
-            "version": "6.4.4",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
-            "integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==",
+            "version": "6.4.5",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
+            "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
             "dev": true
         },
         "execa": {
@@ -1626,17 +1587,6 @@
                 "onetime": "^5.1.0",
                 "signal-exit": "^3.0.2",
                 "strip-final-newline": "^2.0.0"
-            },
-            "dependencies": {
-                "onetime": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-                    "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-                    "dev": true,
-                    "requires": {
-                        "mimic-fn": "^2.1.0"
-                    }
-                }
             }
         },
         "executable": {
@@ -1654,12 +1604,6 @@
             "integrity": "sha1-WKnS1ywCwfbwKg70qRZicrd2CSI=",
             "dev": true
         },
-        "exit-hook": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-            "dev": true
-        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1667,50 +1611,21 @@
             "dev": true
         },
         "extract-zip": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-            "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+            "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
             "dev": true,
             "requires": {
-                "concat-stream": "^1.6.2",
-                "debug": "^2.6.9",
-                "mkdirp": "^0.5.4",
+                "@types/yauzl": "^2.9.1",
+                "debug": "^4.1.1",
+                "get-stream": "^5.1.0",
                 "yauzl": "^2.10.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
             }
         },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "dev": true
-        },
-        "fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
         "fastestsmallesttextencoderdecoder": {
@@ -1728,13 +1643,12 @@
             }
         },
         "figures": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+            "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.5",
-                "object-assign": "^4.1.0"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-type": {
@@ -1767,12 +1681,11 @@
             "dev": true
         },
         "fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+            "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
             "dev": true,
             "requires": {
-                "at-least-node": "^1.0.0",
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
                 "universalify": "^2.0.0"
@@ -1817,9 +1730,9 @@
             }
         },
         "glob": {
-            "version": "7.1.7",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-            "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -1841,12 +1754,12 @@
             }
         },
         "global-dirs": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
-            "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+            "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
             "dev": true,
             "requires": {
-                "ini": "1.3.7"
+                "ini": "2.0.0"
             }
         },
         "graceful-fs": {
@@ -1864,31 +1777,6 @@
                 "uglify-js": "~2.3"
             }
         },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "dev": true
-        },
-        "har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "dev": true,
-            "requires": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            }
-        },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            }
-        },
         "has-binary2": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -1896,14 +1784,6 @@
             "dev": true,
             "requires": {
                 "isarray": "2.0.1"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-                    "dev": true
-                }
             }
         },
         "has-cors": {
@@ -1926,25 +1806,17 @@
             "requires": {
                 "mkdirp": "0.3.0",
                 "nopt": "1.0.10"
-            },
-            "dependencies": {
-                "mkdirp": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-                    "dev": true
-                }
             }
         },
         "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+            "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
             "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "jsprim": "^2.0.2",
+                "sshpk": "^1.14.1"
             }
         },
         "human-signals": {
@@ -1971,9 +1843,9 @@
             "dev": true
         },
         "indent-string": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-            "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true
         },
         "indexof": {
@@ -1999,9 +1871,9 @@
             "dev": true
         },
         "ini": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-            "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+            "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
             "dev": true
         },
         "interactjs": {
@@ -2010,12 +1882,12 @@
             "integrity": "sha512-AQ2CdPEyHqiEEQ1FFgMBj79UEsU1+rUwSXuhOkflvB65p4iECft28SN/PvhD/Y9OtNge8aH1qTibjAi+RXQMqQ=="
         },
         "is-ci": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+            "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
             "dev": true,
             "requires": {
-                "ci-info": "^2.0.0"
+                "ci-info": "^3.2.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -2031,34 +1903,19 @@
             "dev": true
         },
         "is-installed-globally": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
-            "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+            "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
             "dev": true,
             "requires": {
-                "global-dirs": "^2.0.1",
-                "is-path-inside": "^3.0.1"
-            }
-        },
-        "is-observable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
-            "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
-            "dev": true,
-            "requires": {
-                "symbol-observable": "^1.1.0"
+                "global-dirs": "^3.0.0",
+                "is-path-inside": "^3.0.2"
             }
         },
         "is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true
-        },
-        "is-promise": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
             "dev": true
         },
         "is-stream": {
@@ -2080,9 +1937,9 @@
             "dev": true
         },
         "isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+            "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
             "dev": true
         },
         "isexe": {
@@ -2112,9 +1969,9 @@
             },
             "dependencies": {
                 "core-js": {
-                    "version": "3.16.3",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
-                    "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
+                    "version": "3.20.1",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+                    "integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
                     "dev": true
                 }
             }
@@ -2143,15 +2000,9 @@
             "dev": true
         },
         "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-            "dev": true
-        },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
             "dev": true
         },
         "json-stringify-safe": {
@@ -2171,14 +2022,14 @@
             }
         },
         "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+            "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
             "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
+                "json-schema": "0.4.0",
                 "verror": "1.10.0"
             }
         },
@@ -2188,188 +2039,20 @@
             "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
             "dev": true
         },
-        "listr": {
-            "version": "0.14.3",
-            "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
-            "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+        "listr2": {
+            "version": "3.13.5",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.5.tgz",
+            "integrity": "sha512-3n8heFQDSk+NcwBn3CgxEibZGaRzx+pC64n3YjpMD1qguV4nWus3Al+Oo3KooqFKTQEJ1v7MmnbnyyNspgx3NA==",
             "dev": true,
             "requires": {
-                "@samverschueren/stream-to-observable": "^0.3.0",
-                "is-observable": "^1.1.0",
-                "is-promise": "^2.1.0",
-                "is-stream": "^1.1.0",
-                "listr-silent-renderer": "^1.1.1",
-                "listr-update-renderer": "^0.5.0",
-                "listr-verbose-renderer": "^0.5.0",
-                "p-map": "^2.0.0",
-                "rxjs": "^6.3.3"
-            },
-            "dependencies": {
-                "is-stream": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-                    "dev": true
-                }
-            }
-        },
-        "listr-silent-renderer": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-            "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
-            "dev": true
-        },
-        "listr-update-renderer": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
-            "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "cli-truncate": "^0.2.1",
-                "elegant-spinner": "^1.0.1",
-                "figures": "^1.7.0",
-                "indent-string": "^3.0.0",
-                "log-symbols": "^1.0.2",
-                "log-update": "^2.3.0",
-                "strip-ansi": "^3.0.1"
-            },
-            "dependencies": {
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "log-symbols": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-                    "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^1.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
-        },
-        "listr-verbose-renderer": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
-            "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.4.1",
-                "cli-cursor": "^2.1.0",
-                "date-fns": "^1.27.2",
-                "figures": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "cli-cursor": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-                    "dev": true,
-                    "requires": {
-                        "restore-cursor": "^2.0.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
-                },
-                "figures": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-                    "dev": true,
-                    "requires": {
-                        "escape-string-regexp": "^1.0.5"
-                    }
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "mimic-fn": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-                    "dev": true
-                },
-                "onetime": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-                    "dev": true,
-                    "requires": {
-                        "mimic-fn": "^1.0.0"
-                    }
-                },
-                "restore-cursor": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-                    "dev": true,
-                    "requires": {
-                        "onetime": "^2.0.0",
-                        "signal-exit": "^3.0.2"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
+                "cli-truncate": "^2.1.0",
+                "colorette": "^2.0.16",
+                "log-update": "^4.0.0",
+                "p-map": "^4.0.0",
+                "rfdc": "^1.3.0",
+                "rxjs": "^7.4.0",
+                "through": "^2.3.8",
+                "wrap-ansi": "^7.0.0"
             }
         },
         "load-bmfont": {
@@ -2410,48 +2093,37 @@
             }
         },
         "log-update": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
-            "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+            "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "cli-cursor": "^2.0.0",
-                "wrap-ansi": "^3.0.1"
+                "ansi-escapes": "^4.3.0",
+                "cli-cursor": "^3.1.0",
+                "slice-ansi": "^4.0.0",
+                "wrap-ansi": "^6.2.0"
             },
             "dependencies": {
-                "cli-cursor": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                "slice-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+                    "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
                     "dev": true,
                     "requires": {
-                        "restore-cursor": "^2.0.0"
+                        "ansi-styles": "^4.0.0",
+                        "astral-regex": "^2.0.0",
+                        "is-fullwidth-code-point": "^3.0.0"
                     }
                 },
-                "mimic-fn": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-                    "dev": true
-                },
-                "onetime": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "^1.0.0"
-                    }
-                },
-                "restore-cursor": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-                    "dev": true,
-                    "requires": {
-                        "onetime": "^2.0.0",
-                        "signal-exit": "^3.0.2"
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
                     }
                 }
             }
@@ -2475,18 +2147,18 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-            "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.32",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-            "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+            "version": "2.1.34",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
             "dev": true,
             "requires": {
-                "mime-db": "1.49.0"
+                "mime-db": "1.51.0"
             }
         },
         "mimic-fn": {
@@ -2520,13 +2192,10 @@
             "dev": true
         },
         "mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5"
-            }
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+            "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+            "dev": true
         },
         "moment": {
             "version": "2.11.1",
@@ -2577,12 +2246,6 @@
                 "path-key": "^3.0.0"
             }
         },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
-        },
         "oauth-sign": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -2611,10 +2274,13 @@
             }
         },
         "onetime": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-            "dev": true
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^2.1.0"
+            }
         },
         "optimist": {
             "version": "0.3.7",
@@ -2631,10 +2297,13 @@
             "dev": true
         },
         "p-map": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-            "dev": true
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "dev": true,
+            "requires": {
+                "aggregate-error": "^3.0.0"
+            }
         },
         "pako": {
             "version": "1.0.11",
@@ -2756,10 +2425,10 @@
             "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
             "dev": true
         },
-        "process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+        "proxy-from-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
             "dev": true
         },
         "psl": {
@@ -2796,41 +2465,12 @@
             "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
             "dev": true
         },
-        "ramda": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-            "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-            "dev": true
-        },
         "raphael": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.2.0.tgz",
             "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
             "requires": {
                 "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
-            }
-        },
-        "readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dev": true,
-            "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
-                }
             }
         },
         "regenerator-runtime": {
@@ -2848,14 +2488,20 @@
             }
         },
         "restore-cursor": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-            "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
             "dev": true,
             "requires": {
-                "exit-hook": "^1.0.0",
-                "onetime": "^1.0.0"
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
             }
+        },
+        "rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "dev": true
         },
         "rimraf": {
             "version": "3.0.2",
@@ -2867,12 +2513,12 @@
             }
         },
         "rxjs": {
-            "version": "6.6.7",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-            "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+            "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
             "dev": true,
             "requires": {
-                "tslib": "^1.9.0"
+                "tslib": "~2.1.0"
             }
         },
         "safe-buffer": {
@@ -2923,16 +2569,21 @@
             "dev": true
         },
         "signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
+            "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
             "dev": true
         },
         "slice-ansi": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-            "dev": true
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+            "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            }
         },
         "socket.io": {
             "version": "2.4.1",
@@ -2993,12 +2644,6 @@
                         "ms": "2.0.0"
                     }
                 },
-                "isarray": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-                    "dev": true
-                },
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3043,12 +2688,6 @@
                     "requires": {
                         "ms": "^2.1.1"
                     }
-                },
-                "isarray": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-                    "dev": true
                 }
             }
         },
@@ -3059,9 +2698,9 @@
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.19",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -3086,57 +2725,23 @@
             }
         },
         "string-width": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-            "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "requires": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-                    "dev": true
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
-                    }
-                }
-            }
-        },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "~5.1.0"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
-                }
+                "strip-ansi": "^6.0.1"
             }
         },
         "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "^5.0.1"
             }
         },
         "strip-final-newline": {
@@ -3146,24 +2751,24 @@
             "dev": true
         },
         "supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "requires": {
                 "has-flag": "^4.0.0"
             }
         },
-        "symbol-observable": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-            "dev": true
-        },
         "throttleit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
             "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
         "timm": {
@@ -3221,9 +2826,9 @@
             }
         },
         "tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
             "dev": true
         },
         "tunnel-agent": {
@@ -3241,10 +2846,10 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
-        "typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+        "type-fest": {
+            "version": "0.21.3",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+            "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true
         },
         "uglify-js": {
@@ -3304,15 +2909,6 @@
             "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
             "dev": true
         },
-        "uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "requires": {
-                "punycode": "^2.1.0"
-            }
-        },
         "url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -3350,12 +2946,6 @@
             "requires": {
                 "pako": "^1.0.5"
             }
-        },
-        "util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
         },
         "uuid": {
             "version": "8.3.2",
@@ -3400,46 +2990,14 @@
             "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         },
         "wrap-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
-            "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
             }
         },
         "wrappy": {

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -709,8 +709,9 @@
             }
         },
         "@oat-sa/e2e-runner": {
-            "version": "git://github.com/oat-sa/e2e-runner.git#26810f756d1e523bee970bca1d6e9d60be3cc0b5",
-            "from": "git://github.com/oat-sa/e2e-runner.git#feat/AUT-973/update-cypress",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/e2e-runner/-/e2e-runner-1.5.0.tgz",
+            "integrity": "sha512-h9U8bMRL4zWcVOXXR/MoXHFdAcsPqVnbJihCbI5aHhO8kCfF0btbayjedrWkYk2SZzXGK1VZsBIQwam5vMVXcQ==",
             "dev": true,
             "requires": {
                 "cypress": "^9.0.0",
@@ -2513,12 +2514,12 @@
             }
         },
         "rxjs": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
-            "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+            "version": "7.5.1",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.1.tgz",
+            "integrity": "sha512-KExVEeZWxMZnZhUZtsJcFwz8IvPvgu4G2Z2QyqjZQzUGr32KDYuSxrEYO4w3tFFNbfLozcrKUTvTPi+E9ywJkQ==",
             "dev": true,
             "requires": {
-                "tslib": "~2.1.0"
+                "tslib": "^2.1.0"
             }
         },
         "safe-buffer": {
@@ -2826,9 +2827,9 @@
             }
         },
         "tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
             "dev": true
         },
         "tunnel-agent": {

--- a/views/package.json
+++ b/views/package.json
@@ -35,7 +35,7 @@
         "url-polyfill": "1.1.12"
     },
     "devDependencies": {
-        "@oat-sa/e2e-runner": "git://github.com/oat-sa/e2e-runner#feat/AUT-973/update-cypress",
+        "@oat-sa/e2e-runner": "^1.5.0",
         "cypress-downloadfile": "^1.2.1",
         "fs": "0.0.1-security"
     }

--- a/views/package.json
+++ b/views/package.json
@@ -35,7 +35,7 @@
         "url-polyfill": "1.1.12"
     },
     "devDependencies": {
-        "@oat-sa/e2e-runner": "^1.2.1",
+        "@oat-sa/e2e-runner": "git://github.com/oat-sa/e2e-runner#feat/AUT-973/update-cypress",
         "cypress-downloadfile": "^1.2.1",
         "fs": "0.0.1-security"
     }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-973

Update cypress to v9
Stabilize e2e tests

Depends on: 

- [ ] https://github.com/oat-sa/e2e-runner/pull/25