### PR TITLE
ADF-741 [Feat]E2E: Made default search type empty space

### DIFF
--- a/views/cypress/support/search.js
+++ b/views/cypress/support/search.js
@@ -26,7 +26,7 @@
  */
 Cypress.Commands.add('searchFor', (settings) => {
     const defaultSettings = {
-        search: '',
+        search: ' ',
         method: 'GET',
         path: '**/tao/Search/search*'
     };


### PR DESCRIPTION
Added advanced search criteria E2E test case
https://oat-sa.atlassian.net/browse/ADF-740

### Requirements
Must have taoAdvancedSearch extension installed and enabled in enviroment to test.
If it is not present (no extension found or feature flag is found disabling advancedSearch), test case will be skipped on execution time.

### How to
- checkout the branch tao core https://github.com/oat-sa/tao-core/pull/3333
- checkout tao items branch https://github.com/oat-sa/extension-tao-item/pull/559
- Run npm run cy:open from the ./tao/views
- Select tao/views/cypress/tests/search-advanced.spec.js