### PR TITLE
feature/ADF-869: Delete previous statements for a property when edited with an empty value

### DIFF
--- a/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
+++ b/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
@@ -102,7 +102,7 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
                         $instance->removeType($type);
                     }
 
-                    $types = !is_array($propertyValue) ? [$propertyValue] : $propertyValue;
+                    $types = is_array($propertyValue) ? $propertyValue : [$propertyValue];
 
                     foreach ($types as $type) {
                         $instance->setType(new core_kernel_classes_Class($type));

--- a/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
+++ b/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
@@ -122,7 +122,7 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
                             );
                         }
                     } elseif (is_string($propertyValue)) {
-                        if($this->isEmptyValue($propertyValue)) {
+                        if ($this->isEmptyValue($propertyValue)) {
                             $instance->removePropertyValues($prop);
                         } else {
                             $instance->editPropertyValues(
@@ -151,7 +151,7 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
                     new MetadataModified($instance, $propertyUri, $propertyValue)
                 );
             }
-            
+
             return $instance;
         } catch (common_Exception $e) {
             $msg = "An error occured while binding property values to instance '': " . $e->getMessage();
@@ -162,7 +162,7 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
 
     private function isEmptyValue(string $value): bool
     {
-        return '' === $value || ' ' === $value || strlen(trim($value)) == 0;
+        return strlen(trim($value)) === 0;
     }
 
     private function getEventManager(): EventManager

--- a/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
+++ b/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
@@ -18,13 +18,18 @@
  * Copyright (c) 2002-2008 (original work) Public Research Centre Henri Tudor & University of Luxembourg (under the project TAO & TAO2);
  *               2008-2010 (update and modification) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- *
+ *               2022 (update and modification) Open Assessment Technologies SA;
  */
 
 use oat\generis\model\OntologyRdf;
+use oat\tao\model\dataBinding\AbstractDataBinder;
+use oat\tao\model\dataBinding\GenerisInstanceDataBindingException;
+use oat\tao\model\event\MetadataModified;
+use oat\oatbox\event\EventManager;
+use oat\oatbox\service\ServiceManager;
 
 /**
- * A data binder focusing on binding a source of data to a generis instance
+ * A data binder focusing on binding a source of data to a Generis instance
  *
  * @access public
  * @author Jerome Bogaerts, <jerome@taotesting.com>
@@ -33,20 +38,11 @@ use oat\generis\model\OntologyRdf;
  */
 class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_models_classes_dataBinding_AbstractDataBinder
 {
-    // --- ASSOCIATIONS ---
+    /** @var core_kernel_classes_Resource */
+    private $targetInstance;
 
-
-    // --- ATTRIBUTES ---
-
-    /**
-     * A target Resource.
-     *
-     * @access private
-     * @var Resource
-     */
-    private $targetInstance = null;
-
-    // --- OPERATIONS ---
+    /** @var EventManager */
+    private $eventManager;
 
     /**
      * Creates a new instance of binder.
@@ -58,8 +54,12 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
      */
     public function __construct(core_kernel_classes_Resource $targetInstance)
     {
-        
         $this->targetInstance = $targetInstance;
+    }
+
+    public function withEventManager(EventManager $eventManager): void
+    {
+        $this->eventManager = $eventManager;
     }
 
     /**
@@ -71,20 +71,14 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
      */
     protected function getTargetInstance()
     {
-        $returnValue = null;
-
-        
-        $returnValue = $this->targetInstance;
-        
-
-        return $returnValue;
+        return $this->targetInstance;
     }
 
     /**
      * Simply bind data from the source to a specific generis class instance.
      *
      * The array of the data to be bound must contain keys that are property
-     * The repspective values can be either scalar or vector (array) values or
+     * The respective values can be either scalar or vector (array) values or
      * values.
      *
      * - If the element of the $data array is scalar, it is simply bound using
@@ -94,23 +88,22 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
      * @access public
      * @author Jerome Bogaerts, <jerome@taotesting.com>
      * @param  array data An array of values where keys are Property URIs and values are either scalar or vector values.
+     * @throws tao_models_classes_dataBinding_GenerisInstanceDataBindingException
      * @return mixed
      */
     public function bind($data)
     {
-        $returnValue = null;
-
         try {
             $instance = $this->getTargetInstance();
-            $eventManager = \oat\oatbox\service\ServiceManager::getServiceManager()->get(\oat\oatbox\event\EventManager::CONFIG_ID);
+            $eventManager = $this->getEventManager();
             foreach ($data as $propertyUri => $propertyValue) {
                 if ($propertyUri == OntologyRdf::RDF_TYPE) {
                     foreach ($instance->getTypes() as $type) {
                         $instance->removeType($type);
                     }
-                    if (!is_array($propertyValue)) {
-                        $types = [$propertyValue] ;
-                    }
+
+                    $types = !is_array($propertyValue) ? [$propertyValue] : $propertyValue;
+
                     foreach ($types as $type) {
                         $instance->setType(new core_kernel_classes_Class($type));
                     }
@@ -129,13 +122,13 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
                             );
                         }
                     } elseif (is_string($propertyValue)) {
-                        $instance->editPropertyValues(
-                            $prop,
-                            $propertyValue
-                        );
-                        if (strlen(trim($propertyValue)) == 0) {
-                            //if the property value is an empty space(the default value in a select input field), delete the corresponding triplet (and not all property values)
-                            $instance->removePropertyValues($prop, ['pattern' => '']);
+                        if($this->isEmptyValue($propertyValue)) {
+                            $instance->removePropertyValues($prop);
+                        } else {
+                            $instance->editPropertyValues(
+                                $prop,
+                                $propertyValue
+                            );
                         }
                     }
                 } else {
@@ -146,24 +139,38 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
                                 $aPropertyValue
                             );
                         }
-                    } elseif (is_string($propertyValue) && strlen(trim($propertyValue)) !== 0) {
+                    } elseif (is_string($propertyValue) && !$this->isEmptyValue($propertyValue)) {
                         $instance->setPropertyValue(
                             $prop,
                             $propertyValue
                         );
                     }
                 }
-                $eventManager->trigger(new \oat\tao\model\event\MetadataModified($instance, $propertyUri, $propertyValue));
+
+                $eventManager->trigger(
+                    new MetadataModified($instance, $propertyUri, $propertyValue)
+                );
             }
             
-            $returnValue = $instance;
+            return $instance;
         } catch (common_Exception $e) {
             $msg = "An error occured while binding property values to instance '': " . $e->getMessage();
             $instanceUri = $instance->getUri();
             throw new tao_models_classes_dataBinding_GenerisInstanceDataBindingException($msg);
         }
-        
+    }
 
-        return $returnValue;
+    private function isEmptyValue(string $value): bool
+    {
+        return '' === $value || ' ' === $value || strlen(trim($value)) == 0;
+    }
+
+    private function getEventManager(): EventManager
+    {
+        if ($this->eventManager === null) {
+            $this->eventManager = ServiceManager::getServiceManager()->get(EventManager::SERVICE_ID);
+        }
+
+        return $this->eventManager;
     }
 }

--- a/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
+++ b/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
@@ -1,0 +1,670 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\model\action;
+
+use core_kernel_classes_Resource;
+use core_kernel_classes_Class;
+use core_kernel_classes_ContainerCollection;
+use core_kernel_classes_Property;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\oatbox\event\EventManager;
+use oat\tao\model\dataBinding\GenerisInstanceDataBindingException;
+use oat\tao\model\event\MetadataModified;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
+use tao_models_classes_dataBinding_GenerisInstanceDataBinder;
+use tao_models_classes_dataBinding_GenerisInstanceDataBindingException;
+
+class GenerisInstanceDataBinderTest extends TestCase
+{
+    private const URI_CLASS_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    private const URI_PROPERTY_1 = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#p1';
+    private const URI_PROPERTY_2 = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#p2';
+    private const URI_TYPE_1 = 'http://example.com/Type1';
+    private const URI_TYPE_2 = 'http://example.com/Type2';
+
+    /** @var tao_models_classes_dataBinding_GenerisInstanceDataBinder */
+    private $sut;
+
+    /** @var core_kernel_classes_Resource|MockObject */
+    private $target;
+
+    /** @var core_kernel_classes_Class|MockObject */
+    private $classType1;
+
+    /** @var core_kernel_classes_Class|MockObject */
+    private $classType2;
+
+    /** @var core_kernel_classes_Property|MockObject */
+    private $property1;
+
+    /** @var core_kernel_classes_Property|MockObject */
+    private $property2;
+
+    /** @var EventManager|MockObject */
+    private $eventManagerMock;
+
+    /** @var core_kernel_classes_ContainerCollection|MockObject */
+    private $emptyCollectionMock;
+
+    /** @var core_kernel_classes_ContainerCollection|MockObject */
+    private $nonEmptyCollectionMock;
+
+    public function setUp(): void
+    {
+        $this->eventManagerMock = $this->createMock(EventManager::class);
+
+        $this->classType1 = $this->createMock(core_kernel_classes_Class::class);
+        $this->classType1
+            ->method('getUri')
+            ->willReturn(self::URI_TYPE_1);
+
+        $this->classType2 = $this->createMock(core_kernel_classes_Class::class);
+        $this->classType2
+            ->method('getUri')
+            ->willReturn(self::URI_TYPE_2);
+
+        $this->target = $this->createMock(
+            core_kernel_classes_Resource::class
+        );
+
+        $this->target
+            ->method('getClass')
+            ->willReturnMap([
+                [self::URI_TYPE_1, $this->classType1],
+                [self::URI_TYPE_2, $this->classType2],
+            ]);
+
+        $this->property1 = $this->createMock(core_kernel_classes_Property::class);
+        $this->property1
+            ->method('getUri')
+            ->willReturn(self::URI_PROPERTY_1);
+
+        $this->property2 = $this->createMock(core_kernel_classes_Property::class);
+        $this->property2
+            ->method('getUri')
+            ->willReturn(self::URI_PROPERTY_2);
+
+        $this->target
+            ->method('getUri')
+            ->willReturn('http://test/resource');
+
+        $this->nonEmptyCollectionMock = $this->createMock(
+            core_kernel_classes_ContainerCollection::class
+        );
+
+        $this->nonEmptyCollectionMock
+            ->method('count')
+            ->willReturn(1);
+
+        $this->emptyCollectionMock = $this->createMock(
+            core_kernel_classes_ContainerCollection::class
+        );
+
+        $this->emptyCollectionMock
+            ->method('count')
+            ->willReturn(0);
+
+        $this->sut = new tao_models_classes_dataBinding_GenerisInstanceDataBinder(
+            $this->target
+        );
+
+        $this->sut->withEventManager($this->eventManagerMock);
+    }
+
+    public function testBindScalarWithPreviousValue(): void
+    {
+        $this->expectsEvent($this->once(), self::URI_PROPERTY_1, 'Value 1');
+
+        $this->target
+            ->expects($this->once())
+            ->method('setType')
+            ->with($this->callback(function (core_kernel_classes_Class $class) {
+                return $class->getUri() === self::URI_TYPE_1;
+            }))
+            ->willReturn(true);
+
+        $this->target
+            ->method('getTypes')
+            ->willReturn([
+                $this->classType1
+            ]);
+
+        $this->target
+            ->method('getProperty')
+            ->with(self::URI_PROPERTY_1)
+            ->willReturn($this->property1);
+
+        // There is a previous value for prop1 and its new value is a scalar:
+        // The data binder should call editPropertyValues() on the resource.
+        //
+        $this->target
+            ->method('getPropertyValuesCollection')
+            ->will($this->returnCallback(
+                function (core_kernel_classes_Property $property) {
+                    if ($property->getUri() === self::URI_PROPERTY_1) {
+                        return $this->nonEmptyCollectionMock;
+                    }
+
+                    $this->fail('Unexpected property: ' . $property->getUri());
+                }
+            ));
+
+        $this->target
+            ->expects($this->once())
+            ->method('editPropertyValues')
+            ->with($this->callback(
+                function (core_kernel_classes_Property $property, $value = null) {
+                    return $property->getUri() === self::URI_PROPERTY_1;
+                }
+            ));
+
+        // Binding a single class type and a single, non-empty value for
+        // URI_PROPERTY_1, which should trigger editPropertyValues().
+        //
+        $resource = $this->sut->bind([
+            self::URI_CLASS_TYPE => self::URI_TYPE_1,
+            self::URI_PROPERTY_1 => 'Value 1'
+        ]);
+
+        $this->assertSame($this->target, $resource);
+    }
+
+    public function testBindScalarWithNoPreviousValue(): void
+    {
+        $this->expectsEvent($this->once(), self::URI_PROPERTY_1, 'Value 1');
+
+        $this->target
+            ->expects($this->once())
+            ->method('setType')
+            ->with($this->callback(function (core_kernel_classes_Class $class) {
+                return $class->getUri() === self::URI_TYPE_1;
+            }))
+            ->willReturn(true);
+
+        $this->target
+            ->method('getTypes')
+            ->willReturn([
+                $this->classType1
+            ]);
+
+        $this->target
+            ->method('getProperty')
+            ->with(self::URI_PROPERTY_1)
+            ->willReturn($this->property1);
+
+        // There is no previous value for prop1 and its new value is a scalar:
+        // The data binder should call setPropertyValue() on the resource.
+        //
+        $this->target
+            ->method('getPropertyValuesCollection')
+            ->will($this->returnCallback(
+                function (core_kernel_classes_Property $property) {
+                    if ($property->getUri() === self::URI_PROPERTY_1) {
+                        return $this->emptyCollectionMock;
+                    }
+
+                    $this->fail('Unexpected property: ' . $property->getUri());
+                }
+            ));
+
+        $this->target
+            ->expects($this->once())
+            ->method('setPropertyValue')
+            ->with(
+                $this->callback(
+                    function (core_kernel_classes_Property $property, $value = null) {
+                        return $property->getUri() === self::URI_PROPERTY_1;
+                    }
+                ),
+                'Value 1'
+            );
+
+        // Binding a single class type and a single, non-empty value for
+        // URI_PROPERTY_1 (which doesn't have a previous value), which should
+        // trigger setPropertyValue().
+        //
+        $resource = $this->sut->bind([
+            self::URI_CLASS_TYPE => self::URI_TYPE_1,
+            self::URI_PROPERTY_1 => 'Value 1'
+        ]);
+
+        $this->assertSame($this->target, $resource);
+    }
+
+    public function testBindArrayWithPreviousValue(): void
+    {
+        $this->expectsEvent($this->at(0), self::URI_PROPERTY_1, ['one', 'two'], true);
+
+        $this->target
+            ->expects($this->once())
+            ->method('setType')
+            ->with($this->callback(function (core_kernel_classes_Class $class) {
+                return $class->getUri() === self::URI_TYPE_1;
+            }))
+            ->willReturn(true);
+
+        $this->target
+            ->method('getTypes')
+            ->willReturn([
+                $this->classType1
+            ]);
+
+        $this->target
+            ->method('getProperty')
+            ->with(self::URI_PROPERTY_1)
+            ->willReturn($this->property1);
+
+        // There is a previous value for prop1 and its new value is an array:
+        // The data binder should call setPropertyValue() on the resource, but
+        // removePropertyValues should be called first.
+        $this->target
+            ->method('getPropertyValuesCollection')
+            ->will($this->returnCallback(
+                function (core_kernel_classes_Property $property) {
+                    if ($property->getUri() === self::URI_PROPERTY_1) {
+                        return $this->nonEmptyCollectionMock;
+                    }
+
+                    $this->fail('Unexpected property: ' . $property->getUri());
+                }
+            ));
+
+        $this->target
+            ->expects($this->once())
+            ->method('removePropertyValues')
+            ->with($this->callback(
+                function (core_kernel_classes_Property $propoerty) {
+                    return $propoerty->getUri() === self::URI_PROPERTY_1;
+                }
+            ));
+
+        $this->target
+            ->expects($this->exactly(2))
+            ->method('setPropertyValue')
+            ->withConsecutive(
+                [$this->anything(), 'one'],
+                [$this->anything(), 'two']
+            );
+
+        $resource = $this->sut->bind([
+            self::URI_CLASS_TYPE => self::URI_TYPE_1,
+            self::URI_PROPERTY_1 => ['one', 'two']
+        ]);
+
+        $this->assertSame($this->target, $resource);
+    }
+
+    public function testBindArrayWithNoPreviousValue(): void
+    {
+        $this->expectsEvent($this->at(0), self::URI_PROPERTY_1, ['Value 1', 'Value 2']);
+
+        $this->target
+            ->expects($this->once())
+            ->method('setType')
+            ->with($this->callback(function (core_kernel_classes_Class $class) {
+                return $class->getUri() === self::URI_TYPE_1;
+            }))
+            ->willReturn(true);
+
+        $this->target
+            ->method('getTypes')
+            ->willReturn([
+                $this->classType1
+            ]);
+
+        $this->target
+            ->method('getProperty')
+            ->with(self::URI_PROPERTY_1)
+            ->willReturn($this->property1);
+
+        // There is no previous value for prop1 and its new value is a scalar:
+        // The data binder should call setPropertyValue() on the resource.
+        $this->target
+            ->method('getPropertyValuesCollection')
+            ->will($this->returnCallback(
+                function (core_kernel_classes_Property $property) {
+                    if ($property->getUri() === self::URI_PROPERTY_1) {
+                        return $this->emptyCollectionMock;
+                    }
+
+                    $this->fail('Unexpected property: ' . $property->getUri());
+                }
+            ));
+
+        $this->target
+            ->expects($this->never())
+            ->method('removePropertyValues');
+
+        $this->target
+            ->expects($this->exactly(2))
+            ->method('setPropertyValue')
+            ->withConsecutive(
+                [$this->anything(), 'Value 1'],
+                [$this->anything(), 'Value 2']
+            );
+
+        // Binding a single class type and a single, non-empty value for
+        // URI_PROPERTY_1 (which doesn't have a previous value), which should
+        // trigger setPropertyValue().
+        $resource = $this->sut->bind([
+            self::URI_CLASS_TYPE => self::URI_TYPE_1,
+            self::URI_PROPERTY_1 => ['Value 1', 'Value 2']
+        ]);
+
+        $this->assertSame($this->target, $resource);
+    }
+
+    public function testBindEmptyValue(): void
+    {
+        $this->expectsEvent($this->at(0), self::URI_PROPERTY_1, ' ');
+        $this->expectsEvent($this->at(1), self::URI_PROPERTY_2, 'Value 2');
+
+        $this->target
+            ->expects($this->exactly(2))
+            ->method('setType')
+            ->with($this->callback(function (core_kernel_classes_Class $class) {
+                return $class->getUri() === self::URI_TYPE_1
+                    || $class->getUri() === self::URI_TYPE_2;
+            }))
+            ->willReturn(true);
+
+        $this->target
+            ->method('getTypes')
+            ->willReturn([
+                $this->classType1,
+                $this->classType2
+            ]);
+
+        $this->target
+            ->method('getProperty')
+            ->willReturnMap([
+                [self::URI_PROPERTY_1, $this->property1],
+                [self::URI_PROPERTY_2, $this->property2],
+            ]);
+
+        // There is a previous value for prop1 and its new value is empty:
+        // The data binder will call removePropertyValues() for the property.
+        $this->target
+            ->method('getPropertyValuesCollection')
+            ->will($this->returnCallback(
+                function (core_kernel_classes_Property $property) {
+                    if ($property->getUri() === self::URI_PROPERTY_1) {
+                        return $this->nonEmptyCollectionMock;
+                    }
+                    if ($property->getUri() === self::URI_PROPERTY_2) {
+                        return $this->nonEmptyCollectionMock;
+                    }
+
+                    $this->fail('Unexpected property: ' . $property->getUri());
+                }
+            ));
+
+        $this->target
+            ->expects($this->exactly(1))
+            ->method('editPropertyValues')
+            ->willReturnCallback(
+                function (core_kernel_classes_Property $property, $value = null) {
+                    $this->assertEquals('Value 2', $value);
+                    $this->assertEquals(self::URI_PROPERTY_2, $property->getUri());
+                }
+            );
+
+        $this->target
+            ->expects($this->exactly(1))
+            ->method('removePropertyValues')
+            ->willReturnCallback(
+                function (core_kernel_classes_Property $property, $opts = []) {
+                    $this->assertEquals(self::URI_PROPERTY_1, $property->getUri());
+                }
+            );
+
+        // Binding multiple values for the class type, and an empty value for
+        // URI_PROPERTY_1, which should trigger removePropertyValues().
+        $resource = $this->sut->bind([
+            self::URI_CLASS_TYPE => [self::URI_TYPE_1, self::URI_TYPE_2],
+            self::URI_PROPERTY_1 => ' ',
+            self::URI_PROPERTY_2 => 'Value 2',
+        ]);
+
+        $this->assertSame($this->target, $resource);
+    }
+
+    public function testBindNewTypesToExistingInstance(): void
+    {
+        $this->eventManagerMock
+            ->expects($this->never())
+            ->method('trigger');
+
+        $this->target
+            ->method('getTypes')
+            ->willReturn([
+                new core_kernel_classes_Class(self::URI_TYPE_1),
+            ]);
+
+        $this->target
+            ->expects($this->exactly(1))
+            ->method('removeType')
+            ->with($this->callback(function (core_kernel_classes_Class $class) {
+                return $class->getUri() === self::URI_TYPE_1;
+            }))
+            ->willReturn(true);
+
+        $this->target
+            ->expects($this->exactly(1))
+            ->method('setType')
+            ->with($this->callback(function (core_kernel_classes_Class $class) {
+                return $class->getUri() === self::URI_TYPE_2;
+            }))
+            ->willReturn(true);
+
+        $this->target
+            ->method('getProperty')
+            ->willReturnMap([
+                [self::URI_PROPERTY_1, $this->property1],
+                [self::URI_PROPERTY_2, $this->property2],
+            ]);
+
+        // There are no properties other than types for this test
+        $this->target
+            ->expects($this->never())
+            ->method('getPropertyValuesCollection');
+
+        // Binding multiple values for the class type, and an empty value for
+        // URI_PROPERTY_1, which should trigger removePropertyValues().
+        $resource = $this->sut->bind([
+            self::URI_CLASS_TYPE => [self::URI_TYPE_2],
+        ]);
+
+        $this->assertSame($this->target, $resource);
+    }
+
+    public function testDontSetNewValuesIfTheyAreEmpty(): void
+    {
+        // The event is triggered even if the property value stays the same
+        $this->expectsEvent($this->at(0), self::URI_PROPERTY_1, '  ');
+
+        $this->target
+            ->expects($this->never())
+            ->method('setType');
+
+        $this->target
+            ->method('getTypes')
+            ->willReturn([]);
+
+        $this->target
+            ->method('getProperty')
+            ->with(self::URI_PROPERTY_1)
+            ->willReturn($this->property1);
+
+        $this->target
+            ->method('getPropertyValuesCollection')
+            ->will($this->returnCallback(
+                function (core_kernel_classes_Property $property) {
+                    if ($property->getUri() === self::URI_PROPERTY_1) {
+                        return $this->emptyCollectionMock;
+                    }
+                    if ($property->getUri() === self::URI_PROPERTY_2) {
+                        return $this->emptyCollectionMock;
+                    }
+
+                    $this->fail('Unexpected property: ' . $property->getUri());
+                }
+            ));
+
+        $this->target
+            ->expects($this->never())
+            ->method('editPropertyValues');
+
+        $this->target
+            ->expects($this->never())
+            ->method('removePropertyValues');
+
+        $this->target
+            ->expects($this->never())
+            ->method('setPropertyValue');
+
+        // Binding an empty value for URI_PROPERTY_1 , which already has no
+        // values, should not trigger setting, editing nor removal calls.
+        $resource = $this->sut->bind([
+            self::URI_PROPERTY_1 => '  ',
+        ]);
+
+        $this->assertSame($this->target, $resource);
+    }
+
+    public function testZeroIsNotHandledAsAnEmptyValue(): void
+    {
+        $this->expectsEvent($this->once(), self::URI_PROPERTY_1, '0');
+
+        $this->target
+            ->expects($this->never())
+            ->method('setType');
+
+        $this->target
+            ->method('getTypes')
+            ->willReturn([
+                $this->classType1
+            ]);
+
+        $this->target
+            ->method('getProperty')
+            ->with(self::URI_PROPERTY_1)
+            ->willReturn($this->property1);
+
+        // There is no previous value for prop1 and its new value is a scalar:
+        // The data binder should call setPropertyValue() on the resource.
+        //
+        $this->target
+            ->method('getPropertyValuesCollection')
+            ->will($this->returnCallback(
+                function (core_kernel_classes_Property $property) {
+                    if ($property->getUri() === self::URI_PROPERTY_1) {
+                        return $this->emptyCollectionMock;
+                    }
+
+                    $this->fail('Unexpected property: ' . $property->getUri());
+                }
+            ));
+
+        $this->target
+            ->expects($this->once())
+            ->method('setPropertyValue')
+            ->with(
+                $this->callback(
+                    function (core_kernel_classes_Property $property, $value = null) {
+                        return $property->getUri() === self::URI_PROPERTY_1;
+                    }
+                ),
+                '0'
+            );
+
+        $resource = $this->sut->bind([
+            self::URI_PROPERTY_1 => '0'
+        ]);
+
+        $this->assertSame($this->target, $resource);
+    }
+
+    public function testExceptionsAreWrappedAndRethrown(): void
+    {
+        $this->eventManagerMock
+            ->expects($this->never())
+            ->method('trigger');
+
+        $this->target
+            ->expects($this->never())
+            ->method('setType');
+
+        $this->target
+            ->method('getTypes')
+            ->willReturn([
+                $this->classType1
+            ]);
+
+        $this->target
+            ->method('getProperty')
+            ->with(self::URI_PROPERTY_1)
+            ->willReturn($this->property1);
+
+        $this->target
+            ->method('getPropertyValuesCollection')
+            ->willThrowException(new tao_models_classes_dataBinding_GenerisInstanceDataBindingException('error', 123));
+
+        $this->expectException(
+            tao_models_classes_dataBinding_GenerisInstanceDataBindingException::class
+        );
+
+        $this->expectExceptionMessage(
+            "An error occured while binding property values to instance '': "
+        );
+
+        $resource = $this->sut->bind([
+            self::URI_PROPERTY_2 => 'Value 2',
+        ]);
+
+        $this->assertSame($this->target, $resource);
+    }
+
+    private function expectsEvent(
+        InvocationOrder $invocationRule,
+        string $property,
+        $value
+    ): void {
+        $this->eventManagerMock
+            ->expects($invocationRule)
+            ->method('trigger')
+            ->with(
+                $this->callback(function (MetadataModified $event) use (
+                    $property,
+                    $value
+                ) {
+                    return (
+                        $event->getResource()->getUri() === $this->target->getUri()
+                        && $event->getMetadataUri() === $property
+                        && $event->getMetadataValue() === $value
+                    );
+                })
+            );
+    }
+}

--- a/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
+++ b/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
@@ -20,20 +20,12 @@
 
 declare(strict_types=1);
 
-namespace oat\tao\test\unit\model\action;
-
-use core_kernel_classes_Resource;
-use core_kernel_classes_Class;
-use core_kernel_classes_ContainerCollection;
-use core_kernel_classes_Property;
 use oat\generis\test\MockObject;
 use oat\generis\test\TestCase;
 use oat\oatbox\event\EventManager;
 use oat\tao\model\dataBinding\GenerisInstanceDataBindingException;
 use oat\tao\model\event\MetadataModified;
 use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
-use tao_models_classes_dataBinding_GenerisInstanceDataBinder;
-use tao_models_classes_dataBinding_GenerisInstanceDataBindingException;
 
 class GenerisInstanceDataBinderTest extends TestCase
 {


### PR DESCRIPTION
**Associated Jira issue:** [ADF-869](https://oat-sa.atlassian.net/browse/ADF-869)

This pull request fixes the call to `$instance->editPropertyValues()` (near line 140) to just call `removePropertyValues()` or `editPropertyValues()` depending on the value being considered as empty or not.

Previously,
1. The values provided were inserted as-is by calling `editPropertyValues()`, which removed all the values and then inserted the new ones with no conversion, and then
2. `removePropertyValues()` was called for values under the instance being edited **but** using an empty string (`''`) as the matching pattern for the values to be deleted.

This later step may fail in case the RDBMS doesn't _automagically_ turn strings containing only whitespaces into empty strings in step 1 (i.e. if it does not `trim()` the values on insertion behind the scenes). Instead of that, this pull request calls `removePropertyValues()` with no pattern at all, which has the expected behavior of removing all values for the instance being edited before persisting the new ones. 

Additionally, this pull request adds unit tests for the whole data binder class, covering all class methods and branches except the static call to `ServiceManager::getServiceManager()`, that is now wrapped inside a private method to allow injecting the manager from tests.

Note empty values for arrays are still saved ([here](https://github.com/oat-sa/tao-core/blob/7934e85497517172dc10faf1da7935bb3eed5679/models/classes/dataBinding/class.GenerisInstanceDataBinder.php#L118) and [here](https://github.com/oat-sa/tao-core/blob/7934e85497517172dc10faf1da7935bb3eed5679/models/classes/dataBinding/class.GenerisInstanceDataBinder.php#L137)); that is, no filtering is done for arrays but only for string properties.

This pull request supersedes #3339 by providing the intended fix with no additional changes.

---
Self-checks before moving to code review:

- [x] New code is covered by tests (if applicable)
- [x] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [ ] New code is not subject to concurrency issues (if applicable)
- [x] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful
- [x] Pull request's target is not master
- [x] Kitchen links are not exposed in the description
- [x] Commits are following conventional commits
