### PR TITLE
Use https protocol in console recruitment message

### DIFF
--- a/views/templates/blocks/careers-js.tpl
+++ b/views/templates/blocks/careers-js.tpl
@@ -1,1 +1,8 @@
-<script>window.console && console.log && console.log("You can't resist understanding how this is built? Come and join us!", "http://www.taotesting.com/company/careers/")</script>
+<script>
+    window.console &&
+    console.log &&
+    console.log(
+        "You can't resist understanding how this is built? Come and join us!",
+        "https://www.taotesting.com/company/careers/"
+    );
+</script>

--- a/views/templates/blocks/careers.tpl
+++ b/views/templates/blocks/careers.tpl
@@ -3,7 +3,7 @@
 
 
 You can't resist understanding how this is built? Come and join us!
-==========> http://www.taotesting.com/company/careers/ <==========
+==========> https://www.taotesting.com/company/careers/ <==========
 
 
 -->


### PR DESCRIPTION
Changed link protocol from `http://` to `https://` in console recruitment messages. For more up-to-date public image!
