### PR TITLE
[Fix] Clear token store on logout

### DIFF
--- a/views/js/controller/main.js
+++ b/views/js/controller/main.js
@@ -41,7 +41,28 @@ define([
     'layout/search',
     'layout/tree/loader',
     'layout/section-height',
-], function(module, $, _, context, router, helpers, uiForm, urlUtil, loggerFactory, feedback, generisRouter, sections, actionManager,versionWarning, loadingBar, nav, search, treeLoader, sectionHeight){
+    'core/tokenHandler'
+], function (
+    module,
+    $,
+    _,
+    context,
+    router,
+    helpers,
+    uiForm,
+    urlUtil,
+    loggerFactory,
+    feedback,
+    generisRouter,
+    sections,
+    actionManager,versionWarning,
+    loadingBar,
+    nav,
+    search,
+    treeLoader,
+    sectionHeight,
+    tokenHandlerFactory
+) {
     'use strict';
 
     const logger = loggerFactory('controller/main');
@@ -105,7 +126,6 @@ define([
      */
     return {
         start() {
-
             const config = module.config();
             const $doc = $(document);
 
@@ -187,6 +207,11 @@ define([
             if(config && _.isArray(config.extraRoutes) && config.extraRoutes.length){
                 router.dispatch(config.extraRoutes);
             }
+
+            $('#logout').on('click', () => {
+                const tokenHandler = new tokenHandlerFactory();
+                tokenHandler.clearStore();
+            });
         }
     };
 });

--- a/views/js/layout/logout-event.js
+++ b/views/js/layout/logout-event.js
@@ -22,12 +22,20 @@
  *
  * @author Alexander Zagovorichev <zagovorichev@1pt.com>
  */
-define(['jquery', 'lodash', 'i18n', 'util/url', 'ui/dialog/alert'], function (
+define([
+    'jquery',
+    'lodash',
+    'i18n',
+    'util/url',
+    'ui/dialog/alert',
+    'core/tokenHandler'
+], function (
     $,
     _,
     __,
     url,
-    alert
+    alert,
+    tokenHandlerFactory
 ) {
     'use strict';
 
@@ -44,6 +52,9 @@ define(['jquery', 'lodash', 'i18n', 'util/url', 'ui/dialog/alert'], function (
     return function logoutEvent(options) {
         options = _.defaults(options || {}, defaults);
         alert(options.message, function () {
+            const tokenHandler = new tokenHandlerFactory();
+            tokenHandler.clearStore();
+
             window.location = options.redirectUrl;
         });
     };


### PR DESCRIPTION
# [AUT-2124](https://oat-sa.atlassian.net/browse/AUT-2124)

## Changes
* Token Store is cleared when exit button is pressed
* Token Store is cleared when receiving a 403 error + logging out

## How to test
1. Configure `tao/security-xsrf-token.conf.php` to use `localStorage`:
   ```php
   <?php
   /**
    * Default config header created during install
    */

   return new oat\tao\model\security\xsrf\TokenService(array(
       'store' => new oat\tao\model\security\xsrf\TokenStoreSession(),
       'poolSize' => 10,
       'timeLimit' => 0,
       'validateTokens' => true,
       'clientStore' => 'localStorage'
   ));
   ```
2. Clear site data and refresh the page - you will be logged out
3. Log in
4. Create new class/item/test
5. Log out
6. Log it again
7. Try to create new class/item/test

### Previous behavior
`Error: 403 : Unable to process your request` pops-up, user log out.
### New behavior
No errors, class/item/test created and displayed under the tree.