### PR TITLE
[Backport] fix: fallback to default language for form labels

### DIFF
--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -296,7 +296,11 @@ class ElementMapFactory extends ConfigurableService
             )
         );
 
-        if (false !== $propertyLabel && empty(trim($propertyLabel))) {
+        if (empty($propertyLabel)) {
+            $propertyLabel = $property->getLabel();
+        }
+
+        if (empty(trim($propertyLabel))) {
             return str_replace(LOCAL_NAMESPACE, '', $property->getUri());
         }
 


### PR DESCRIPTION
Backport of https://github.com/oat-sa/tao-core/pull/3492 for https://oat-sa.atlassian.net/browse/REL-714