### PR TITLE
fix: TAO Version  to '2022.02'

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -247,9 +247,9 @@ return [
     ],
     'constants' => [
         #TAO version number
-        'TAO_VERSION' => '2022.01',
+        'TAO_VERSION' => '2022.02',
         #TAO version label
-        'TAO_VERSION_NAME' => '2022.01',
+        'TAO_VERSION_NAME' => '2022.02',
         #the name to display
         'PRODUCT_NAME' => 'TAO',
         #TAO release status, use to add specific footer to TAO, available alpha, beta, demo, stable


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1882

TAO Version was updated to 2022.02 