### PR TITLE
feat/ADF-922: Add tests for ElementMapFactory

### DIFF
--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -152,7 +152,7 @@ class ElementMapFactory extends ConfigurableService
         // Horrible hack to fix file widget
         if ($widgetUri === AsyncFile::WIDGET_ID) {
             $expectedWidget = GenerisAsyncFile::WIDGET_ID;
-            $widgetResource = new core_kernel_classes_Resource($expectedWidget);
+            $widgetResource = $property->getResource($expectedWidget);
         }
 
         if ($this->hasElement) {

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -140,8 +140,8 @@ class ElementMapFactory extends ConfigurableService
             return null;
         }
 
-        $widgetUri      = $widgetResource->getUri();
-        $propertyUri    = $property->getUri();
+        $widgetUri = $widgetResource->getUri();
+        $propertyUri = $property->getUri();
         $expectedWidget = $widgetUri;
 
         // Authoring widget is not used in standalone mode

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -140,8 +140,9 @@ class ElementMapFactory extends ConfigurableService
             return null;
         }
 
-        $widgetUri   = $widgetResource->getUri();
-        $propertyUri = $property->getUri();
+        $widgetUri      = $widgetResource->getUri();
+        $propertyUri    = $property->getUri();
+        $expectedWidget = $widgetUri;
 
         // Authoring widget is not used in standalone mode
         if ($widgetUri === Authoring::WIDGET_ID && $this->isStandaloneMode()) {
@@ -150,7 +151,8 @@ class ElementMapFactory extends ConfigurableService
 
         // Horrible hack to fix file widget
         if ($widgetUri === AsyncFile::WIDGET_ID) {
-            $widgetResource = new core_kernel_classes_Resource(GenerisAsyncFile::WIDGET_ID);
+            $expectedWidget = GenerisAsyncFile::WIDGET_ID;
+            $widgetResource = new core_kernel_classes_Resource($expectedWidget);
         }
 
         if ($this->hasElement) {
@@ -166,7 +168,7 @@ class ElementMapFactory extends ConfigurableService
             return null;
         }
 
-        if ($element->getWidget() !== $widgetUri) {
+        if ($element->getWidget() !== $expectedWidget) {
             common_Logger::w(sprintf(
                 'Widget definition differs from implementation: %s != %s',
                 $element->getWidget(),

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -371,7 +371,7 @@ class ElementMapFactory extends ConfigurableService
 
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
     {
-        if ($this->featureFlagChecker == null) {
+        if ($this->featureFlagChecker === null) {
             $this->featureFlagChecker = $this->getContainer()->get(FeatureFlagChecker::class);
         }
 

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -49,7 +49,6 @@ use tao_helpers_form_elements_GenerisAsyncFile as GenerisAsyncFile;
 use oat\tao\model\Lists\Business\Domain\ValueCollectionSearchRequest;
 use oat\tao\model\Language\Business\Specification\LanguageClassSpecification;
 use oat\tao\model\Language\Service\LanguageListElementSortService;
-use function Webmozart\Assert\Tests\StaticAnalysis\null;
 
 class ElementMapFactory extends ConfigurableService
 {
@@ -253,9 +252,11 @@ class ElementMapFactory extends ConfigurableService
 
     private function isBlockedForModification(core_kernel_classes_Property $property): bool
     {
-        if ($this->getFeatureFlagChecker()->isEnabled(
-            FeatureFlagCheckerInterface::FEATURE_FLAG_STATISTIC_METADATA_IMPORT
-        )) {
+        if (
+            $this->getFeatureFlagChecker()->isEnabled(
+                FeatureFlagCheckerInterface::FEATURE_FLAG_STATISTIC_METADATA_IMPORT
+            )
+        ) {
             return $property->isStatistical();
         }
 

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\tao\helpers\form;
 
 use common_Logger;
+use oat\oatbox\AbstractRegistry;
 use tao_helpers_Uri;
 use tao_helpers_Context;
 use core_kernel_classes_Class;
@@ -57,15 +58,18 @@ class ElementMapFactory extends ConfigurableService
     private $instance;
 
     /** @var ?bool */
-    private $isStandaloneMode = null;
+    private $isStandaloneMode;
 
     /** @var tao_helpers_form_FormElement */
-    private $element = null;
+    private $element;
 
     /**
-     * Used to allow setting the element to null by withElement() in tests.
+     * Used to allow setting the element explicitly to null in tests.
      */
     private $hasElement = false;
+
+    /** @var AbstractRegistry */
+    private $validationRuleRegistry;
 
     public function withInstance(core_kernel_classes_Resource $instance): self
     {
@@ -85,6 +89,13 @@ class ElementMapFactory extends ConfigurableService
     {
         $this->hasElement = true;
         $this->element = $element;
+
+        return $this;
+    }
+
+    public function withValidationRuleRegistry(AbstractRegistry $registry): self
+    {
+        $this->validationRuleRegistry = $registry;
 
         return $this;
     }
@@ -300,8 +311,11 @@ class ElementMapFactory extends ConfigurableService
 
     private function getValidationRuleRegistry(): AbstractRegistry
     {
-        // @todo Allow this to be injected
-        return ValidationRuleRegistry::getRegistry();
+        if($this->validationRuleRegistry === null) {
+            $this->validationRuleRegistry = ValidationRuleRegistry::getRegistry();
+        }
+
+        return $this->validationRuleRegistry;
     }
 
     private function getValueCollectionService(): ValueCollectionService

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -363,9 +363,7 @@ class ElementMapFactory extends ConfigurableService
     private function getValueCollectionService(): ValueCollectionService
     {
         if ($this->valueCollectionService === null) {
-            $this->valueCollectionService = $this->getContainer()->get(
-                ValueCollectionService::class
-            );
+            $this->valueCollectionService = $this->getContainer()->get(ValueCollectionService::class);
         }
 
         return $this->valueCollectionService;
@@ -374,9 +372,7 @@ class ElementMapFactory extends ConfigurableService
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
     {
         if ($this->featureFlagChecker == null) {
-            $this->featureFlagChecker = $this->getContainer()->get(
-                FeatureFlagChecker::class
-            );
+            $this->featureFlagChecker = $this->getContainer()->get(FeatureFlagChecker::class);
         }
 
         return $this->featureFlagChecker;
@@ -385,9 +381,7 @@ class ElementMapFactory extends ConfigurableService
     private function getLanguageClassSpecification(): LanguageClassSpecification
     {
         if ($this->languageClassSpecification == null) {
-            $this->languageClassSpecification = $this->getContainer()->get(
-                LanguageClassSpecification::class
-            );
+            $this->languageClassSpecification = $this->getContainer()->get(LanguageClassSpecification::class);
         }
 
         return $this->languageClassSpecification;

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -123,7 +123,6 @@ class ElementMapFactory extends ConfigurableService
             $widgetResource = new core_kernel_classes_Resource(GenerisAsyncFile::WIDGET_ID);
         }
 
-        //$element = $this->getElement($propertyUri, $widgetResource);
         if ($this->hasElement) {
             $element = $this->element;
         } else {
@@ -153,7 +152,10 @@ class ElementMapFactory extends ConfigurableService
             $parentProperty = $this->getParentProperty($property);
 
             if ($parentProperty) {
-                $element->addAttribute('data-depends-on-property', tao_helpers_Uri::encode($parentProperty->getUri()));
+                $element->addAttribute(
+                    'data-depends-on-property',
+                    tao_helpers_Uri::encode($parentProperty->getUri())
+                );
             }
         }
 
@@ -194,16 +196,18 @@ class ElementMapFactory extends ConfigurableService
                                 new core_kernel_classes_Property(TaoOntology::PROPERTY_LIST_LEVEL)
                             );
 
-                            $encodedUri = tao_helpers_Uri::encode($rangeInstance->getUri());
-
                             if (null === $level) {
+                                $encodedUri = tao_helpers_Uri::encode($rangeInstance->getUri());
                                 $options[$encodedUri] = [$encodedUri, $rangeInstance->getLabel()];
                             } else {
                                 $level = ($level instanceof core_kernel_classes_Resource)
                                     ? $level->getUri()
                                     : (string)$level;
 
-                                $options[$level] = [$encodedUri, $rangeInstance->getLabel()];
+                                $options[$level] = [
+                                    tao_helpers_Uri::encode($rangeInstance->getUri()),
+                                    $rangeInstance->getLabel()
+                                ];
                             }
                         }
 
@@ -311,7 +315,7 @@ class ElementMapFactory extends ConfigurableService
 
     private function getValidationRuleRegistry(): AbstractRegistry
     {
-        if($this->validationRuleRegistry === null) {
+        if ($this->validationRuleRegistry === null) {
             $this->validationRuleRegistry = ValidationRuleRegistry::getRegistry();
         }
 

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -380,7 +380,7 @@ class ElementMapFactory extends ConfigurableService
 
     private function getLanguageClassSpecification(): LanguageClassSpecification
     {
-        if ($this->languageClassSpecification == null) {
+        if ($this->languageClassSpecification === null) {
             $this->languageClassSpecification = $this->getContainer()->get(LanguageClassSpecification::class);
         }
 

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -389,7 +389,7 @@ class ElementMapFactory extends ConfigurableService
 
     private function getLanguageListElementSortService(): ListElementSorterInterface
     {
-        if ($this->languageClassSpecification == null) {
+        if ($this->languageClassSpecification === null) {
             $this->languageClassSpecification = $this->getContainer()->get(LanguageListElementSortService::class);
         }
 

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -49,6 +49,7 @@ use tao_helpers_form_elements_GenerisAsyncFile as GenerisAsyncFile;
 use oat\tao\model\Lists\Business\Domain\ValueCollectionSearchRequest;
 use oat\tao\model\Language\Business\Specification\LanguageClassSpecification;
 use oat\tao\model\Language\Service\LanguageListElementSortService;
+use function Webmozart\Assert\Tests\StaticAnalysis\null;
 
 class ElementMapFactory extends ConfigurableService
 {
@@ -70,6 +71,9 @@ class ElementMapFactory extends ConfigurableService
 
     /** @var AbstractRegistry */
     private $validationRuleRegistry;
+
+    /** @var FeatureFlagCheckerInterface */
+    private $featureFlagChecker;
 
     public function withInstance(core_kernel_classes_Resource $instance): self
     {
@@ -96,6 +100,13 @@ class ElementMapFactory extends ConfigurableService
     public function withValidationRuleRegistry(AbstractRegistry $registry): self
     {
         $this->validationRuleRegistry = $registry;
+
+        return $this;
+    }
+
+    public function withFeatureFlagChecker(FeatureFlagChecker $checker): self
+    {
+        $this->featureFlagChecker = $checker;
 
         return $this;
     }
@@ -242,7 +253,9 @@ class ElementMapFactory extends ConfigurableService
 
     private function isBlockedForModification(core_kernel_classes_Property $property): bool
     {
-        if ($this->getFeatureFlagChecker()->isEnabled('FEATURE_FLAG_STATISTIC_METADATA_IMPORT')) {
+        if ($this->getFeatureFlagChecker()->isEnabled(
+            FeatureFlagCheckerInterface::FEATURE_FLAG_STATISTIC_METADATA_IMPORT
+        )) {
             return $property->isStatistical();
         }
 
@@ -329,7 +342,13 @@ class ElementMapFactory extends ConfigurableService
 
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
     {
-        return $this->getContainer()->get(FeatureFlagChecker::class);
+        if ($this->featureFlagChecker == null) {
+            $this->featureFlagChecker = $this->getContainer()->get(
+                FeatureFlagChecker::class
+            );
+        }
+
+        return $this->featureFlagChecker;
     }
 
     private function getLanguageClassSpecification(): LanguageClassSpecification

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -57,7 +57,7 @@ class ElementMapFactory extends ConfigurableService
     /** @var core_kernel_classes_Resource */
     private $instance;
 
-    /** @var ?bool */
+    /** @var bool */
     private $isStandaloneMode;
 
     /** @var tao_helpers_form_FormElement */

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -74,7 +74,7 @@ class ElementMapFactory extends ConfigurableService
     /**
      * Used for tests
      */
-    public function withStandaloneModel(bool $isStandaloneMode): self
+    public function withStandaloneMode(bool $isStandaloneMode): self
     {
         $this->isStandaloneMode = $isStandaloneMode;
 
@@ -116,7 +116,7 @@ class ElementMapFactory extends ConfigurableService
         }
 
         $element = $this->getElement($propertyUri, $widgetResource);
-        if(null === $element) {
+        if (null === $element) {
             return null;
         }
 
@@ -149,8 +149,10 @@ class ElementMapFactory extends ConfigurableService
                     $range
                 );
 
-                if (!($element instanceof TreeAware)
-                    && method_exists($element, 'setEmptyOption')) {
+                if (
+                    !($element instanceof TreeAware)
+                    && method_exists($element, 'setEmptyOption')
+                ) {
                     // Set the default value to an empty space
                     $element->setEmptyOption(' ');
                 }
@@ -174,8 +176,7 @@ class ElementMapFactory extends ConfigurableService
     private function getElement(
         string $propertyUri,
         $widgetResource
-    ): ?tao_helpers_form_FormElement
-    {
+    ): ?tao_helpers_form_FormElement {
         if ($this->hasElement) {
             return $this->element;
         }
@@ -337,8 +338,7 @@ class ElementMapFactory extends ConfigurableService
 
     private function isStandaloneMode(): bool
     {
-        if ($this->isStandaloneMode === null)
-        {
+        if ($this->isStandaloneMode === null) {
             $this->isStandaloneMode = tao_helpers_Context::check('STANDALONE_MODE');
         }
 

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -74,6 +74,12 @@ class ElementMapFactory extends ConfigurableService
     /** @var FeatureFlagCheckerInterface */
     private $featureFlagChecker;
 
+    /** @var LanguageClassSpecification */
+    private $languageClassSpecification;
+
+    /** @var ValueCollectionService */
+    private $valueCollectionService;
+
     public function withInstance(core_kernel_classes_Resource $instance): self
     {
         $this->instance = $instance;
@@ -106,6 +112,20 @@ class ElementMapFactory extends ConfigurableService
     public function withFeatureFlagChecker(FeatureFlagChecker $checker): self
     {
         $this->featureFlagChecker = $checker;
+
+        return $this;
+    }
+
+    public function withLanguageClassSpecification(LanguageClassSpecification $specification): self
+    {
+        $this->languageClassSpecification = $specification;
+
+        return $this;
+    }
+
+    public function withValueCollectionService(ValueCollectionService $service): self
+    {
+        $this->valueCollectionService = $service;
 
         return $this;
     }
@@ -315,7 +335,9 @@ class ElementMapFactory extends ConfigurableService
             }
         }
 
-        return $this->getValueCollectionService()->findAll(new ValueCollectionSearchInput($searchRequest));
+        return $this->getValueCollectionService()->findAll(
+            new ValueCollectionSearchInput($searchRequest)
+        );
     }
 
     private function isStandaloneMode(): bool
@@ -338,7 +360,13 @@ class ElementMapFactory extends ConfigurableService
 
     private function getValueCollectionService(): ValueCollectionService
     {
-        return $this->getContainer()->get(ValueCollectionService::class);
+        if ($this->valueCollectionService === null) {
+            $this->valueCollectionService = $this->getContainer()->get(
+                ValueCollectionService::class
+            );
+        }
+
+        return $this->valueCollectionService;
     }
 
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
@@ -354,12 +382,22 @@ class ElementMapFactory extends ConfigurableService
 
     private function getLanguageClassSpecification(): LanguageClassSpecification
     {
-        return $this->getContainer()->get(LanguageClassSpecification::class);
+        if ($this->languageClassSpecification == null) {
+            $this->languageClassSpecification = $this->getContainer()->get(
+                LanguageClassSpecification::class
+            );
+        }
+
+        return $this->languageClassSpecification;
     }
 
     private function getLanguageListElementSortService(): ListElementSorterInterface
     {
-        return $this->getContainer()->get(LanguageListElementSortService::class);
+        if ($this->languageClassSpecification == null) {
+            $this->languageClassSpecification = $this->getContainer()->get(LanguageListElementSortService::class);
+        }
+
+        return $this->languageClassSpecification;
     }
 
     private function getContainer(): ContainerInterface

--- a/test/unit/helpers/form/ElementMapFactoryTest.php
+++ b/test/unit/helpers/form/ElementMapFactoryTest.php
@@ -47,9 +47,6 @@ class ElementMapFactoryTest extends TestCase
     /** @var ElementMapFactory */
     private $sut;
 
-    /** @var tao_helpers_form_FormElement|MockObject */
-    //private $elementMock;
-
     /** @var AbstractRegistry|MockObject */
     private $ruleRegistry;
 
@@ -58,9 +55,6 @@ class ElementMapFactoryTest extends TestCase
 
     /** @var LanguageClassSpecification|MockObject */
     private $languageClassSpecification;
-
-    /** @var ServiceLocatorInterface|ServiceManager */
-    private $serviceLocator;
 
     /** @var ValueCollectionService|MockObject */
     private $valueCollectionService;
@@ -72,11 +66,7 @@ class ElementMapFactoryTest extends TestCase
         $this->languageClassSpecification = $this->createMock(LanguageClassSpecification::class);
         $this->valueCollectionService = $this->createMock(ValueCollectionService::class);
 
-        // @todo Maybe unneeded if/once we inject all deps
-        $this->serviceLocator = $this->getServiceLocatorMock([]);
-
         $this->sut = new ElementMapFactory();
-        //$this->elementMock = $this->createMock(tao_helpers_form_FormElement::class);
 
         $this->sut->withFeatureFlagChecker($this->ffChecker);
         $this->sut->withValidationRuleRegistry($this->ruleRegistry);
@@ -96,7 +86,6 @@ class ElementMapFactoryTest extends TestCase
         ?tao_helpers_form_FormElement $elementForWidget,
         array $validators
     ): void {
-
         $this->ffChecker
             ->method('isEnabled')
             ->willReturnMap(
@@ -127,7 +116,6 @@ class ElementMapFactoryTest extends TestCase
         $this->sut->withStandaloneMode($standalone);
         $this->sut->withElement($elementForWidget);
         $this->sut->withValueCollectionService($this->valueCollectionService);
-
 
         $elementForWidget
             ->expects($this->atLeastOnce())
@@ -283,8 +271,6 @@ class ElementMapFactoryTest extends TestCase
         string $name,
         string $description
     ): tao_helpers_form_FormElement {
-        // Needs to be created here since the dataProvider is evaluated before
-        // setUp() runs (so $this->elementMock is null here)
         $elementMock = $this->createMock(tao_helpers_form_FormElement::class);
         $elementMock
             ->method('getName')
@@ -300,8 +286,6 @@ class ElementMapFactoryTest extends TestCase
         string $widgetId,
         string $className = tao_helpers_form_FormElement::class
     ): tao_helpers_form_FormElement {
-        // Needs to be created here since the dataProvider is evaluated before
-        // setUp() runs (so $this->elementMock is null here)
         $elementMock = $this->createMock($className);
         $elementMock
             ->method('getWidget')

--- a/test/unit/helpers/form/ElementMapFactoryTest.php
+++ b/test/unit/helpers/form/ElementMapFactoryTest.php
@@ -58,26 +58,24 @@ class ElementMapFactoryTest extends TestCase
         bool $listDependencyEnabled,
         core_kernel_classes_Property $property,
         ?tao_helpers_form_FormElement $elementForWidget
-    ): void
-    {
+    ): void {
         $ffChecker = $this->createMock(FeatureFlagChecker::class);
         $ffChecker
             ->method('isEnabled')
             ->with(FeatureFlagCheckerInterface::FEATURE_FLAG_LISTS_DEPENDENCY_ENABLED)
             ->willReturn($listDependencyEnabled);
 
-        $this->sut->withStandaloneModel($standalone);
+        $this->sut->withStandaloneMode($standalone);
         $this->sut->withElement($elementForWidget);
 
         $element = $this->sut->create($property);
 
-        if($expected === null) {
+        if ($expected === null) {
             $this->assertNull($element);
             return;
         }
 
         $this->assertEquals($expected->getName(), $element->getName());
-
     }
 
     public function somethingDataProvider(): array
@@ -120,8 +118,7 @@ class ElementMapFactoryTest extends TestCase
         bool $isList,
         bool $isClass = true,
         string $rangeObjectType = core_kernel_classes_Class::class
-    ): core_kernel_classes_Property
-    {
+    ): core_kernel_classes_Property {
         $rangeClass = $this->createMock($rangeObjectType);
 
         if (is_a($rangeClass, core_kernel_classes_Resource::class)) {

--- a/test/unit/helpers/form/ElementMapFactoryTest.php
+++ b/test/unit/helpers/form/ElementMapFactoryTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\helpers\test\unit\helpers\form;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use oat\generis\test\TestCase;
+use oat\tao\helpers\form\ElementMapFactory;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\tao\model\Lists\Business\Specification\PresortedListSpecification;
+use oat\tao\test\Asset\CustomRootClassFixture;
+use tao_helpers_form_elements_Authoring;
+use PHPUnit\Framework\MockObject\MockObject;
+use tao_helpers_form_FormElement;
+
+class ElementMapFactoryTest extends TestCase
+{
+    /** @var ElementMapFactory */
+    private $sut;
+
+    /** @var tao_helpers_form_FormElement|MockObject */
+    private $elementMock;
+
+    public function setUp(): void
+    {
+        $this->sut = new ElementMapFactory();
+        $this->elementMock = $this->createMock(tao_helpers_form_FormElement::class);
+    }
+
+    /**
+     * @dataProvider somethingDataProvider
+     */
+    public function testSomething(
+        ?\tao_helpers_form_FormElement $expected,
+        bool $standalone,
+        bool $listDependencyEnabled,
+        core_kernel_classes_Property $property,
+        ?tao_helpers_form_FormElement $elementForWidget
+    ): void
+    {
+        $ffChecker = $this->createMock(FeatureFlagChecker::class);
+        $ffChecker
+            ->method('isEnabled')
+            ->with(FeatureFlagCheckerInterface::FEATURE_FLAG_LISTS_DEPENDENCY_ENABLED)
+            ->willReturn($listDependencyEnabled);
+
+        $this->sut->withStandaloneModel($standalone);
+        $this->sut->withElement($elementForWidget);
+
+        $element = $this->sut->create($property);
+
+        if($expected === null) {
+            $this->assertNull($element);
+            return;
+        }
+
+        $this->assertEquals($expected->getName(), $element->getName());
+
+    }
+
+    public function somethingDataProvider(): array
+    {
+        return [
+            'A property with no widget returns a null element' => [
+                'expected' => null,
+                'standalone' => false,
+                'listDependencyEnabled' => false,
+                'property' => $this->getMockProperty(null, true),
+                'elementForWidget' => null,
+            ],
+            'Authoring widget returns null in standalone mode' => [
+                'expected' => null,
+                'standalone' => true,
+                'listDependencyEnabled' => false,
+                'property' => $this->getMockProperty(
+                    tao_helpers_form_elements_Authoring::WIDGET_ID,
+                    true
+                ),
+                'elementForWidget' => null,
+            ],
+            // @todo Test to cover the implicit conversion
+            //       AsyncFile::WIDGET_ID -> GenerisAsyncFile::WIDGET_ID
+            'Having no element for the widget returns null' => [
+                'expected' => null,
+                'standalone' => false,
+                'listDependencyEnabled' => false,
+                'property' => $this->getMockProperty(
+                    'hello-world',
+                    true
+                ),
+                'elementForWidget' => $this->elementMock,
+            ],
+        ];
+    }
+
+    private function getMockProperty(
+        ?string $widgetType,
+        bool $isList,
+        bool $isClass = true,
+        string $rangeObjectType = core_kernel_classes_Class::class
+    ): core_kernel_classes_Property
+    {
+        $rangeClass = $this->createMock($rangeObjectType);
+
+        if (is_a($rangeClass, core_kernel_classes_Resource::class)) {
+            $rangeClass
+                ->method('isClass')
+                ->willReturn($isClass);
+        }
+
+        if (is_a($rangeClass, core_kernel_classes_Class::class)) {
+            $rangeClass
+                ->method('isSubClassOf')
+                ->willReturn($isList);
+        }
+
+        $property = $this->createMock(core_kernel_classes_Property::class);
+        $property
+            ->method('getRange')
+            ->withAnyParameters()
+            ->willReturn($rangeClass);
+
+        if ($widgetType) {
+            $widgetMock = $this->createMock(core_kernel_classes_Property::class);
+            $widgetMock
+                ->method('getUri')
+                ->willReturn($widgetType);
+        }
+
+        $property
+            ->method('getWidget')
+            ->willReturn($widgetType ? $widgetMock : null);
+
+        return $property;
+    }
+}

--- a/test/unit/helpers/form/ElementMapFactoryTest.php
+++ b/test/unit/helpers/form/ElementMapFactoryTest.php
@@ -41,6 +41,8 @@ use tao_helpers_form_elements_Authoring;
 use tao_helpers_form_elements_MultipleElement;
 use tao_helpers_form_FormElement;
 use PHPUnit\Framework\MockObject\MockObject;
+use tao_helpers_form_elements_AsyncFile;
+use tao_helpers_form_elements_GenerisAsyncFile;
 
 class ElementMapFactoryTest extends TestCase
 {
@@ -84,7 +86,8 @@ class ElementMapFactoryTest extends TestCase
         bool $statisticMetadataEnabled,
         core_kernel_classes_Property $property,
         ?tao_helpers_form_FormElement $elementForWidget,
-        array $validators
+        array $validators,
+        ?core_kernel_classes_Resource $instance = null
     ): void {
         $this->ffChecker
             ->method('isEnabled')
@@ -112,6 +115,10 @@ class ElementMapFactoryTest extends TestCase
             ->method('getValidators')
             ->with($property)
             ->willReturn($validators);
+
+        if ($instance !== null) {
+            $this->sut->withInstance($instance);
+        }
 
         $this->sut->withStandaloneMode($standalone);
         $this->sut->withElement($elementForWidget);
@@ -159,9 +166,9 @@ class ElementMapFactoryTest extends TestCase
                 ),
                 'validators' => [],
             ],
-            'AsyncFile is implicitly converted to GenerisAsyncFile' => [
+            'Happy Path with instance' => [
                 'expected' => $this->mockNamedElement(
-                    \tao_helpers_form_elements_GenerisAsyncFile::WIDGET_ID,
+                    tao_helpers_form_elements_Authoring::WIDGET_ID,
                     'property label'
                 ),
                 'expectedOptions' => [
@@ -171,12 +178,37 @@ class ElementMapFactoryTest extends TestCase
                 'listDependencyEnabled' => false,
                 'statisticMetadataEnabled' => false,
                 'property' => $this->getMockProperty(
-                    \tao_helpers_form_elements_AsyncFile::WIDGET_ID,
+                    tao_helpers_form_elements_Authoring::WIDGET_ID,
                     true,
                     'property label'
                 ),
                 'elementForWidget' => $this->mockElementForWidget(
-                    \tao_helpers_form_elements_GenerisAsyncFile::WIDGET_ID,
+                    tao_helpers_form_elements_Authoring::WIDGET_ID,
+                    tao_helpers_form_elements_MultipleElement::class
+                ),
+                'validators' => [],
+                'instance' => $this->createMock(
+                    core_kernel_classes_Resource::class
+                ),
+            ],
+            'AsyncFile is implicitly converted to GenerisAsyncFile' => [
+                'expected' => $this->mockNamedElement(
+                    tao_helpers_form_elements_GenerisAsyncFile::WIDGET_ID,
+                    'property label'
+                ),
+                'expectedOptions' => [
+
+                ],
+                'standalone' => false,
+                'listDependencyEnabled' => false,
+                'statisticMetadataEnabled' => false,
+                'property' => $this->getMockProperty(
+                    tao_helpers_form_elements_AsyncFile::WIDGET_ID,
+                    true,
+                    'property label'
+                ),
+                'elementForWidget' => $this->mockElementForWidget(
+                    tao_helpers_form_elements_GenerisAsyncFile::WIDGET_ID,
                     tao_helpers_form_elements_MultipleElement::class
                 ),
                 'validators' => [],

--- a/test/unit/helpers/form/ElementMapFactoryTest.php
+++ b/test/unit/helpers/form/ElementMapFactoryTest.php
@@ -26,7 +26,9 @@ use core_kernel_classes_Class;
 use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
 use oat\generis\test\TestCase;
+use oat\oatbox\AbstractRegistry;
 use oat\tao\helpers\form\ElementMapFactory;
+use oat\tao\helpers\form\ValidationRuleRegistry;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
 use oat\tao\model\Lists\Business\Specification\PresortedListSpecification;
@@ -41,12 +43,21 @@ class ElementMapFactoryTest extends TestCase
     private $sut;
 
     /** @var tao_helpers_form_FormElement|MockObject */
-    private $elementMock;
+    //private $elementMock;
+
+    /** @var AbstractRegistry|MockObject */
+    private $ruleRegistry;
+
+    /** @var FeatureFlagCheckerInterface|MockObject */
+    private $ffChecker;
 
     public function setUp(): void
     {
+        $this->ffChecker = $this->createMock(FeatureFlagChecker::class);
+        $this->ruleRegistry = $this->createMock(ValidationRuleRegistry::class);
+
         $this->sut = new ElementMapFactory();
-        $this->elementMock = $this->createMock(tao_helpers_form_FormElement::class);
+        //$this->elementMock = $this->createMock(tao_helpers_form_FormElement::class);
     }
 
     /**
@@ -56,26 +67,66 @@ class ElementMapFactoryTest extends TestCase
         ?\tao_helpers_form_FormElement $expected,
         bool $standalone,
         bool $listDependencyEnabled,
+        bool $statisticMetadataEnabled,
         core_kernel_classes_Property $property,
-        ?tao_helpers_form_FormElement $elementForWidget
+        ?tao_helpers_form_FormElement $elementForWidget,
+        array $validators
     ): void {
-        $ffChecker = $this->createMock(FeatureFlagChecker::class);
-        $ffChecker
+        /*$this->ffChecker
+            ->expects($this->at(0))
             ->method('isEnabled')
             ->with(FeatureFlagCheckerInterface::FEATURE_FLAG_LISTS_DEPENDENCY_ENABLED)
-            ->willReturn($listDependencyEnabled);
+            ->willReturn($listDependencyEnabled);*/
+
+        $this->ffChecker
+            //->expects($this->atMost(1))
+            ->method('isEnabled')
+            ->willReturnMap(
+                [
+                    [
+                        FeatureFlagCheckerInterface::FEATURE_FLAG_LISTS_DEPENDENCY_ENABLED,
+                        $listDependencyEnabled
+                    ],
+                    [
+                        FeatureFlagCheckerInterface::FEATURE_FLAG_STATISTIC_METADATA_IMPORT,
+                        $statisticMetadataEnabled,
+                    ],
+                ]
+            );
+
+        $this->ruleRegistry
+            ->method('getValidators')
+            ->with($property)
+            ->willReturn($validators);
 
         $this->sut->withStandaloneMode($standalone);
         $this->sut->withElement($elementForWidget);
+        $this->sut->withFeatureFlagChecker($this->ffChecker);
+        $this->sut->withValidationRuleRegistry($this->ruleRegistry);
+
+        if ($expected !== null) {
+            $elementForWidget
+                ->expects($this->atLeastOnce())
+                ->method('setDescription')
+                ->with($expected->getDescription());
+
+        }/* else {
+            throw new \Exception('wtf');
+        }*/
 
         $element = $this->sut->create($property);
 
         if ($expected === null) {
             $this->assertNull($element);
-            return;
-        }
+            // return;
+        } else {
 
-        $this->assertEquals($expected->getName(), $element->getName());
+
+            /*$this->assertEquals(
+                $expected->getDescription(),
+                $element->getDescription()
+            );*/
+        }
     }
 
     public function somethingDataProvider(): array
@@ -85,18 +136,27 @@ class ElementMapFactoryTest extends TestCase
                 'expected' => null,
                 'standalone' => false,
                 'listDependencyEnabled' => false,
-                'property' => $this->getMockProperty(null, true),
+                'statisticMetadataEnabled' => false,
+                'property' => $this->getMockProperty(
+                    null,
+                    true,
+                    'the label'
+                ),
                 'elementForWidget' => null,
+                'validators' => [],
             ],
             'Authoring widget returns null in standalone mode' => [
                 'expected' => null,
                 'standalone' => true,
                 'listDependencyEnabled' => false,
+                'statisticMetadataEnabled' => false,
                 'property' => $this->getMockProperty(
                     tao_helpers_form_elements_Authoring::WIDGET_ID,
-                    true
+                    true,
+                    'the label'
                 ),
                 'elementForWidget' => null,
+                'validators' => [],
             ],
             // @todo Test to cover the implicit conversion
             //       AsyncFile::WIDGET_ID -> GenerisAsyncFile::WIDGET_ID
@@ -104,18 +164,70 @@ class ElementMapFactoryTest extends TestCase
                 'expected' => null,
                 'standalone' => false,
                 'listDependencyEnabled' => false,
+                'statisticMetadataEnabled' => false,
                 'property' => $this->getMockProperty(
                     'hello-world',
-                    true
+                    true,
+                    'the label'
                 ),
-                'elementForWidget' => $this->elementMock,
+                'elementForWidget' => null,
+                'validators' => [],
+            ],
+
+            // @fixme This still exits in the
+            //        "if($element->getWidget() !== $widgetUri)" condition
+            'Happy Path' => [
+                'expected' => $this->mockNamedElement(
+                    tao_helpers_form_elements_Authoring::WIDGET_ID,
+                    'property label'
+                ),
+                'standalone' => false,
+                'listDependencyEnabled' => false,
+                'statisticMetadataEnabled' => false,
+                'property' => $this->getMockProperty(
+                    tao_helpers_form_elements_Authoring::WIDGET_ID,
+                    true,
+                    'property label'
+                ),
+                'elementForWidget' => $this->mockElementForWidget(
+                    tao_helpers_form_elements_Authoring::WIDGET_ID
+                ),
+                'validators' => [],
             ],
         ];
+    }
+
+    private function mockNamedElement(string $name, string $description)
+    {
+        // Needs to be created here since the dataProvider is evaluated before
+        // setUp() runs (so $this->elementMock is null here)
+        $elementMock = $this->createMock(tao_helpers_form_FormElement::class);
+        $elementMock
+            ->method('getName')
+            ->willReturn($name);
+        $elementMock
+            ->method('getDescription')
+            ->willReturn($description);
+
+        return $elementMock;
+    }
+
+    private function mockElementForWidget(string $widgetId)
+    {
+        // Needs to be created here since the dataProvider is evaluated before
+        // setUp() runs (so $this->elementMock is null here)
+        $elementMock = $this->createMock(tao_helpers_form_FormElement::class);
+        $elementMock
+            ->method('getWidget')
+            ->willReturn($widgetId);
+
+        return $elementMock;
     }
 
     private function getMockProperty(
         ?string $widgetType,
         bool $isList,
+        string $label,
         bool $isClass = true,
         string $rangeObjectType = core_kernel_classes_Class::class
     ): core_kernel_classes_Property {
@@ -138,6 +250,10 @@ class ElementMapFactoryTest extends TestCase
             ->method('getRange')
             ->withAnyParameters()
             ->willReturn($rangeClass);
+
+        $property
+            ->method('getLabel')
+            ->willReturn($label);
 
         if ($widgetType) {
             $widgetMock = $this->createMock(core_kernel_classes_Property::class);

--- a/test/unit/helpers/form/ElementMapFactoryTest.php
+++ b/test/unit/helpers/form/ElementMapFactoryTest.php
@@ -25,6 +25,7 @@ namespace oat\tao\helpers\test\unit\helpers\form;
 use core_kernel_classes_Class;
 use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
+use oat\generis\model\resource\DependsOnPropertyCollection;
 use oat\generis\test\TestCase;
 use oat\oatbox\AbstractRegistry;
 use oat\oatbox\service\ServiceManager;
@@ -136,6 +137,49 @@ class ElementMapFactoryTest extends TestCase
                 ->with($expectedOptions);
         }
 
+        if ($listDependencyEnabled) {
+            $dependencyCollection = $this->createMock(
+                DependsOnPropertyCollection::class
+            );
+
+            $parentProperty = $this->createMock(
+                core_kernel_classes_Property::class
+            );
+
+            $parentProperty
+                ->method('getUri')
+                ->willReturn('url://parent');
+
+            $dependencyCollection
+                ->method('offsetExists')
+                ->with(0)
+                ->willReturn(true);
+
+            $dependencyCollection
+                ->method('offsetGet')
+                ->with(0)
+                ->willReturn($parentProperty);
+
+            $property
+                ->expects($this->once())
+                ->method('getDependsOnPropertyCollection')
+                ->with()
+                ->willReturn($dependencyCollection);
+
+            $elementForWidget
+                ->expects($this->atLeastOnce())
+                ->method('addAttribute')
+                ->with('data-depends-on-property', 'url://parent');
+
+            $instance
+                ->method('getPropertyValuesCollection')
+                ->with($parentProperty)
+                ->willReturn([
+                    'parentPropertyValue1',
+                    'parentPropertyValue2',
+                ]);
+        }
+
         $element = $this->sut->create($property);
 
         $this->assertInstanceOf(tao_helpers_form_FormElement::class, $element);
@@ -176,6 +220,31 @@ class ElementMapFactoryTest extends TestCase
                 ],
                 'standalone' => false,
                 'listDependencyEnabled' => false,
+                'statisticMetadataEnabled' => false,
+                'property' => $this->getMockProperty(
+                    tao_helpers_form_elements_Authoring::WIDGET_ID,
+                    true,
+                    'property label'
+                ),
+                'elementForWidget' => $this->mockElementForWidget(
+                    tao_helpers_form_elements_Authoring::WIDGET_ID,
+                    tao_helpers_form_elements_MultipleElement::class
+                ),
+                'validators' => [],
+                'instance' => $this->createMock(
+                    core_kernel_classes_Resource::class
+                ),
+            ],
+            'Happy Path with instance & listDependencyEnabled' => [
+                'expected' => $this->mockNamedElement(
+                    tao_helpers_form_elements_Authoring::WIDGET_ID,
+                    'property label'
+                ),
+                'expectedOptions' => [
+
+                ],
+                'standalone' => false,
+                'listDependencyEnabled' => true,
                 'statisticMetadataEnabled' => false,
                 'property' => $this->getMockProperty(
                     tao_helpers_form_elements_Authoring::WIDGET_ID,

--- a/test/unit/helpers/form/ElementMapFactoryTest.php
+++ b/test/unit/helpers/form/ElementMapFactoryTest.php
@@ -87,7 +87,7 @@ class ElementMapFactoryTest extends TestCase
      * @dataProvider successScenariosDataProvider
      */
     public function testSuccessScenario(
-        ?\tao_helpers_form_FormElement $expected,
+        ?tao_helpers_form_FormElement $expected,
         array $expectedOptions,
         bool $standalone,
         bool $listDependencyEnabled,
@@ -171,6 +171,28 @@ class ElementMapFactoryTest extends TestCase
                 ),
                 'validators' => [],
             ],
+            'AsyncFile is implicitly converted to GenerisAsyncFile' => [
+                'expected' => $this->mockNamedElement(
+                    \tao_helpers_form_elements_GenerisAsyncFile::WIDGET_ID,
+                    'property label'
+                ),
+                'expectedOptions' => [
+
+                ],
+                'standalone' => false,
+                'listDependencyEnabled' => false,
+                'statisticMetadataEnabled' => false,
+                'property' => $this->getMockProperty(
+                    \tao_helpers_form_elements_AsyncFile::WIDGET_ID,
+                    true,
+                    'property label'
+                ),
+                'elementForWidget' => $this->mockElementForWidget(
+                    \tao_helpers_form_elements_GenerisAsyncFile::WIDGET_ID,
+                    tao_helpers_form_elements_MultipleElement::class
+                ),
+                'validators' => [],
+            ],
         ];
     }
 
@@ -241,8 +263,7 @@ class ElementMapFactoryTest extends TestCase
                 'elementForWidget' => null,
                 'validators' => [],
             ],
-            // @todo Test to cover the implicit conversion
-            //       AsyncFile::WIDGET_ID -> GenerisAsyncFile::WIDGET_ID
+
             'Having no element for the widget returns null' => [
                 'standalone' => false,
                 'listDependencyEnabled' => false,

--- a/test/unit/helpers/form/ElementMapFactoryTest.php
+++ b/test/unit/helpers/form/ElementMapFactoryTest.php
@@ -109,19 +109,15 @@ class ElementMapFactoryTest extends TestCase
                 ->expects($this->atLeastOnce())
                 ->method('setDescription')
                 ->with($expected->getDescription());
-
-        }/* else {
-            throw new \Exception('wtf');
-        }*/
+        }
 
         $element = $this->sut->create($property);
 
         if ($expected === null) {
             $this->assertNull($element);
-            // return;
         } else {
-
-
+            // @todo We are not really testing anything other than the call to
+            //       setDescription()
             /*$this->assertEquals(
                 $expected->getDescription(),
                 $element->getDescription()


### PR DESCRIPTION
**Associated Jira issue:** [ADF-922](https://oat-sa.atlassian.net/browse/ADF-922)

This PR adds tests for the main/common branches from `ElementMapFactory`:

- Adds `withSomething()` methods to allow injecting mocks for services used from tests.
  -  `withElement()` allows mocking both having an element (`element!=null && hasElement=true`) or not having it (`element==null && hasElement=true`)
- Adds a `isStandaloneMode()` whose return value can be mocked from tests as well
- Adds the tests itself, covering the branches detailed in the attached report

<details>
  <summary>PHPUnit coverage report</summary>

![image](https://user-images.githubusercontent.com/339792/152761701-729311fb-c09a-4807-b704-5ec9f8d72a54.png)

</details>

