### PR TITLE
[backport] fix: Use the proper form container name for the change password form

### DIFF
--- a/actions/class.UserSettings.php
+++ b/actions/class.UserSettings.php
@@ -66,7 +66,7 @@ class tao_actions_UserSettings extends tao_actions_CommonModule
                 $this->setData('message', __('Password changed'));
             }
 
-            $this->setData('myForm', $passwordForm->render());
+            $this->setData('settingsForm', $passwordForm->render());
         }
 
         $this->setView('form/settings_user.tpl');


### PR DESCRIPTION
**Associated Jira issue:** [ADF-929](https://oat-sa.atlassian.net/browse/ADF-929).

Backporting the password form fix into the https://github.com/oat-sa/tao-core/releases/tag/v48.81.0

This was previously released as tao-core fix version [v49.0.2](https://github.com/oat-sa/tao-core/releases/tag/v49.0.2) (pull request #3373).