### PR TITLE
fix: use string fr exception + remove type hint

### DIFF
--- a/models/classes/password/PasswordConstraintsService.php
+++ b/models/classes/password/PasswordConstraintsService.php
@@ -29,7 +29,7 @@ use tao_helpers_form_Validator;
 class PasswordConstraintsService extends ConfigurableService implements PasswordConstraintsServiceInterface
 {
     /** @var tao_helpers_form_Validator[] */
-    private array $validators = [];
+    private $validators = [];
 
     public function validate($password): bool
     {

--- a/models/classes/taskQueue/Task/TaskLanguageLoader.php
+++ b/models/classes/taskQueue/Task/TaskLanguageLoader.php
@@ -43,7 +43,7 @@ class TaskLanguageLoader extends ConfigurableService implements TaskLanguageLoad
                 $this->getServiceLocator()->get(UserLanguageServiceInterface::SERVICE_ID)->getDefaultLanguage()
             );
 
-            $message = sprintf('Translations loaded for extension "%s"', $extension);
+            $message = sprintf('Translations loaded for extension "%s"', $extension->getId());
         } catch (Throwable $e) {
             $message = sprintf('Unable to load translations for task "%s".', $task->getId());
         }


### PR DESCRIPTION
Fix
- remove type hint to ensure php7.2 compatibility
- use extension id as string for exception message