### PR TITLE
fix/ADF-929: Fix password form

### DIFF
--- a/actions/class.UserSettings.php
+++ b/actions/class.UserSettings.php
@@ -66,7 +66,7 @@ class tao_actions_UserSettings extends tao_actions_CommonModule
                 $this->setData('message', __('Password changed'));
             }
 
-            $this->setData('myForm', $passwordForm->render());
+            $this->setData('settingsForm', $passwordForm->render());
         }
 
         $this->setView('form/settings_user.tpl');


### PR DESCRIPTION
**Associated Jira issue:** [ADF-929](https://oat-sa.atlassian.net/browse/ADF-929)

`tao_actions_UserSettings` was expecting the form container name to be `myForm`  ([here](https://github.com/oat-sa/tao-core/blob/develop/actions/class.UserSettings.php#L69)), but it has been since changed to `settingsForm` as part of another pull request and it seems the new name was not reflected on all places.

Checked as well if this template is used by other controllers -- it doesn't seem to be the case.