### PR TITLE
fix: only execute initRendering when it is not in the authoring context

### DIFF
--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -113,7 +113,14 @@
                         testedUrl = settings.url;
                     }
 
-                    self.initRendering();
+                    /**
+                     * Prevent manage-schema form initialization when the targeted url is related to authoring
+                     * associated action is "launchEditor"
+                    */
+                    if (!testedUrl.includes('authoring')) {
+                        self.initRendering();
+                    }
+
                     self.initElements();
                     if (self.initGenerisFormPattern.test(testedUrl)) {
                         self.initOntoForms();


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-916

### How to

- Go to Tests tab/Item tab
- Create a new test/item with dependant properties
- Click 'Authoring' button
- Actual result: Authoring page is opened, 2 errors appear in browser console.
- Expected result: Authoring page is opened, no errors appear in browser console.

### Description
This has been solved by only rendering the dependant properties when needed (not in authoring context)