### PR TITLE
fix: use uri for empty property label case

### DIFF
--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -295,7 +295,7 @@ class ElementMapFactory extends ConfigurableService
         ));
 
         if (empty(trim($propertyLabel))) {
-            str_replace(LOCAL_NAMESPACE, '', $property->getUri());
+            return str_replace(LOCAL_NAMESPACE, '', $property->getUri());
         }
 
         return $propertyLabel;


### PR DESCRIPTION
**Description**
Forgot return statement in the previous PR https://github.com/oat-sa/tao-core/pull/3463

**How to test**
- Pick a resource and replace one of it's properties label with an empty string in db
- Go to resource Edit form
- Verify that property description has uri w/o instance namespace, instead of empty string

**Ticket**
https://oat-sa.atlassian.net/browse/REL-665