### PR TITLE
Feature TR-3070 extend exception handler and response codes

### DIFF
--- a/actions/class.RestController.php
+++ b/actions/class.RestController.php
@@ -44,7 +44,10 @@ abstract class tao_actions_RestController extends \tao_actions_CommonModule impl
     {
         if ($this->hasHeader("Accept")) {
             try {
-                $this->responseEncoding = (tao_helpers_Http::acceptHeader($this->getAcceptableMimeTypes(), $this->getHeader("Accept")));
+                $this->responseEncoding = tao_helpers_Http::acceptHeader(
+                    $this->getAcceptableMimeTypes(),
+                    $this->getHeader("Accept")
+                ) ?? $this->responseEncoding;
             } catch (common_exception_ClientException $e) {
                 header('Content-Type: ' . $this->responseEncoding);
                 $this->setServiceLocator(ServiceManager::getServiceManager());

--- a/actions/class.RestController.php
+++ b/actions/class.RestController.php
@@ -20,6 +20,7 @@
  */
 
 use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ServiceManager;
 use oat\tao\model\action\RestControllerInterface;
 use oat\tao\model\routing\AnnotationReader\security;
 
@@ -45,6 +46,8 @@ abstract class tao_actions_RestController extends \tao_actions_CommonModule impl
             try {
                 $this->responseEncoding = (tao_helpers_Http::acceptHeader($this->getAcceptableMimeTypes(), $this->getHeader("Accept")));
             } catch (common_exception_ClientException $e) {
+                header('Content-Type: ' . $this->responseEncoding);
+                $this->setServiceLocator(ServiceManager::getServiceManager());
                 $this->returnFailure($e);
             }
         }

--- a/helpers/RestExceptionHandler.php
+++ b/helpers/RestExceptionHandler.php
@@ -53,6 +53,9 @@ class RestExceptionHandler
 
             case \common_exception_MethodNotAllowed::class:
                 header("HTTP/1.0 405 Method Not Allowed");
+                if ($exception->getAllowedMethods()) {
+                    header('Allow: ' . implode(', ', $exception->getAllowedMethods()));
+                }
                 break;
 
             case \common_exception_NotAcceptable::class:

--- a/helpers/class.Http.php
+++ b/helpers/class.Http.php
@@ -126,7 +126,7 @@ class tao_helpers_Http
 
     /**
      * @author "Patrick Plichart, <patrick@taotesting.com>"
-     * @return string
+     * @return string[]
      */
     public static function getFiles()
     {
@@ -214,17 +214,20 @@ class tao_helpers_Http
         }
         arsort($acceptTypes);
         if (!$supportedMimeTypes) {
-            return $acceptTypes;
+            return reset($acceptTypes);
         }
         $supportedMimeTypes = array_map('strtolower', (array) $supportedMimeTypes);
         // let’s check our supported types:
         foreach ($acceptTypes as $mime => $q) {
+            if ($mime === '*/*') {
+                return null;
+            }
+
             if ($q && in_array(trim($mime), $supportedMimeTypes)) {
                 return trim($mime);
             }
         }
         throw new common_exception_NotAcceptable();
-        return null;
     }
 
     /**

--- a/helpers/form/elements/xhtml/class.Calendar.php
+++ b/helpers/form/elements/xhtml/class.Calendar.php
@@ -65,7 +65,11 @@ class tao_helpers_form_elements_xhtml_Calendar extends tao_helpers_form_elements
     {
         $returnValue = $this->getRawValue();
 
-        if (! empty($returnValue)) {
+        if (is_numeric($returnValue)) {
+            return (int)$returnValue;
+        }
+
+        if (!empty($returnValue)) {
             $tz = new DateTimeZone(common_session_SessionManager::getSession()->getTimeZone());
             $dt = new DateTime($returnValue, $tz);
             $returnValue = $dt->getTimestamp() . '';

--- a/models/classes/mvc/error/ExceptionInterpretor.php
+++ b/models/classes/mvc/error/ExceptionInterpretor.php
@@ -21,6 +21,7 @@
 namespace oat\tao\model\mvc\error;
 
 use common_exception_MethodNotAllowed;
+use common_exception_RestApi;
 use Exception;
 use common_exception_MissingParameter;
 use common_exception_BadRequest;
@@ -85,13 +86,20 @@ class ExceptionInterpretor implements ServiceLocatorAwareInterface
      */
     protected function interpretError()
     {
+        $this->responseClassName = 'MainResponse';
+
+        if ($this->exception instanceof common_exception_RestApi) {
+            $this->returnHttpCode = $this->exception->getCode() ?: StatusCode::HTTP_BAD_REQUEST;
+
+            return $this;
+        }
+
         switch (get_class($this->exception)) {
             case UserErrorException::class:
             case tao_models_classes_MissingRequestParameterException::class:
             case common_exception_MissingParameter::class:
             case common_exception_BadRequest::class:
                 $this->returnHttpCode = StatusCode::HTTP_BAD_REQUEST;
-                $this->responseClassName = 'MainResponse';
                 break;
             case 'tao_models_classes_AccessDeniedException':
             case 'ResolverException':
@@ -99,25 +107,21 @@ class ExceptionInterpretor implements ServiceLocatorAwareInterface
                 $this->responseClassName = 'RedirectResponse';
                 break;
             case 'tao_models_classes_UserException':
-                $this->returnHttpCode    = StatusCode::HTTP_FORBIDDEN;
-                $this->responseClassName = 'MainResponse';
+                $this->returnHttpCode = StatusCode::HTTP_FORBIDDEN;
                 break;
             case 'ActionEnforcingException':
             case 'tao_models_classes_FileNotFoundException':
             case common_exception_ResourceNotFound::class:
-                $this->returnHttpCode    = StatusCode::HTTP_NOT_FOUND;
-                $this->responseClassName = 'MainResponse';
+                $this->returnHttpCode = StatusCode::HTTP_NOT_FOUND;
                 break;
             case common_exception_MethodNotAllowed::class:
-                $this->returnHttpCode    = StatusCode::HTTP_METHOD_NOT_ALLOWED;
-                $this->responseClassName = 'MainResponse';
+                $this->returnHttpCode = StatusCode::HTTP_METHOD_NOT_ALLOWED;
                 /** @var common_exception_MethodNotAllowed $exception */
                 $exception = $this->exception;
                 $this->allowedRequestMethods = $exception->getAllowedMethods();
                 break;
             default:
-                $this->responseClassName = 'MainResponse';
-                $this->returnHttpCode    = StatusCode::HTTP_INTERNAL_SERVER_ERROR;
+                $this->returnHttpCode = StatusCode::HTTP_INTERNAL_SERVER_ERROR;
                 break;
         }
         return $this;

--- a/models/classes/mvc/error/ExceptionInterpretor.php
+++ b/models/classes/mvc/error/ExceptionInterpretor.php
@@ -22,6 +22,7 @@ namespace oat\tao\model\mvc\error;
 
 use common_exception_MethodNotAllowed;
 use common_exception_RestApi;
+use common_exception_ValidationFailed;
 use Exception;
 use common_exception_MissingParameter;
 use common_exception_BadRequest;
@@ -99,6 +100,7 @@ class ExceptionInterpretor implements ServiceLocatorAwareInterface
             case tao_models_classes_MissingRequestParameterException::class:
             case common_exception_MissingParameter::class:
             case common_exception_BadRequest::class:
+            case common_exception_ValidationFailed::class:
                 $this->returnHttpCode = StatusCode::HTTP_BAD_REQUEST;
                 break;
             case 'tao_models_classes_AccessDeniedException':

--- a/models/classes/mvc/error/HtmlResponse.php
+++ b/models/classes/mvc/error/HtmlResponse.php
@@ -42,6 +42,17 @@ class HtmlResponse extends ResponseAbstract
         $returnUrl = (parse_url($referer, PHP_URL_HOST) === parse_url(ROOT_URL, PHP_URL_HOST))
             ? htmlentities($referer, ENT_QUOTES)
             : false;
-        require Template::getTemplate('error/error' . $this->httpCode . '.tpl', 'tao');
+        require $this->createTemplatePath();
+    }
+
+    private function createTemplatePath(): string
+    {
+        $path = Template::getTemplate("error/error{$this->httpCode}.tpl", 'tao');
+
+        if (!file_exists($path)) {
+            return Template::getTemplate('error/user_error.tpl', 'tao');
+        }
+
+        return $path;
     }
 }

--- a/models/classes/mvc/error/ResponseAbstract.php
+++ b/models/classes/mvc/error/ResponseAbstract.php
@@ -109,7 +109,10 @@ abstract class ResponseAbstract implements ResponseInterface, ServiceLocatorAwar
     {
         $context = Context::getInstance();
         $context->getResponse()->setContentHeader($this->contentType);
-        header(HTTPToolkit::statusCodeHeader($this->httpCode));
+
+        $statusCodeHeader = HTTPToolkit::statusCodeHeader($this->httpCode);
+        $statusCodeHeader ? header($statusCodeHeader) : http_response_code($this->httpCode);
+
         if (!empty($this->allowMethodsHeader)) {
             header('Allow: ' . implode(', ', $this->allowMethodsHeader));
         }


### PR DESCRIPTION
# [TR-3070](https://oat-sa.atlassian.net/browse/TR-3070)

This is a helper PR to deliver the Delivery property PATCH API endpoint.

## Changelog
- fix: add `Allow` header in case of a `405 Method Not Allowed` request error
- fix: return a proper error response in case of a `406 Not Acceptable` request error
- fix: handle `*/*` `Accept` request header
- feat: treat `common_exception_RestApi` as an HTTP exception, allowing to set any response code and message
- fix: fallback to `user_error` template in case of an unknown http status code
- feat: treat `common_exception_ValidationFailed` as a "400 Bad request" case
- fix: support partially initialized form data retrieval
- feat: support any response code