### PR TITLE
fix: disable resource icon on taskQueue in case it is a metadata import

### DIFF
--- a/actions/class.Import.php
+++ b/actions/class.Import.php
@@ -78,7 +78,7 @@ class tao_actions_Import extends tao_actions_CommonModule
             $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcher::SERVICE_ID);
 
             $task = $queueDispatcher->createTask(
-                new ImportByHandler(),
+                $this->getImportByHandler(),
                 $this->createTaskData($importer, $importForm),
                 __('Import a %s into "%s"', $importer->getLabel(), $this->getCurrentClass()->getLabel())
             );
@@ -141,6 +141,11 @@ class tao_actions_Import extends tao_actions_CommonModule
         }
 
         return $this->availableHandlers;
+    }
+
+    protected function getImportByHandler(): ImportByHandler
+    {
+        return new ImportByHandler();
     }
 
     /**

--- a/actions/class.MetadataImport.php
+++ b/actions/class.MetadataImport.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 use oat\tao\model\TaoOntology;
 use oat\tao\model\import\Form\MetadataImportForm;
 use oat\tao\model\import\service\AgnosticImportHandler;
+use oat\tao\model\task\ImportByHandler;
+use oat\tao\model\task\UnrelatedResourceImportByHandler;
 
 class tao_actions_MetadataImport extends tao_actions_Import
 {
@@ -48,6 +50,11 @@ class tao_actions_MetadataImport extends tao_actions_Import
         return [
             AgnosticImportHandler::class => AgnosticImportHandler::STATISTICAL_METADATA_SERVICE_ID,
         ];
+    }
+
+    protected function getImportByHandler(): ImportByHandler
+    {
+        return new UnrelatedResourceImportByHandler();
     }
 
     protected function getCurrentClass(): core_kernel_classes_Class

--- a/migrations/Version202202171146482234_tao.php
+++ b/migrations/Version202202171146482234_tao.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\task\UnrelatedResourceImportByHandler;
+use oat\tao\model\taskQueue\TaskLogInterface;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+final class Version202202171146482234_tao extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Associate TaskQueue category for unrelated resources';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var TaskLogInterface|ConfigurableService $taskLog */
+        $taskLog = $this->getServiceManager()->get(TaskLogInterface::SERVICE_ID);
+
+        $taskLog->linkTaskToCategory(
+            UnrelatedResourceImportByHandler::class,
+            TaskLogInterface::CATEGORY_UNRELATED_RESOURCE
+        );
+
+        $this->registerService(TaskLogInterface::SERVICE_ID, $taskLog);
+    }
+
+    public function down(Schema $schema): void
+    {
+        /** @var TaskLogInterface|ConfigurableService $taskLog */
+        $taskLog = $this->getServiceManager()->get(TaskLogInterface::SERVICE_ID);
+
+        $associations = $taskLog->getOption(TaskLogInterface::OPTION_TASK_TO_CATEGORY_ASSOCIATIONS, []);
+
+        unset($associations[UnrelatedResourceImportByHandler::class]);
+
+        $taskLog->setOption(TaskLogInterface::OPTION_TASK_TO_CATEGORY_ASSOCIATIONS, $associations);
+
+        $this->registerService(TaskLogInterface::SERVICE_ID, $taskLog);
+    }
+}

--- a/models/classes/task/UnrelatedResourceImportByHandler.php
+++ b/models/classes/task/UnrelatedResourceImportByHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+namespace oat\tao\model\task;
+
+class UnrelatedResourceImportByHandler extends ImportByHandler
+{
+}

--- a/models/classes/taskQueue/TaskLog.php
+++ b/models/classes/taskQueue/TaskLog.php
@@ -460,6 +460,7 @@ class TaskLog extends ConfigurableService implements TaskLogInterface
             self::CATEGORY_IMPORT,
             self::CATEGORY_EXPORT,
             self::CATEGORY_DELIVERY_COMPILATION,
+            self::CATEGORY_UNRELATED_RESOURCE,
         ];
     }
 

--- a/models/classes/taskQueue/TaskLog/Decorator/RedirectUrlEntityDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/RedirectUrlEntityDecorator.php
@@ -76,7 +76,8 @@ class RedirectUrlEntityDecorator extends TaskLogEntityDecorator
         $deniedCategories = [
             TaskLogInterface::CATEGORY_DELETE,
             TaskLogInterface::CATEGORY_EXPORT,
-            TaskLogInterface::CATEGORY_UNKNOWN
+            TaskLogInterface::CATEGORY_UNKNOWN,
+            TaskLogInterface::CATEGORY_UNRELATED_RESOURCE,
         ];
 
         if (

--- a/models/classes/taskQueue/TaskLogInterface.php
+++ b/models/classes/taskQueue/TaskLogInterface.php
@@ -37,9 +37,9 @@ use Psr\Log\LoggerAwareInterface;
  */
 interface TaskLogInterface extends LoggerAwareInterface
 {
-    const SERVICE_ID = 'tao/taskLog';
+    public const SERVICE_ID = 'tao/taskLog';
 
-    const OPTION_TASK_LOG_BROKER = 'task_log_broker';
+    public const OPTION_TASK_LOG_BROKER = 'task_log_broker';
 
     /**
      * An array of tasks names with the specified category.
@@ -48,30 +48,31 @@ interface TaskLogInterface extends LoggerAwareInterface
 
     public const OPTION_TASK_IGNORE_LIST = 'task_ui_ignore_list';
 
-    const STATUS_ENQUEUED = 'enqueued';
-    const STATUS_DEQUEUED = 'dequeued';
-    const STATUS_RUNNING = 'running';
-    const STATUS_CHILD_RUNNING = 'child_running';
-    const STATUS_COMPLETED = 'completed';
-    const STATUS_FAILED = 'failed';
-    const STATUS_ARCHIVED = 'archived';
-    const STATUS_CANCELLED = 'cancelled';
-    const STATUS_UNKNOWN = 'unknown';
+    public const STATUS_ENQUEUED = 'enqueued';
+    public const STATUS_DEQUEUED = 'dequeued';
+    public const STATUS_RUNNING = 'running';
+    public const STATUS_CHILD_RUNNING = 'child_running';
+    public const STATUS_COMPLETED = 'completed';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_ARCHIVED = 'archived';
+    public const STATUS_CANCELLED = 'cancelled';
+    public const STATUS_UNKNOWN = 'unknown';
 
-    const CATEGORY_UNKNOWN = 'unknown';
-    const CATEGORY_IMPORT = 'import';
-    const CATEGORY_EXPORT = 'export';
-    const CATEGORY_DELIVERY_COMPILATION = 'delivery_comp';
-    const CATEGORY_CREATE = 'create';
-    const CATEGORY_UPDATE = 'update';
-    const CATEGORY_DELETE = 'delete';
+    public const CATEGORY_UNKNOWN = 'unknown';
+    public const CATEGORY_IMPORT = 'import';
+    public const CATEGORY_EXPORT = 'export';
+    public const CATEGORY_DELIVERY_COMPILATION = 'delivery_comp';
+    public const CATEGORY_CREATE = 'create';
+    public const CATEGORY_UPDATE = 'update';
+    public const CATEGORY_DELETE = 'delete';
+    public const CATEGORY_UNRELATED_RESOURCE = 'unrelated_resource';
 
-    const DEFAULT_LIMIT = 20;
+    public const DEFAULT_LIMIT = 20;
 
     /**
      * It's not related to the user management, just a placeholder to distinguish the user running the script from CLI.
      */
-    const SUPER_USER = 'cli-user';
+    public const SUPER_USER = 'cli-user';
 
     /**
      * @return void

--- a/scripts/install/SetUpQueueTasks.php
+++ b/scripts/install/SetUpQueueTasks.php
@@ -32,6 +32,7 @@ use oat\tao\model\search\tasks\UpdateDataAccessControlInIndex;
 use oat\tao\model\search\tasks\UpdateResourceInIndex;
 use oat\tao\model\task\ExportByHandler;
 use oat\tao\model\task\ImportByHandler;
+use oat\tao\model\task\UnrelatedResourceImportByHandler;
 use oat\tao\model\taskQueue\TaskLogInterface;
 
 /**
@@ -46,6 +47,10 @@ class SetUpQueueTasks extends InstallAction
 
         $taskLogService->linkTaskToCategory(ImportByHandler::class, TaskLogInterface::CATEGORY_IMPORT);
         $taskLogService->linkTaskToCategory(ExportByHandler::class, TaskLogInterface::CATEGORY_EXPORT);
+        $taskLogService->linkTaskToCategory(
+            UnrelatedResourceImportByHandler::class,
+            TaskLogInterface::CATEGORY_UNRELATED_RESOURCE
+        );
         $taskLogService->setOption(TaskLogInterface::OPTION_TASK_IGNORE_LIST, [
             UpdateResourceInIndex::class,
             UpdateClassInIndex::class,


### PR DESCRIPTION
Task https://oat-sa.atlassian.net/browse/ADF-945

The idea is to disable resource link in the task queue for certain types of import handler

Pending: 

- [ ] Unit tests