### PR TITLE
Fix/TR-3634/Switch from hash keys to simple keys, use ttl for tokens

### DIFF
--- a/helpers/form/class.FormContainer.php
+++ b/helpers/form/class.FormContainer.php
@@ -17,7 +17,7 @@
  *
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- *               2020-2021 (original work) Open Assessment Technologies SA
+ *               2020-2022 (original work) Open Assessment Technologies SA.
  */
 
 declare(strict_types=1);
@@ -44,6 +44,8 @@ abstract class tao_helpers_form_FormContainer
     public const IS_DISABLED = 'is_disabled';
     public const ADDITIONAL_VALIDATORS = 'extraValidators';
     public const ATTRIBUTE_VALIDATORS = 'attributeValidators';
+
+    public const WITH_SERVICE_MANAGER = 'withServiceManager';
 
     /**
      * the form instance contained
@@ -81,6 +83,9 @@ abstract class tao_helpers_form_FormContainer
     /** @var SanitizerValidationFeederInterface */
     private $sanitizerValidationFeeder;
 
+    /** @var ServiceManager */
+    private $serviceManager;
+
     /**
      * The constructor, initialize and build the form
      * regarding the initForm and initElements methods
@@ -91,6 +96,8 @@ abstract class tao_helpers_form_FormContainer
      */
     public function __construct(array $data = [], array $options = [])
     {
+        $this->withServiceManager($options);
+
         $this->data = $data;
         $this->options = $options;
 
@@ -308,11 +315,22 @@ abstract class tao_helpers_form_FormContainer
     private function getSanitizerValidationFeeder(): SanitizerValidationFeederInterface
     {
         if (!isset($this->sanitizerValidationFeeder)) {
-            $this->sanitizerValidationFeeder = ServiceManager::getServiceManager()->getContainer()->get(
-                SanitizerValidationFeeder::class
-            );
+            $serviceManager = $this->serviceManager ?? ServiceManager::getServiceManager();
+            $this->sanitizerValidationFeeder = $serviceManager->getContainer()->get(SanitizerValidationFeeder::class);
         }
 
         return $this->sanitizerValidationFeeder;
+    }
+
+    private function withServiceManager(array &$options): void
+    {
+        if (
+            isset($options[self::WITH_SERVICE_MANAGER])
+            && $options[self::WITH_SERVICE_MANAGER] instanceof ServiceManager
+        ) {
+            $this->serviceManager = $options[self::WITH_SERVICE_MANAGER];
+        }
+
+        unset($options[self::WITH_SERVICE_MANAGER]);
     }
 }

--- a/models/classes/security/xsrf/TokenStore.php
+++ b/models/classes/security/xsrf/TokenStore.php
@@ -27,6 +27,8 @@ namespace oat\tao\model\security\xsrf;
  */
 interface TokenStore
 {
+    public const TOKEN_NAME = 'XSRF_TOKEN_NAME';
+
     public function getToken(string $tokenId): ?Token;
 
     public function setToken(string $tokenId, Token $token): void;

--- a/models/classes/security/xsrf/TokenStore.php
+++ b/models/classes/security/xsrf/TokenStore.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2017-2022 (original work) Open Assessment Technologies SA.
  */
 
 namespace oat\tao\model\security\xsrf;
@@ -27,35 +27,14 @@ namespace oat\tao\model\security\xsrf;
  */
 interface TokenStore
 {
-    const TOKEN_NAME = 'XSRF_TOKEN_NAME';
-
-    /**
-     * @param string $tokenId
-     * @return Token|null
-     */
     public function getToken(string $tokenId): ?Token;
 
-    /**
-     * @param string $tokenId
-     * @param Token $token
-     */
     public function setToken(string $tokenId, Token $token): void;
 
-    /**
-     * @param string $tokenId
-     * @return bool
-     */
     public function hasToken(string $tokenId): bool;
 
-    /**
-     * @param string $tokenId
-     * @return bool
-     */
     public function removeToken(string $tokenId): bool;
 
-    /**
-     * @return void;
-     */
     public function clear(): void;
 
     /**

--- a/models/classes/security/xsrf/TokenStoreKeyValue.php
+++ b/models/classes/security/xsrf/TokenStoreKeyValue.php
@@ -144,7 +144,9 @@ class TokenStoreKeyValue extends ConfigurableService implements TokenStore
 
     private function getKeys(): array
     {
-        return $this->getPersistence()->keys($this->getKeyPrefix() . '*');
+        $keys = $this->getPersistence()->keys($this->getKeyPrefix() . '*');
+
+        return is_array($keys) ? $keys : [];
     }
 
     private function buildKey(string $name): string

--- a/models/classes/security/xsrf/TokenStoreKeyValue.php
+++ b/models/classes/security/xsrf/TokenStoreKeyValue.php
@@ -40,7 +40,7 @@ class TokenStoreKeyValue extends ConfigurableService implements TokenStore
     public const OPTION_PERSISTENCE = 'persistence';
     public const OPTION_TTL = 'ttl';
 
-    private const TOKENS_STORAGE_KEY = 'tao_tokens';
+    public const TOKENS_STORAGE_KEY = 'tao_tokens';
 
     /** @var common_persistence_KeyValuePersistence */
     private $persistence;
@@ -104,25 +104,10 @@ class TokenStoreKeyValue extends ConfigurableService implements TokenStore
         return $tokens;
     }
 
-    private function getKeys(): array
-    {
-        return $this->getPersistence()->keys($this->getKeyPrefix() . '*');
-    }
-
-    private function buildKey(string $name): string
-    {
-        return sprintf('%s_%s', $this->getKeyPrefix(), $name);
-    }
-
-    private function getTtl(): ?int
-    {
-        return ((int) $this->getOption(self::OPTION_TTL)) ?: null;
-    }
-
     /**
      * @throws common_exception_Error
      */
-    private function getPersistence(): common_persistence_AdvKeyValuePersistence
+    protected function getPersistence(): common_persistence_AdvKeyValuePersistence
     {
         if (!isset($this->persistence)) {
             $persistence = $this->getPersistenceManager()->getPersistenceById(
@@ -144,7 +129,7 @@ class TokenStoreKeyValue extends ConfigurableService implements TokenStore
     /**
      * @throws common_exception_Error
      */
-    private function getKeyPrefix(): string
+    protected function getKeyPrefix(): string
     {
         if (!isset($this->keyPrefix)) {
             $this->keyPrefix = sprintf(
@@ -155,6 +140,21 @@ class TokenStoreKeyValue extends ConfigurableService implements TokenStore
         }
 
         return $this->keyPrefix;
+    }
+
+    private function getKeys(): array
+    {
+        return $this->getPersistence()->keys($this->getKeyPrefix() . '*');
+    }
+
+    private function buildKey(string $name): string
+    {
+        return sprintf('%s_%s', $this->getKeyPrefix(), $name);
+    }
+
+    private function getTtl(): ?int
+    {
+        return ((int) $this->getOption(self::OPTION_TTL)) ?: null;
     }
 
     private function getPersistenceManager(): PersistenceManager

--- a/test/unit/import/Form/MetadataImportFormTest.php
+++ b/test/unit/import/Form/MetadataImportFormTest.php
@@ -26,6 +26,8 @@ use oat\tao\model\import\Form\MetadataImportForm;
 use oat\generis\test\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use tao_helpers_form_FormElement;
+use oat\tao\helpers\form\Feeder\SanitizerValidationFeeder;
+use oat\tao\helpers\form\Feeder\SanitizerValidationFeederInterface;
 
 class MetadataImportFormTest extends TestCase
 {
@@ -61,7 +63,15 @@ class MetadataImportFormTest extends TestCase
 
         $this->subject = new MetadataImportForm(
             [],
-            [],
+            [
+                MetadataImportForm::WITH_SERVICE_MANAGER => $this->getServiceLocatorMock(
+                    [
+                        SanitizerValidationFeeder::class => $this->createMock(
+                            SanitizerValidationFeederInterface::class
+                        ),
+                    ]
+                ),
+            ],
             $this->fileUploadElement,
             $this->hiddenImportElement,
             $this->submitElement


### PR DESCRIPTION
# [TR-3634](https://oat-sa.atlassian.net/browse/TR-3634)

## Companion PRs
* https://github.com/oat-sa/extension-tao-bosa-selor/pull/117

## Changes
* Removed unused `TOKEN_NAME` constant
* Added/changed constants' visibility:
  * `const OPTION_PERSISTENCE` ===> `public const OPTION_PERSISTENCE`
  * `const TOKENS_STORAGE_KEY` ===> `private const TOKENS_STORAGE_KEY`
* Changed visibility for methods:
  * `protected function getPersistence()` ===> `private function getPersistence()`
  * `protected function getKey()` ===> `private function getKey()`
* Changed all hash function calls to simple key functions
* Added new option `ttl` to configure TTL value