### PR TITLE
fix: release version corrected for May

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -249,9 +249,9 @@ return [
     ],
     'constants' => [
         #TAO version number
-        'TAO_VERSION' => '2022.01',
+        'TAO_VERSION' => '2022.05',
         #TAO version label
-        'TAO_VERSION_NAME' => '2022.01',
+        'TAO_VERSION_NAME' => '2022.05',
         #the name to display
         'PRODUCT_NAME' => 'TAO',
         #TAO release status, use to add specific footer to TAO, available alpha, beta, demo, stable


### PR DESCRIPTION
Related Issue: https://oat-sa.atlassian.net/browse/AUT-2137

Version mismatch for May release.

**SETPS to test:**
• Checkout to branch: fix/AUT-2137/incorrect-release-version-displayed-in-footer
• Check date on Footer version.

**Current behavior:**
Footer displays 2022.01 (January release)

**Expected behavior**
Footer should display  2022.05 (May) release like below.

![image](https://user-images.githubusercontent.com/60346520/165737435-fec694bd-acde-4aeb-ad61-a2189f2b9bf4.png)
