### PR TITLE
chore: fix protocol for eve

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1588,10 +1588,6 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
-        "eve": {
-            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed"
-        },
         "eventemitter2": {
             "version": "6.4.5",
             "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
@@ -2769,6 +2765,12 @@
             "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
             "requires": {
                 "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+            },
+            "dependencies": {
+                "eve": {
+                    "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+                    "from": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+                }
             }
         },
         "readable-stream": {


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3287

 - remove the git protocol from the package-lock to prevent issues installing the direct dependency