### PR TITLE
Fix TR-3287 remove source based npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1563,9 +1563,10 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
-        "eve": {
-            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+        "eve-raphael": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+            "integrity": "sha1-F8dUt5K+7z+maE15z1pHxjxM2jA="
         },
         "eventemitter2": {
             "version": "6.4.5",
@@ -2467,11 +2468,11 @@
             "dev": true
         },
         "raphael": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.2.0.tgz",
-            "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
+            "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve-raphael": "0.5.0"
             }
         },
         "regenerator-runtime": {

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao",
-    "version": "0.10.0",
+    "version": "0.10.1",
     "license": "GPL-2.0",
     "description": "tao core dependencies",
     "repository": {

--- a/views/package.json
+++ b/views/package.json
@@ -29,7 +29,7 @@
         "moment": "2.11.1",
         "moment-timezone": "0.5.10",
         "popper.js": "1.16.1",
-        "raphael": "2.2.0",
+        "raphael": "2.3.0",
         "select2": "3.5.1",
         "tooltip.js": "1.3.3",
         "url-polyfill": "1.1.12"


### PR DESCRIPTION
# [TR-3287](https://oat-sa.atlassian.net/browse/TR-3287)

- fix: remove an invalid `package-lock.json`
- fix: remove source-based npm dependencies by updating `raphael` package dependency to `2.3.0`