### PR TITLE
fix: include oauth parameters in only one place, either query or header

### DIFF
--- a/models/classes/oauth/OauthService.php
+++ b/models/classes/oauth/OauthService.php
@@ -243,7 +243,13 @@ class OauthService extends ConfigurableService implements \common_http_Signature
      */
     private function buildAuthorizationHeader(OAuthRequest $signedRequest)
     {
-        return mb_substr($signedRequest->to_header(), 15);
+        $headerPrefix = 'Authorization: ';
+        $authorizationHeader = $signedRequest->to_header();
+        if (mb_strpos($authorizationHeader, $headerPrefix) === 0) {
+            $authorizationHeader = mb_substr($authorizationHeader, mb_strlen($headerPrefix));
+        }
+
+        return $authorizationHeader;
     }
 
     /**


### PR DESCRIPTION
Oauth 1.0 parameters must be included either in request query parameters, `Authorization` header, or body. According to [protocol specification](https://datatracker.ietf.org/doc/html/rfc5849#section-3.5). Currently it was either query params, or query params + `Authorization` header.
 
Related to: https://oat-sa.atlassian.net/browse/TR-2754

Also updated the auth header construction, other http headers should not be included in signature calculation and replaced formatting with library implementation.
  
#### How to test
 
- launch delivery via LTI 1.1 with specified additional parameter `lis_outcome_service_url`, sending a url where result should be submitted. For testing you could use a webhook testing tool like https://webhook.site
- complete the test
- verify that generated request had oauth parameters only in the `Authorization` header, and not in query parameters