### PR TITLE
fix/TR-2831_fix-remove-theme-by-id

### DIFF
--- a/models/classes/theme/ThemeService.php
+++ b/models/classes/theme/ThemeService.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -102,10 +102,14 @@ class ThemeService extends ThemeServiceAbstract
             return false;
         }
 
-        $themes = $this->getOption(static::OPTION_AVAILABLE);
-        unset($themes[$themeId]);
+        $availableThemes = $this->getOption(static::OPTION_AVAILABLE);
+        foreach ($this->getAllThemes() as $key => $theme) {
+            if ($theme->getId() === $themeId) {
+                unset($availableThemes[$key]);
+            }
+        }
 
-        $this->setOption(static::OPTION_AVAILABLE, $themes);
+        $this->setOption(static::OPTION_AVAILABLE, $availableThemes);
 
         return true;
     }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-2831

Theme handler remove functionality did not work correctly, because the key is postfixed with an id as well (https://github.com/oat-sa/tao-core/blob/master/models/classes/theme/ThemeServiceAbstract.php#L133), like `bosa_selor_default_theme0`, `bosa_selor_default_theme1`.