### PR TITLE
fix: add regex validator for login and allow to fix broken login

### DIFF
--- a/actions/form/class.Users.php
+++ b/actions/form/class.Users.php
@@ -225,12 +225,15 @@ class tao_actions_form_Users extends SignedFormInstance
             }
         }
 
-        $this->getSanitizerValidationFeeder()
-            ->addValidator($this->getSanitizerRegexValidator())
-            ->addElementByUri(OntologyRdfs::RDFS_LABEL)
-            ->addElementByUri(UserRdf::PROPERTY_LOGIN)
-            ->addElementByUri(UserRdf::PROPERTY_FIRSTNAME)
-            ->addElementByUri(UserRdf::PROPERTY_LASTNAME);
+        $this->addSanitizerValidator(
+            $this->getSanitizerRegexValidator(),
+            [
+                OntologyRdfs::RDFS_LABEL,
+                UserRdf::PROPERTY_LOGIN,
+                UserRdf::PROPERTY_FIRSTNAME,
+                UserRdf::PROPERTY_LASTNAME,
+            ]
+        );
     }
 
     private function initLoginElement(): void

--- a/helpers/class.Display.php
+++ b/helpers/class.Display.php
@@ -52,7 +52,11 @@ class tao_helpers_Display
             return $input;
         }
 
-        return "<span title='$input' class='cutted' style='cursor:pointer;'>" . mb_substr($input, 0, $maxLength, $encoding) . '[...]</span>';
+        return sprintf(
+            '<span title="%s" class="cutted" style="cursor:pointer;">%s[...]</span>',
+            $input,
+            mb_substr($input, 0, $maxLength, $encoding)
+        );
     }
 
     /**

--- a/helpers/form/Feeder/SanitizerValidationFeeder.php
+++ b/helpers/form/Feeder/SanitizerValidationFeeder.php
@@ -63,6 +63,9 @@ class SanitizerValidationFeeder implements SanitizerValidationFeederInterface
         return $this;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function addElement(tao_helpers_form_FormElement $element): SanitizerValidationFeederInterface
     {
         $this->checkFormAvailability();
@@ -74,6 +77,9 @@ class SanitizerValidationFeeder implements SanitizerValidationFeederInterface
         return $this;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function addElementByUri(string $elementUri): SanitizerValidationFeederInterface
     {
         $this->checkFormAvailability();

--- a/helpers/form/Feeder/SanitizerValidationFeeder.php
+++ b/helpers/form/Feeder/SanitizerValidationFeeder.php
@@ -49,8 +49,6 @@ class SanitizerValidationFeeder implements SanitizerValidationFeederInterface
 
     public function setForm(tao_helpers_form_Form $form): SanitizerValidationFeederInterface
     {
-        $this->reset();
-
         $this->form = $form;
 
         return $this;
@@ -68,7 +66,7 @@ class SanitizerValidationFeeder implements SanitizerValidationFeederInterface
      */
     public function addElement(tao_helpers_form_FormElement $element): SanitizerValidationFeederInterface
     {
-        $this->checkFormAvailability();
+        $this->assertHasForm();
 
         if ($this->isElementValid($element) && $this->form->hasElement(tao_helpers_Uri::encode($element->getName()))) {
             $this->elements[] = $element;
@@ -82,7 +80,7 @@ class SanitizerValidationFeeder implements SanitizerValidationFeederInterface
      */
     public function addElementByUri(string $elementUri): SanitizerValidationFeederInterface
     {
-        $this->checkFormAvailability();
+        $this->assertHasForm();
 
         $element = $this->form->getElement(tao_helpers_Uri::encode($elementUri));
 
@@ -115,13 +113,7 @@ class SanitizerValidationFeeder implements SanitizerValidationFeederInterface
         return $element->getInputValue() ?? $element->getRawValue();
     }
 
-    private function reset(): void
-    {
-        $this->validators = [];
-        $this->elements = [];
-    }
-
-    private function checkFormAvailability(): void
+    private function assertHasForm(): void
     {
         if (!isset($this->form)) {
             throw new RuntimeException('Cannot add element because form is not set');

--- a/helpers/form/Feeder/SanitizerValidationFeeder.php
+++ b/helpers/form/Feeder/SanitizerValidationFeeder.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\helpers\form\Feeder;
+
+use tao_helpers_Uri;
+use tao_helpers_form_Form;
+use tao_helpers_form_Validator;
+use tao_helpers_form_FormElement;
+use tao_helpers_form_elements_Textbox;
+use tao_helpers_form_elements_Textarea;
+
+class SanitizerValidationFeeder implements SanitizerValidationFeederInterface
+{
+    public const USER_FORM_SERVICE_ID = self::class . '::USER_FORM';
+
+    private const ALLOWED_WIDGETS = [
+        tao_helpers_form_elements_Textbox::WIDGET_ID,
+        tao_helpers_form_elements_Textarea::WIDGET_ID,
+    ];
+
+    /** @var tao_helpers_form_Validator[] */
+    private $validators = [];
+
+    /** @var tao_helpers_form_FormElement[] */
+    private $elements = [];
+
+    public function addValidator(tao_helpers_form_Validator $validator): SanitizerValidationFeederInterface
+    {
+        $this->validators[] = $validator;
+
+        return $this;
+    }
+
+    public function addElement(tao_helpers_form_FormElement $element): SanitizerValidationFeederInterface
+    {
+        if (in_array($element->getWidget(), self::ALLOWED_WIDGETS, true)) {
+            $this->elements[] = $element;
+        }
+
+        return $this;
+    }
+
+    public function addFormElement(tao_helpers_form_Form $form, string $elementUri): SanitizerValidationFeederInterface
+    {
+        $element = $form->getElement(tao_helpers_Uri::encode($elementUri));
+
+        if ($element !== null) {
+            $this->addElement($element);
+        }
+
+        return $this;
+    }
+
+    public function feed(): void
+    {
+        if (empty($this->validators)) {
+            return;
+        }
+
+        foreach ($this->elements as $element) {
+            if ($this->getValue($element) === null) {
+                continue;
+            }
+
+            foreach ($this->validators as $validator) {
+                $element->addValidator($validator);
+            }
+        }
+
+
+    }
+
+    private function getValue(tao_helpers_form_FormElement $element): ?string
+    {
+        $element->feedInputValue();
+
+        return $element->getInputValue() ?? $element->getRawValue();
+    }
+}

--- a/helpers/form/Feeder/SanitizerValidationFeederInterface.php
+++ b/helpers/form/Feeder/SanitizerValidationFeederInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\helpers\form\Feeder;
+
+use tao_helpers_form_Form;
+use tao_helpers_form_FormElement;
+
+interface SanitizerValidationFeederInterface
+{
+    public function addElement(tao_helpers_form_FormElement $element): self;
+
+    public function addFormElement(tao_helpers_form_Form $form, string $elementUri): self;
+
+    public function feed(): void;
+}

--- a/helpers/form/Feeder/SanitizerValidationFeederInterface.php
+++ b/helpers/form/Feeder/SanitizerValidationFeederInterface.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\tao\helpers\form\Feeder;
 
+use RuntimeException;
 use tao_helpers_form_Form;
 use tao_helpers_form_Validator;
 use tao_helpers_form_FormElement;
@@ -32,8 +33,14 @@ interface SanitizerValidationFeederInterface
 
     public function setForm(tao_helpers_form_Form $form): self;
 
+    /**
+     * @throws RuntimeException
+     */
     public function addElement(tao_helpers_form_FormElement $element): self;
 
+    /**
+     * @throws RuntimeException
+     */
     public function addElementByUri(string $elementUri): self;
 
     public function feed(): void;

--- a/helpers/form/ServiceProvider/FormServiceProvider.php
+++ b/helpers/form/ServiceProvider/FormServiceProvider.php
@@ -84,8 +84,8 @@ class FormServiceProvider implements ContainerServiceProviderInterface
                 [
                     [
                         'isPreValidationRequired' => true,
-                        'format' => '/^[^<>;]+$/',
-                        'message' => 'Field must not contain the following characters: <, >, ;',
+                        'format' => '/^[^<>\\/;]+$/',
+                        'message' => 'Field must not contain the following characters: <, >, \, /, ;',
                     ]
                 ]
             );

--- a/helpers/form/ServiceProvider/FormServiceProvider.php
+++ b/helpers/form/ServiceProvider/FormServiceProvider.php
@@ -84,8 +84,8 @@ class FormServiceProvider implements ContainerServiceProviderInterface
                 [
                     [
                         'isPreValidationRequired' => true,
-                        'format' => '/^[^"\'<>\\/]+$/',
-                        'message' => 'Field must not contain the following characters: ", \', \, /, <, >',
+                        'format' => '/^[^<>;]+$/',
+                        'message' => 'Field must not contain the following characters: <, >, ;',
                     ]
                 ]
             );

--- a/helpers/form/ServiceProvider/FormServiceProvider.php
+++ b/helpers/form/ServiceProvider/FormServiceProvider.php
@@ -92,6 +92,7 @@ class FormServiceProvider implements ContainerServiceProviderInterface
 
         $services
             ->set(SanitizerValidationFeeder::class, SanitizerValidationFeeder::class)
-            ->public();
+            ->public()
+            ->share(false);
     }
 }

--- a/helpers/form/ServiceProvider/FormServiceProvider.php
+++ b/helpers/form/ServiceProvider/FormServiceProvider.php
@@ -85,7 +85,7 @@ class FormServiceProvider implements ContainerServiceProviderInterface
                     [
                         'isPreValidationRequired' => true,
                         'format' => '/^[^<>\\\\\/;]+$/',
-                        'message' => 'Field must not contain the following characters: <, >, \, /, ;',
+                        'message' => 'This field must not include the following characters: < > \ / ;',
                     ]
                 ]
             );

--- a/helpers/form/ServiceProvider/FormServiceProvider.php
+++ b/helpers/form/ServiceProvider/FormServiceProvider.php
@@ -84,7 +84,7 @@ class FormServiceProvider implements ContainerServiceProviderInterface
                 [
                     [
                         'isPreValidationRequired' => true,
-                        'format' => '/^[^<>\\/;]+$/',
+                        'format' => '/^[^<>\\\\\/;]+$/',
                         'message' => 'Field must not contain the following characters: <, >, \, /, ;',
                     ]
                 ]

--- a/helpers/form/ServiceProvider/FormServiceProvider.php
+++ b/helpers/form/ServiceProvider/FormServiceProvider.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace oat\tao\helpers\form\ServiceProvider;
 
+use tao_helpers_form_validators_Regex;
+use oat\tao\helpers\form\Feeder\SanitizerValidationFeeder;
 use oat\tao\helpers\form\Factory\ElementPropertyEmptyListValuesFactory;
 use oat\tao\helpers\form\Factory\ElementPropertyListValuesFactory;
 use oat\tao\helpers\form\Factory\ElementPropertyTypeFactory;
@@ -73,7 +75,29 @@ class FormServiceProvider implements ContainerServiceProviderInterface
                 ]
             );
 
+        $services->set(DependencyPropertyWidgetSpecification::class, DependencyPropertyWidgetSpecification::class);
+
         $services
-            ->set(DependencyPropertyWidgetSpecification::class, DependencyPropertyWidgetSpecification::class);
+            ->set(tao_helpers_form_validators_Regex::USER_FORM_SERVICE_ID, tao_helpers_form_validators_Regex::class)
+            ->public()
+            ->args(
+                [
+                    [
+                        'isPreValidationRequired' => true,
+                        'format' => '/^[^"\'<>\\/]+$/',
+                        'message' => 'Field must not contain the following characters: ", \', \, /, <, >',
+                    ]
+                ]
+            );
+
+        $services
+            ->set(SanitizerValidationFeeder::USER_FORM_SERVICE_ID, SanitizerValidationFeeder::class)
+            ->public()
+            ->call(
+                'addValidator',
+                [
+                    service(tao_helpers_form_validators_Regex::USER_FORM_SERVICE_ID),
+                ]
+            );
     }
 }

--- a/helpers/form/class.FormContainer.php
+++ b/helpers/form/class.FormContainer.php
@@ -163,6 +163,34 @@ abstract class tao_helpers_form_FormContainer
         return $this->form;
     }
 
+    public function addSanitizerValidator(tao_helpers_form_Validator $validator, array $elements): self
+    {
+        $this->getSanitizerValidationFeeder()->addValidator($validator);
+
+        foreach ($elements as $element) {
+            if ($element instanceof tao_helpers_form_FormElement) {
+                $this->getSanitizerValidationFeeder()->addElement($element);
+
+                continue;
+            }
+
+            if (is_string($element)) {
+                $this->getSanitizerValidationFeeder()->addElementByUri($element);
+
+                continue;
+            }
+
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Element provided to sanitizer must be an instance of %s or a string',
+                    tao_helpers_form_FormElement::class
+                )
+            );
+        }
+
+        return $this;
+    }
+
     /**
      * Must be overridden and must instantiate the form instance and put it in
      * form attribute
@@ -277,7 +305,7 @@ abstract class tao_helpers_form_FormContainer
         }
     }
 
-    protected function getSanitizerValidationFeeder(): SanitizerValidationFeederInterface
+    private function getSanitizerValidationFeeder(): SanitizerValidationFeederInterface
     {
         if (!isset($this->sanitizerValidationFeeder)) {
             $this->sanitizerValidationFeeder = ServiceManager::getServiceManager()->getContainer()->get(

--- a/helpers/form/validators/class.Regex.php
+++ b/helpers/form/validators/class.Regex.php
@@ -29,6 +29,8 @@ use oat\tao\helpers\form\validators\PreliminaryValidationInterface;
  */
 class tao_helpers_form_validators_Regex extends tao_helpers_form_Validator implements PreliminaryValidationInterface
 {
+    public const USER_FORM_SERVICE_ID = self::class . '::USER_FORM';
+
     public function isPreValidationRequired(): bool
     {
         return $this->getOption('isPreValidationRequired', false);

--- a/helpers/form/validators/class.Regex.php
+++ b/helpers/form/validators/class.Regex.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -16,19 +17,22 @@
  *
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- *
+ *               2022 (original work) Open Assessment Technologies SA.
  */
+
+declare(strict_types=1);
+
+use oat\tao\helpers\form\validators\PreliminaryValidationInterface;
 
 /**
- * Short description of class tao_helpers_form_validators_Regex
- *
- * @access public
  * @author Joel Bout, <joel.bout@tudor.lu>
- * @package tao
-
  */
-class tao_helpers_form_validators_Regex extends tao_helpers_form_Validator
+class tao_helpers_form_validators_Regex extends tao_helpers_form_Validator implements PreliminaryValidationInterface
 {
+    public function isPreValidationRequired(): bool
+    {
+        return $this->getOption('isPreValidationRequired', false);
+    }
 
     public function setOptions(array $options)
     {
@@ -37,7 +41,7 @@ class tao_helpers_form_validators_Regex extends tao_helpers_form_Validator
         if (!$this->hasOption('format')) {
             throw new common_Exception("Please set the format options (define your regular expression)!");
         }
-        
+
         if ($this->hasOption('message')) {
             $this->setMessage($this->getOption('message'));
         }

--- a/models/classes/class.UserService.php
+++ b/models/classes/class.UserService.php
@@ -25,6 +25,7 @@ use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyRdfs;
 use oat\oatbox\user\LoginService;
 use oat\oatbox\user\User;
+use oat\generis\model\user\UserRdf;
 use oat\tao\model\event\UserCreatedEvent;
 use oat\tao\model\event\UserRemovedEvent;
 use oat\tao\model\TaoOntology;
@@ -276,7 +277,7 @@ class tao_models_classes_UserService extends ConfigurableService implements core
      * @param array $options
      * @param array $filters
      *
-     * @return array
+     * @return core_kernel_classes_Resource[]
      * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
      */
     public function getAllUsers($options = [], $filters = [GenerisRdf::PROPERTY_USER_LOGIN => '*'])
@@ -305,24 +306,24 @@ class tao_models_classes_UserService extends ConfigurableService implements core
     }
 
     /**
-     * Short description of method toTree
+     * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
      *
-     * @param TypeClass $clazz
-     * @param array     $options
+     * @throws core_kernel_persistence_Exception
      *
      * @return array
-     * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
      */
     public function toTree(TypeClass $clazz, array $options = [])
     {
         $returnValue = [];
-        $users = $this->getAllUsers(['order' => GenerisRdf::PROPERTY_USER_LOGIN]);
+        $users = $this->getAllUsers(['order' => UserRdf::PROPERTY_LOGIN]);
+
         foreach ($users as $user) {
-            $login = (string)$user->getOnePropertyValue(
-                new core_kernel_classes_Property(GenerisRdf::PROPERTY_USER_LOGIN)
-            );
+            $login = (string) $user->getOnePropertyValue($user->getProperty(UserRdf::PROPERTY_LOGIN));
+            $login = tao_helpers_Display::htmlEscape($login);
+            $login = tao_helpers_Display::textCutter($login, 16);
+
             $returnValue[] = [
-                'data' => tao_helpers_Display::textCutter($login, 16),
+                'data' => $login,
                 'attributes' => [
                     'id' => tao_helpers_Uri::encode($user->getUri()),
                     'class' => 'node-instance',

--- a/test/unit/helpers/form/Feeder/SanitizerValidationFeederTest.php
+++ b/test/unit/helpers/form/Feeder/SanitizerValidationFeederTest.php
@@ -1,0 +1,348 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\helpers\form\Feeder;
+
+use RuntimeException;
+use tao_helpers_form_Form;
+use oat\generis\test\TestCase;
+use tao_helpers_form_Validator;
+use tao_helpers_form_FormElement;
+use tao_helpers_form_elements_Textbox;
+use tao_helpers_form_elements_Textarea;
+use PHPUnit\Framework\MockObject\MockObject;
+use oat\tao\helpers\form\Feeder\SanitizerValidationFeeder;
+
+class SanitizerValidationFeederTest extends TestCase
+{
+    /** @var SanitizerValidationFeeder */
+    private $sut;
+
+    /** @var MockObject|tao_helpers_form_FormElement */
+    private $element1;
+
+    /** @var MockObject|tao_helpers_form_FormElement */
+    private $element2;
+
+    /** @var MockObject|tao_helpers_form_Validator */
+    private $validator;
+
+    /** @var MockObject|tao_helpers_form_Form */
+    private $form;
+
+    protected function setUp(): void
+    {
+        $this->element1 = $this->createMock(tao_helpers_form_FormElement::class);
+        $this->element2 = $this->createMock(tao_helpers_form_FormElement::class);
+        $this->validator = $this->createMock(tao_helpers_form_Validator::class);
+        $this->form = $this->createMock(tao_helpers_form_Form::class);
+
+        $this->sut = new SanitizerValidationFeeder();
+    }
+
+    public function testFeed(): void
+    {
+        $this->element1
+            ->expects($this->once())
+            ->method('getWidget')
+            ->willReturn(tao_helpers_form_elements_Textbox::WIDGET_ID);
+        $this->element1
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('element1Name');
+        $this->element1
+            ->expects($this->once())
+            ->method('getInputValue')
+            ->willReturn('element1InputValue');
+        $this->element1
+            ->expects($this->never())
+            ->method('getRawValue');
+        $this->element1
+            ->expects($this->once())
+            ->method('addValidator')
+            ->with($this->validator);
+
+        $this->element2
+            ->expects($this->once())
+            ->method('getWidget')
+            ->willReturn(tao_helpers_form_elements_Textarea::WIDGET_ID);
+        $this->element2
+            ->expects($this->once())
+            ->method('getInputValue')
+            ->willReturn(null);
+        $this->element2
+            ->expects($this->once())
+            ->method('getRawValue')
+            ->willReturn('element2RawValue');
+        $this->element2
+            ->expects($this->once())
+            ->method('addValidator')
+            ->with($this->validator);
+
+        $this->form
+            ->expects($this->once())
+            ->method('hasElement')
+            ->with('element1Name')
+            ->willReturn(true);
+        $this->form
+            ->expects($this->once())
+            ->method('getElement')
+            ->with('element2Name')
+            ->willReturn($this->element2);
+
+        $this->sut
+            ->setForm($this->form)
+            ->addValidator($this->validator)
+            ->addElement($this->element1)
+            ->addElementByUri('element2Name')
+            ->feed();
+    }
+
+    public function testAddElementWithoutForm(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->sut->addElement($this->element1);
+    }
+
+    public function testAddElementByUriWithoutForm(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->sut->addElementByUri('element1Name');
+    }
+
+    public function testFeedWithoutValidator(): void
+    {
+        $this->element1
+            ->expects($this->once())
+            ->method('getWidget')
+            ->willReturn(tao_helpers_form_elements_Textbox::WIDGET_ID);
+        $this->element1
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('element1Name');
+        $this->element1
+            ->expects($this->never())
+            ->method('getInputValue');
+        $this->element1
+            ->expects($this->never())
+            ->method('getRawValue');
+        $this->element1
+            ->expects($this->never())
+            ->method('addValidator');
+
+        $this->element2
+            ->expects($this->once())
+            ->method('getWidget')
+            ->willReturn(tao_helpers_form_elements_Textarea::WIDGET_ID);
+        $this->element2
+            ->expects($this->never())
+            ->method('getInputValue');
+        $this->element2
+            ->expects($this->never())
+            ->method('getRawValue');
+        $this->element2
+            ->expects($this->never())
+            ->method('addValidator');
+
+        $this->form
+            ->expects($this->once())
+            ->method('hasElement')
+            ->with('element1Name')
+            ->willReturn(true);
+        $this->form
+            ->expects($this->once())
+            ->method('getElement')
+            ->with('element2Name')
+            ->willReturn($this->element2);
+
+        $this->sut
+            ->setForm($this->form)
+            ->addElement($this->element1)
+            ->addElementByUri('element2Name')
+            ->feed();
+    }
+
+    public function testFeedWithInvalidWidget(): void
+    {
+        $this->element1
+            ->expects($this->once())
+            ->method('getWidget')
+            ->willReturn('invalidWidget1');
+        $this->element1
+            ->expects($this->never())
+            ->method('getName');
+        $this->element1
+            ->expects($this->never())
+            ->method('getInputValue');
+        $this->element1
+            ->expects($this->never())
+            ->method('getRawValue');
+        $this->element1
+            ->expects($this->never())
+            ->method('addValidator');
+
+        $this->element2
+            ->expects($this->once())
+            ->method('getWidget')
+            ->willReturn('invalidWidget2');
+        $this->element2
+            ->expects($this->never())
+            ->method('getInputValue');
+        $this->element2
+            ->expects($this->never())
+            ->method('getRawValue');
+        $this->element2
+            ->expects($this->never())
+            ->method('addValidator');
+
+        $this->form
+            ->expects($this->never())
+            ->method('hasElement');
+        $this->form
+            ->expects($this->once())
+            ->method('getElement')
+            ->with('element2Name')
+            ->willReturn($this->element2);
+
+        $this->sut
+            ->setForm($this->form)
+            ->addValidator($this->validator)
+            ->addElement($this->element1)
+            ->addElementByUri('element2Name')
+            ->feed();
+    }
+
+    public function testFeedWithNullOrEmptyValue(): void
+    {
+        $this->element1
+            ->expects($this->once())
+            ->method('getWidget')
+            ->willReturn(tao_helpers_form_elements_Textbox::WIDGET_ID);
+        $this->element1
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('element1Name');
+        $this->element1
+            ->expects($this->once())
+            ->method('getInputValue')
+            ->willReturn('');
+        $this->element1
+            ->expects($this->never())
+            ->method('getRawValue');
+        $this->element1
+            ->expects($this->never())
+            ->method('addValidator');
+
+        $this->element2
+            ->expects($this->once())
+            ->method('getWidget')
+            ->willReturn(tao_helpers_form_elements_Textarea::WIDGET_ID);
+        $this->element2
+            ->expects($this->once())
+            ->method('getInputValue')
+            ->willReturn(null);
+        $this->element2
+            ->expects($this->once())
+            ->method('getRawValue')
+            ->willReturn(null);
+        $this->element2
+            ->expects($this->never())
+            ->method('addValidator');
+
+        $this->form
+            ->expects($this->once())
+            ->method('hasElement')
+            ->with('element1Name')
+            ->willReturn(true);
+        $this->form
+            ->expects($this->once())
+            ->method('getElement')
+            ->with('element2Name')
+            ->willReturn($this->element2);
+
+        $this->sut
+            ->setForm($this->form)
+            ->addValidator($this->validator)
+            ->addElement($this->element1)
+            ->addElementByUri('element2Name')
+            ->feed();
+    }
+
+    public function testFeedWithInvalidElements(): void
+    {
+        $this->element1
+            ->expects($this->once())
+            ->method('getWidget')
+            ->willReturn(tao_helpers_form_elements_Textbox::WIDGET_ID);
+        $this->element1
+            ->expects($this->once())
+            ->method('getName')
+            ->willReturn('invalidElement1Name');
+        $this->element1
+            ->expects($this->never())
+            ->method('getInputValue');
+        $this->element1
+            ->expects($this->never())
+            ->method('getRawValue');
+        $this->element1
+            ->expects($this->never())
+            ->method('addValidator');
+
+        $this->element2
+            ->expects($this->never())
+            ->method('getName')
+            ->willReturn('element2Name');
+        $this->element2
+            ->expects($this->never())
+            ->method('getWidget');
+        $this->element2
+            ->expects($this->never())
+            ->method('getInputValue');
+        $this->element2
+            ->expects($this->never())
+            ->method('getRawValue');
+        $this->element2
+            ->expects($this->never())
+            ->method('addValidator');
+
+        $this->form
+            ->expects($this->once())
+            ->method('hasElement')
+            ->with('invalidElement1Name')
+            ->willReturn(false);
+
+        $this->form
+            ->expects($this->once())
+            ->method('getElement')
+            ->with('invalidElement2Name')
+            ->willReturn(null);
+
+        $this->sut
+            ->setForm($this->form)
+            ->addValidator($this->validator)
+            ->addElement($this->element1)
+            ->addElementByUri('invalidElement2Name')
+            ->feed();
+    }
+}


### PR DESCRIPTION
# [ADF-940](https://oat-sa.atlassian.net/browse/ADF-940)

## Companion PRs
* https://github.com/oat-sa/extension-tao-delivery/pull/540

## Changes
* Added regex validator for login field. The following characters no longer allowed: `"`, `'`, `\`, `/`, `>`, `<`
* Regex validator for login field is configured to be called during form initialization (preliminary validation) and after form submit
* Added possibility to fix existing logins, which contains invalid characters