### PR TITLE
fix: avoid consider duplicated empty URIs

### DIFF
--- a/models/classes/Lists/Business/Domain/ValueCollection.php
+++ b/models/classes/Lists/Business/Domain/ValueCollection.php
@@ -83,6 +83,10 @@ class ValueCollection implements IteratorAggregate, JsonSerializable, Countable
         $counter = 0;
 
         foreach ($this->values as $value) {
+            if (empty($value->getUri())) {
+                continue;
+            }
+
             $duplicationCandidate = $this->extractValueByUri($value->getUri());
 
             if ($duplicationCandidate !== null && $duplicationCandidate !== $value) {

--- a/test/unit/models/classes/Lists/Business/Domain/ValueCollectionTest.php
+++ b/test/unit/models/classes/Lists/Business/Domain/ValueCollectionTest.php
@@ -100,7 +100,9 @@ class ValueCollectionTest extends TestCase
     {
         $value1 = new Value(null, 'http://example.com#1', '1');
         $value2 = new Value(null, 'http://example.com#2', '2');
-        $sut    = new ValueCollection(null, $value1, $value2);
+        $value3 = new Value(null, '', 'value 3 - empty uri');
+        $value4 = new Value(null, '', 'value 4 - empty uri');
+        $sut    = new ValueCollection(null, $value1, $value2, $value3, $value4);
 
         $this->assertFalse($sut->hasDuplicates());
 
@@ -109,6 +111,17 @@ class ValueCollectionTest extends TestCase
 
         $value1->setUri($value2->getUri());
         $this->assertTrue($sut->hasDuplicates());
+    }
+
+    public function testGetDuplicates(): void
+    {
+        $value1 = new Value(null, 'http://example.com#1', '1');
+        $value2 = new Value(null, 'http://example.com#2', '2');
+        $value3 = new Value(null, '', 'value 3 - empty uri');
+        $value4 = new Value(null, '', 'value 4 - empty uri');
+        $sut    = new ValueCollection(null, $value1, $value2, $value3, $value4);
+
+        $this->assertSame(0, $sut->getDuplicatedValues()->count());
     }
 
     /**


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/ADF-915

## Description

We need to put back the previous behavior and ignore duplications in case on empty URIs (which means, new records).

## PRs

- [ ] https://github.com/oat-sa/extension-tao-backoffice/pull/129