### PR TITLE
fix: make properties label searchable by language

### DIFF
--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -83,6 +83,13 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
         $instance = $this->getInstance();
         $guiOrderProperty = new core_kernel_classes_Property(TaoOntology::PROPERTY_GUI_ORDER);
 
+        // Guess language
+        try {
+            $language = $this->options['lang'] ?? common_session_SessionManager::getSession()->getInterfaceLanguage();
+        } catch (common_exception_Error $exception) {
+            $language = DEFAULT_LANG;
+        }
+
         //get the list of properties to set in the form
         $propertyCandidates = tao_helpers_form_GenerisFormFactory::getDefaultProperties();
 
@@ -117,7 +124,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
                 $elementFactory->withInstance($instance);
             }
 
-            $element = $elementFactory->create($property);
+            $element = $elementFactory->create($property, $language);
 
             if ($element !== null) {
                 // take instance values to populate the form

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -63,8 +63,11 @@ class ElementMapFactory extends ConfigurableService
         return $this;
     }
 
-    public function create(core_kernel_classes_Property $property): ?tao_helpers_form_FormElement
-    {
+    public function create(
+        core_kernel_classes_Property $property,
+        string $language = DEFAULT_LANG)
+    : ?tao_helpers_form_FormElement {
+
         // Create the element from the right widget
         $property->feed();
 
@@ -121,11 +124,17 @@ class ElementMapFactory extends ConfigurableService
             return null;
         }
 
-        // Use the property label as element description
-        $propDesc = (trim($property->getLabel()) !== '')
-            ? $property->getLabel()
-            : str_replace(LOCAL_NAMESPACE, '', $propertyUri);
+        // Get property label
+        $label = current($property->getPropertyValues(
+            new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL),
+            [
+                'lg' => $language,
+                'one' => true
+            ]
+        ));
+        $propDesc = $label ?? str_replace(LOCAL_NAMESPACE, '', $propertyUri);
 
+        // Use the property label as element description
         $element->setDescription($propDesc);
 
         if (method_exists($element, 'setOptions')) {


### PR DESCRIPTION
**Description**
While editing a resource, property labels are not translated based on User Interface language.
This PR aims to fix it

**Ticket**
https://oat-sa.atlassian.net/browse/REL-665