### PR TITLE
fix: fallback to default language for form labels

### DIFF
--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -296,7 +296,11 @@ class ElementMapFactory extends ConfigurableService
             )
         );
 
-        if (false !== $propertyLabel && empty(trim($propertyLabel))) {
+        if (empty($propertyLabel)) {
+            $propertyLabel = $property->getLabel();
+        }
+
+        if (empty(trim($propertyLabel))) {
             return str_replace(LOCAL_NAMESPACE, '', $property->getUri());
         }
 


### PR DESCRIPTION
Fallback to default language to translate form labels
 
Related to : https://oat-sa.atlassian.net/browse/REL-714
  
#### How to test
 
- Log in as a user which has interface language defined different than system default (f.e. jp-JP)
- Open a form with some missing label translations (f.e. Test Taker form)
- Verify that all labels are present, and label translation is shown in system language in case interface language translation is missing 