### PR TITLE
Checking empty value of label to avoid fatal errors

### DIFF
--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\tao\helpers\form;
 
 use common_Logger;
+use oat\generis\model\OntologyAwareTrait;
 use tao_helpers_Uri;
 use tao_helpers_Context;
 use core_kernel_classes_Class;
@@ -51,6 +52,8 @@ use oat\tao\model\Language\Service\LanguageListElementSortService;
 
 class ElementMapFactory extends ConfigurableService
 {
+    use OntologyAwareTrait;
+
     public const SERVICE_ID = 'tao/ElementMapFactory';
 
     /** @var core_kernel_classes_Resource */
@@ -286,15 +289,14 @@ class ElementMapFactory extends ConfigurableService
         core_kernel_classes_Property $property,
         string $language
     ) {
-        $propertyLabel = current($property->getPropertyValues(
-            new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL),
-            [
-                'lg' => $language,
-                'one' => true
-            ]
-        ));
+        $propertyLabel = current(
+            $property->getPropertyValues(
+                $this->getProperty(OntologyRdfs::RDFS_LABEL),
+                ['lg' => $language, 'one' => true]
+            )
+        );
 
-        if (empty(trim($propertyLabel))) {
+        if (false !== $propertyLabel && empty(trim($propertyLabel))) {
             return str_replace(LOCAL_NAMESPACE, '', $property->getUri());
         }
 


### PR DESCRIPTION
The related task is [REL-665](https://oat-sa.atlassian.net/browse/REL-665)

It raises the issue on the Premium.

It fixes issues introduced [here](https://github.com/oat-sa/tao-core/pull/3463/files) and [here](https://github.com/oat-sa/tao-core/pull/3467/files)

**How to test?**

Create a user with a different than the default language interface language, log in with this user, and try to reach any type of object (or even rdf forms). For example, create a new user. You will get 500 error, which is unexpected normally.