### PR TITLE
AUT-1785 fix: exclude more type from permissions check

### DIFF
--- a/views/js/layout/tree/provider/jstree.js
+++ b/views/js/layout/tree/provider/jstree.js
@@ -40,6 +40,9 @@ define([
     'use strict';
 
     var pageRange = 30;
+    var nodeTypes = {
+        more: 'more'
+    };
 
     return {
 
@@ -73,7 +76,7 @@ define([
 
             var moreNode = {
                 data : __('More'),
-                type : 'more',
+                type : nodeTypes.more,
                 attributes : {
                     class : 'more'
                 }
@@ -648,7 +651,7 @@ define([
                     _.forEach(node, computeSelectionAccess);
                     return;
                 }
-                if(node.type){
+                if(node.type && node.type !== nodeTypes.more){
                     addClassToNode(node, getPermissionClass(node));
                     if (!hasAccessTo('moveInstance', node)) {
                         addClassToNode(node, 'node-undraggable');


### PR DESCRIPTION
Related to: [AUT-1785](https://oat-sa.atlassian.net/browse/AUT-1785)

**Description:**
Remove the lock icon next to load more links in the resource tree.

**Changes:**
Exclude node type "more" from  addClassToNode logic that is decorating based on permission styles

**How to check:**
- Go to booklets
- Create multiple booklets to have more button
- Click the more button
- See lock icon is not appearing after loading the next items

**Requires:**
- Checkout tao-core https://github.com/oat-sa/tao-core/pull/3443
- Install taoBooklet extension
- For easy testing, you can decrease the limit amount booklets to show in tao/views/js/layout/tree/provider/jstree.js :42 var pageRange = 30;
