### PR TITLE
Fix TR-3469 Display human readable request-handling errors in Backoffice

### DIFF
--- a/views/js/controller/backoffice.js
+++ b/views/js/controller/backoffice.js
@@ -34,11 +34,7 @@ define([
     'use strict';
 
     function hasRequiredProperties(response) {
-        return response &&
-            typeof response.success !== 'undefined' &&
-            typeof response.type !== 'undefined' &&
-            typeof response.message !== 'undefined' &&
-            typeof response.data !== 'undefined'
+        return typeof response !== 'undefined' && !['success', 'type', 'message', 'data'].some(key => typeof response[key] === 'undefined');
     }
 
     /**

--- a/views/js/controller/backoffice.js
+++ b/views/js/controller/backoffice.js
@@ -33,15 +33,12 @@ define([
 ], function ($, _, __, context, helpers, router, uikitLoader, history, feedback, logoutEvent) {
     'use strict';
 
-    function hasAjaxResponse(ajaxResponse) {
-        return ajaxResponse && ajaxResponse !== null;
-    }
-
-    function hasAjaxResponseProperties(ajaxResponse) {
-        return typeof ajaxResponse.success !== 'undefined' &&
-            typeof ajaxResponse.type !== 'undefined' &&
-            typeof ajaxResponse.message !== 'undefined' &&
-            typeof ajaxResponse.data !== 'undefined'
+    function hasRequiredProperties(response) {
+        return response &&
+            typeof response.success !== 'undefined' &&
+            typeof response.type !== 'undefined' &&
+            typeof response.message !== 'undefined' &&
+            typeof response.data !== 'undefined'
     }
 
     /**
@@ -101,7 +98,7 @@ define([
                     //consider it as a "test" to check if resource exists
                     return;
                 } else if (request.status === 404 || request.status === 500) {
-                    if (hasAjaxResponse() && hasAjaxResponseProperties()) {
+                    if (hasRequiredProperties(ajaxResponse)) {
                         errorMessage = `${request.status}: ${ajaxResponse.message}`;
                     } else {
                         errorMessage = `${request.status}: ${request.responseText}`;

--- a/views/js/controller/backoffice.js
+++ b/views/js/controller/backoffice.js
@@ -33,8 +33,15 @@ define([
 ], function ($, _, __, context, helpers, router, uikitLoader, history, feedback, logoutEvent) {
     'use strict';
 
+    /**
+     * @typedef {{success: boolean, type: string, message: string, data: Object}} Response
+     *
+     * @param {Response} response
+     * @return {boolean}
+     */
     function hasRequiredProperties(response) {
-        return typeof response !== 'undefined' && !['success', 'type', 'message', 'data'].some(key => typeof response[key] === 'undefined');
+        return typeof response !== 'undefined'
+            && !['success', 'type', 'message', 'data'].some(key => typeof response[key] === 'undefined');
     }
 
     /**


### PR DESCRIPTION
# [TR-3469](https://oat-sa.atlassian.net/browse/TR-3469)
ℹ️ Caused by #2584 ℹ️

## How to test
1. Login as a bckoffice user
2. Cause a back-end error upon an action within the backoffice, e.g. ⬇️ 
3. Manually set the value of a delivery end date to a non-parsable one
4. Observe the error message

ℹ️ Indeed, the error message itself is still not human-readable, but it's a lot better than the whole response object displayed as is. The back-end messages will be improved further.

|Before|After|
|-|-| 
|<img width="409" alt="before" src="https://user-images.githubusercontent.com/2943256/154251144-605af23b-4878-4b07-b029-bd0c1c93f6bc.png">|<img width="409" alt="image" src="https://user-images.githubusercontent.com/2943256/154251249-5a55877b-ff7c-4977-9f86-6c9ae32850b6.png">|

## Changelog
- fix: display a human-readable request-handling error instead of a full response body in backoffice