### PR TITLE
fix: fix the configuration key for the feature visibility service

### DIFF
--- a/models/classes/featureVisibility/FeatureVisibilityService.php
+++ b/models/classes/featureVisibility/FeatureVisibilityService.php
@@ -31,7 +31,7 @@ class FeatureVisibilityService
     public const HIDE_PARAM = 'hide';
     public const SHOW_PARAM = 'show';
 
-    private const GLOBAL_UI_CONFIG_NAME = 'helpers/features';
+    private const GLOBAL_UI_CONFIG_NAME = 'services/features';
 
     /** @var AbstractRegistry */
     private $registry;

--- a/test/unit/featureVisibility/FeatureVisibilityServiceTest.php
+++ b/test/unit/featureVisibility/FeatureVisibilityServiceTest.php
@@ -81,7 +81,7 @@ class FeatureVisibilityServiceTest extends TestCase
 
         $this->featureVisibilityService->showFeature($featureName);
 
-        $resultConfig = $this->abstractRegistryStub->get('helpers/features');
+        $resultConfig = $this->abstractRegistryStub->get('services/features');
         $this->assertEquals(
             FeatureVisibilityService::SHOW_PARAM,
             $resultConfig['visibility'][$featureName]
@@ -94,7 +94,7 @@ class FeatureVisibilityServiceTest extends TestCase
 
         $this->featureVisibilityService->hideFeature($featureName);
 
-        $resultConfig = $this->abstractRegistryStub->get('helpers/features');
+        $resultConfig = $this->abstractRegistryStub->get('services/features');
 
         $this->assertEquals(
             FeatureVisibilityService::HIDE_PARAM,
@@ -114,7 +114,7 @@ class FeatureVisibilityServiceTest extends TestCase
         $this->featureVisibilityService->showFeature($singleFeatureName);
         $this->featureVisibilityService->setFeaturesVisibility($featuresMap);
 
-        $resultConfig = $this->abstractRegistryStub->get('helpers/features');
+        $resultConfig = $this->abstractRegistryStub->get('services/features');
         $this->assertEquals(
             $featuresMap + [$singleFeatureName => FeatureVisibilityService::SHOW_PARAM],
             $resultConfig['visibility']
@@ -137,7 +137,7 @@ class FeatureVisibilityServiceTest extends TestCase
         $this->featureVisibilityService->showFeature($featureName);
         $this->featureVisibilityService->removeFeature($featureName);
 
-        $resultConfig = $this->abstractRegistryStub->get('helpers/features');
+        $resultConfig = $this->abstractRegistryStub->get('services/features');
 
         $this->assertEmpty($resultConfig['visibility']);
     }
@@ -162,7 +162,7 @@ class FeatureVisibilityServiceTest extends TestCase
             $this->featureVisibilityService->removeFeature($featureNameFour);
         }
 
-        $resultConfig = $this->abstractRegistryStub->get('helpers/features');
+        $resultConfig = $this->abstractRegistryStub->get('services/features');
 
         $this->assertEquals(
             [


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/AUT-2081 and https://oat-sa.atlassian.net/browse/AUT-2042

The key in the configuration wasn't matching the implementation due to a mistake in the PR description. 

how to test:
 - run the unit test `./vendor/bin/phpunit --color tao/test/unit/featureVisibility/FeatureVisibilityServiceTest.php`
 - configure a key, using a script for example and inspect the file `config/tao/client_lib_config_registry.conf.php` to look for the something like 
```
        'services/features' => array(
            'visibility' => array(
                'item/interaction/endAttempt' => 'hide'
            )
        )
```