### PR TITLE
[Hotfix] Make properties label searchable by language

### DIFF
--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -83,6 +83,13 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
         $instance = $this->getInstance();
         $guiOrderProperty = new core_kernel_classes_Property(TaoOntology::PROPERTY_GUI_ORDER);
 
+        // Guess language
+        try {
+            $language = $this->options['lang'] ?? common_session_SessionManager::getSession()->getInterfaceLanguage();
+        } catch (common_exception_Error $exception) {
+            $language = DEFAULT_LANG;
+        }
+
         //get the list of properties to set in the form
         $propertyCandidates = tao_helpers_form_GenerisFormFactory::getDefaultProperties();
 
@@ -117,7 +124,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
                 $elementFactory->withInstance($instance);
             }
 
-            $element = $elementFactory->create($property);
+            $element = $elementFactory->create($property, $language);
 
             if ($element !== null) {
                 // take instance values to populate the form

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -63,8 +63,11 @@ class ElementMapFactory extends ConfigurableService
         return $this;
     }
 
-    public function create(core_kernel_classes_Property $property): ?tao_helpers_form_FormElement
-    {
+    public function create(
+        core_kernel_classes_Property $property,
+        string $language = DEFAULT_LANG)
+    : ?tao_helpers_form_FormElement {
+
         // Create the element from the right widget
         $property->feed();
 
@@ -121,11 +124,17 @@ class ElementMapFactory extends ConfigurableService
             return null;
         }
 
-        // Use the property label as element description
-        $propDesc = (trim($property->getLabel()) !== '')
-            ? $property->getLabel()
-            : str_replace(LOCAL_NAMESPACE, '', $propertyUri);
+        // Get property label
+        $label = current($property->getPropertyValues(
+            new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL),
+            [
+                'lg' => $language,
+                'one' => true
+            ]
+        ));
+        $propDesc = $label ?? str_replace(LOCAL_NAMESPACE, '', $propertyUri);
 
+        // Use the property label as element description
         $element->setDescription($propDesc);
 
         if (method_exists($element, 'setOptions')) {

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -295,7 +295,7 @@ class ElementMapFactory extends ConfigurableService
         ));
 
         if (empty(trim($propertyLabel))) {
-            str_replace(LOCAL_NAMESPACE, '', $property->getUri());
+            return str_replace(LOCAL_NAMESPACE, '', $property->getUri());
         }
 
         return $propertyLabel;

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\tao\helpers\form;
 
 use common_Logger;
+use oat\generis\model\OntologyAwareTrait;
 use tao_helpers_Uri;
 use tao_helpers_Context;
 use core_kernel_classes_Class;
@@ -51,6 +52,8 @@ use oat\tao\model\Language\Service\LanguageListElementSortService;
 
 class ElementMapFactory extends ConfigurableService
 {
+    use OntologyAwareTrait;
+
     public const SERVICE_ID = 'tao/ElementMapFactory';
 
     /** @var core_kernel_classes_Resource */
@@ -286,15 +289,14 @@ class ElementMapFactory extends ConfigurableService
         core_kernel_classes_Property $property,
         string $language
     ) {
-        $propertyLabel = current($property->getPropertyValues(
-            new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL),
-            [
-                'lg' => $language,
-                'one' => true
-            ]
-        ));
+        $propertyLabel = current(
+            $property->getPropertyValues(
+                $this->getProperty(OntologyRdfs::RDFS_LABEL),
+                ['lg' => $language, 'one' => true]
+            )
+        );
 
-        if (empty(trim($propertyLabel))) {
+        if (false !== $propertyLabel && empty(trim($propertyLabel))) {
             return str_replace(LOCAL_NAMESPACE, '', $property->getUri());
         }
 

--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -124,18 +124,7 @@ class ElementMapFactory extends ConfigurableService
             return null;
         }
 
-        // Get property label
-        $label = current($property->getPropertyValues(
-            new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL),
-            [
-                'lg' => $language,
-                'one' => true
-            ]
-        ));
-        $propDesc = $label ?? str_replace(LOCAL_NAMESPACE, '', $propertyUri);
-
-        // Use the property label as element description
-        $element->setDescription($propDesc);
+        $element->setDescription($this->getDescriptionFromTranslatedPropertyLabel($property, $language));
 
         if (method_exists($element, 'setOptions')) {
             // Multi elements use the property range as options
@@ -291,5 +280,24 @@ class ElementMapFactory extends ConfigurableService
     private function getContainer(): ContainerInterface
     {
         return $this->getServiceManager()->getContainer();
+    }
+
+    private function getDescriptionFromTranslatedPropertyLabel(
+        core_kernel_classes_Property $property,
+        string $language
+    ) {
+        $propertyLabel = current($property->getPropertyValues(
+            new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL),
+            [
+                'lg' => $language,
+                'one' => true
+            ]
+        ));
+
+        if (empty(trim($propertyLabel))) {
+            str_replace(LOCAL_NAMESPACE, '', $property->getUri());
+        }
+
+        return $propertyLabel;
     }
 }


### PR DESCRIPTION
Backport of the following PRs:

https://github.com/oat-sa/tao-core/pull/3463
https://github.com/oat-sa/tao-core/pull/3467
https://github.com/oat-sa/tao-core/pull/3484

**Description**
While editing a resource, property labels are not translated based on User Interface language.
This PR aims to fix it

**How to test**
- Change user language
- Go to item tab and select Item
- Edit form should be translated (Label) if token exist in PO files
