### PR TITLE
fix: update the protocol of the eve dependency

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1602,8 +1602,8 @@
             "dev": true
         },
         "eve": {
-            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+            "version": "https://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
+            "from": "https://github.com/adobe-webplatform/eve.git#eef80ed"
         },
         "eventemitter2": {
             "version": "6.4.4",
@@ -2815,7 +2815,7 @@
             "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.2.0.tgz",
             "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve": "https://github.com/adobe-webplatform/eve.git#eef80ed"
             }
         },
         "readable-stream": {


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3287

 - remove the git protocol from the package-lock to prevent issues installing the direct dependency