### PR TITLE
feat: Add FeatureVisibilityService

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -28,6 +28,7 @@ use oat\tao\controller\api\Users;
 use oat\tao\controller\Middleware\MiddlewareConfig;
 use oat\tao\model\accessControl\AccessControlServiceProvider;
 use oat\tao\model\Csv\CsvServiceProvider;
+use oat\tao\model\featureVisibility\FeatureVisibilityServiceProvider;
 use oat\tao\model\import\ServiceProvider\ImportServiceProvider;
 use oat\tao\model\metadata\ServiceProvider\MetadataServiceProvider;
 use oat\tao\model\Observer\ServiceProvider\ObserverServiceProvider;
@@ -296,6 +297,7 @@ return [
         AccessControlServiceProvider::class,
         MetadataServiceProvider::class,
         ObserverServiceProvider::class,
+        FeatureVisibilityServiceProvider::class,
     ],
     'middlewares' => [
         MiddlewareConfig::class,

--- a/models/classes/featureVisibility/FeatureVisibilityService.php
+++ b/models/classes/featureVisibility/FeatureVisibilityService.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\featureVisibility;
+
+use common_ext_ExtensionsManager;
+use Exception;
+
+class FeatureVisibilityService
+{
+    public const HIDE_PARAM = 'hide';
+    public const SHOW_PARAM = 'show';
+
+    private const GLOBAL_UI_CONFIG_NAME = 'helpers/features';
+    private const EXTENSION_NAME = 'tao';
+    private const CONFIG_FILE_NAME = 'client_lib_config_registry';
+
+    /** @var common_ext_ExtensionsManager  */
+    private $extensionsManager;
+
+    public function __construct(common_ext_ExtensionsManager $extensionsManager)
+    {
+        $this->extensionsManager = $extensionsManager;
+    }
+
+    public function showFeature(string $featureName): void
+    {
+        $this->updateFeatureVisibility('updateConfig', [$featureName => self::SHOW_PARAM]);
+    }
+
+    public function hideFeature(string $featureName): void
+    {
+        $this->updateFeatureVisibility('updateConfig', [$featureName => self::HIDE_PARAM]);
+    }
+
+    public function setFeaturesVisibility(array $featureNameVisibilityMap): void
+    {
+        $this->updateFeatureVisibility('updateConfig', $featureNameVisibilityMap);
+    }
+
+    public function removeFeature(string $featureName): void
+    {
+        $this->updateFeatureVisibility('removeFeatureFromConfig', $featureName);
+    }
+
+    private function updateFeatureVisibility(string $configUpdaterCallableName, $configUpdaterArg): void
+    {
+        $taoExtension = $this->extensionsManager->getExtensionById(self::EXTENSION_NAME);
+        if ($taoExtension === null) {
+            throw new Exception(sprintf('Cannot find %s extension', self::EXTENSION_NAME));
+        }
+
+        $existingConfig = $taoExtension->getConfig(self::CONFIG_FILE_NAME);
+        if ($existingConfig === false) {
+            throw new Exception(sprintf('Cannot read %s config', self::CONFIG_FILE_NAME));
+        }
+
+        $updatedConfig = $this->{$configUpdaterCallableName}($existingConfig, $configUpdaterArg);
+
+        $taoExtension->setConfig(self::CONFIG_FILE_NAME, $updatedConfig);
+    }
+
+    private function updateConfig(array $existingConfig, array $newStatuses): array
+    {
+        foreach ($newStatuses as $featureName => $featureValue) {
+            if (!in_array($featureValue, [self::HIDE_PARAM, self::SHOW_PARAM], true)) {
+                throw new Exception(sprintf(
+                    'Feature value should be either %s or %s, %s given',
+                    self::SHOW_PARAM,
+                    self::HIDE_PARAM,
+                    $featureValue
+                ));
+            }
+            $existingConfig[self::GLOBAL_UI_CONFIG_NAME]['visibility'][$featureName] = $featureValue;
+        }
+
+        return $existingConfig;
+    }
+
+    private function removeFeatureFromConfig(array $existingConfig, string $featureName): array
+    {
+        unset($existingConfig[self::GLOBAL_UI_CONFIG_NAME]['visibility'][$featureName]);
+
+        return $existingConfig;
+    }
+}

--- a/models/classes/featureVisibility/FeatureVisibilityServiceProvider.php
+++ b/models/classes/featureVisibility/FeatureVisibilityServiceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\featureVisibility;
+
+use common_ext_ExtensionsManager;
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+class FeatureVisibilityServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services
+            ->set(FeatureVisibilityService::class, FeatureVisibilityService::class)
+            ->public()
+            ->args([
+                service(common_ext_ExtensionsManager::SERVICE_ID),
+            ]);
+    }
+}

--- a/models/classes/featureVisibility/FeatureVisibilityServiceProvider.php
+++ b/models/classes/featureVisibility/FeatureVisibilityServiceProvider.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace oat\tao\model\featureVisibility;
 
-use common_ext_ExtensionsManager;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\tao\model\ClientLibConfigRegistry;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -37,7 +37,7 @@ class FeatureVisibilityServiceProvider implements ContainerServiceProviderInterf
             ->set(FeatureVisibilityService::class, FeatureVisibilityService::class)
             ->public()
             ->args([
-                service(common_ext_ExtensionsManager::SERVICE_ID),
+                service(ClientLibConfigRegistry::class),
             ]);
     }
 }

--- a/test/unit/featureVisibility/FeatureVisibilityServiceTest.php
+++ b/test/unit/featureVisibility/FeatureVisibilityServiceTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\test\unit\model\listener;
+
+use common_ext_ExtensionsManager;
+use Exception;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\tao\model\featureVisibility\FeatureVisibilityService;
+
+class FeatureVisibilityServiceTest extends TestCase
+{
+    /** @var common_ext_ExtensionsManager|MockObject */
+    private $extManager;
+
+    /** @var FeatureVisibilityService  */
+    private $fv;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $extensionStub = new class() {
+            private $config = [];
+
+            public function getConfig($key)
+            {
+                return $this->config;
+            }
+
+            public function setConfig($key, $value)
+            {
+                $this->config = $value;
+            }
+        };
+        $this->extManager = $this->createStub(common_ext_ExtensionsManager::class);
+        $this->extManager->method('getExtensionById')->willReturn($extensionStub);
+
+        $this->fv = new FeatureVisibilityService($this->extManager);
+    }
+
+    public function testShowFeature_SetsFeatureToTheShowStatus()
+    {
+        $featureName = 'item/customInteraction/*';
+
+        $this->fv->showFeature($featureName);
+
+        $resultConfig = $this->extManager->getExtensionById('extId')->getConfig('confId');
+        $this->assertEquals(
+            FeatureVisibilityService::SHOW_PARAM,
+            $resultConfig['helpers/features']['visibility'][$featureName]
+        );
+    }
+
+    public function testHideFeature_SetsFeatureToTheHideStatus()
+    {
+        $featureName = 'item/multiColumn';
+
+        $this->fv->hideFeature($featureName);
+
+        $resultConfig = $this->extManager->getExtensionById('extId')->getConfig('confId');
+
+        $this->assertEquals(
+            FeatureVisibilityService::HIDE_PARAM,
+            $resultConfig['helpers/features']['visibility'][$featureName]
+        );
+    }
+
+    public function testSetFeaturesVisibility_SetsFeaturesToTheGivenStatusesAndDoesNotRemovePreviouslySetFeatures()
+    {
+        $singleFeatureName = 'item/multiColumn';
+
+        $featuresMap = [
+            "item/customInteraction/audioPciInteraction" => FeatureVisibilityService::SHOW_PARAM,
+            "test/item/timeLimits" => FeatureVisibilityService::HIDE_PARAM,
+        ];
+
+        $this->fv->showFeature($singleFeatureName);
+        $this->fv->setFeaturesVisibility($featuresMap);
+
+        $resultConfig = $this->extManager->getExtensionById('extId')->getConfig('confId');
+        $this->assertEquals(
+            $featuresMap + [$singleFeatureName => FeatureVisibilityService::SHOW_PARAM],
+            $resultConfig['helpers/features']['visibility']
+        );
+    }
+
+    public function testSetFeaturesVisibility_ThrowsExceptionInCaseOfWrongStatus()
+    {
+        $wrongFeatureStatus = 'wrongStatus';
+
+        try {
+            $this->fv->setFeaturesVisibility(['featureName' => $wrongFeatureStatus]);
+        } catch (Exception $e) {
+            $this->assertStringContainsString($wrongFeatureStatus, $e->getMessage());
+        }
+    }
+
+    public function testRemoveFeature_RemovesFeatureFromConfig()
+    {
+        $featureName = 'featureName';
+
+        $this->fv->showFeature($featureName);
+        $this->fv->removeFeature($featureName);
+
+        $resultConfig = $this->extManager->getExtensionById('extId')->getConfig('confId');
+
+        $this->assertEmpty($resultConfig['helpers/features']['visibility']);
+    }
+
+    public function testAllFeatureVisibilityMethods_WorkWithoutIssuesBeingCalledSeveralTimes()
+    {
+        $featureNameOne = 'feature1';
+        $featureNameTwo = 'feature2';
+        $featureNameThree = 'feature3';
+        $featureNameFour = 'feature4';
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->fv->showFeature($featureNameOne);
+
+            $this->fv->hideFeature($featureNameTwo);
+
+            $this->fv->setFeaturesVisibility([
+                $featureNameThree => FeatureVisibilityService::SHOW_PARAM,
+                $featureNameFour => FeatureVisibilityService::HIDE_PARAM
+            ]);
+
+            $this->fv->removeFeature($featureNameFour);
+        }
+
+        $resultConfig = $this->extManager->getExtensionById('extId')->getConfig('confId');
+
+        $this->assertEquals(
+            [
+                $featureNameOne => FeatureVisibilityService::SHOW_PARAM,
+                $featureNameTwo => FeatureVisibilityService::HIDE_PARAM,
+                $featureNameThree => FeatureVisibilityService::SHOW_PARAM,
+            ],
+            $resultConfig['helpers/features']['visibility']
+        );
+    }
+}


### PR DESCRIPTION
### Ticket
https://oat-sa.atlassian.net/browse/AUT-2081

### Summary
Add feature visibility service in order to manage visibility of UI features. It is suppose to be used for hiding not supported authoring features in Solar

### How to use service
For example, directly from container:
```
/** @var FeatureVisibilityService $vs */
$vs = $this->getServiceLocator()->getContainer()->get(FeatureVisibilityService::class);
$vs->showFeature('item/image/mediaAlignment');
```
After performing these lines of code config `app/config/tao/client_lib_config_registry.conf.php` will be updated with the following lines:
```
        'helpers/features' => array(
            'visibility' => array(
                'item/image/mediaAlignment' => 'show'
            )
        )
```

### Sandbox environment
No QA is needed