### PR TITLE
[Backport] TR-3785 oauth 1 parameters in header

### DIFF
--- a/models/classes/oauth/OauthService.php
+++ b/models/classes/oauth/OauthService.php
@@ -243,7 +243,13 @@ class OauthService extends ConfigurableService implements \common_http_Signature
      */
     private function buildAuthorizationHeader(OAuthRequest $signedRequest)
     {
-        return mb_substr($signedRequest->to_header(), 15);
+        $headerPrefix = 'Authorization: ';
+        $authorizationHeader = $signedRequest->to_header();
+        if (mb_strpos($authorizationHeader, $headerPrefix) === 0) {
+            $authorizationHeader = mb_substr($authorizationHeader, mb_strlen($headerPrefix));
+        }
+
+        return $authorizationHeader;
     }
 
     /**


### PR DESCRIPTION
Backport of https://github.com/oat-sa/tao-core/pull/3368 for https://oat-sa.atlassian.net/browse/TR-3785, targeting November release.
