### PR TITLE
refactor: fix #3484 checking empty value of label to avoid fatal errors

### DIFF
--- a/helpers/form/ElementMapFactory.php
+++ b/helpers/form/ElementMapFactory.php
@@ -296,13 +296,7 @@ class ElementMapFactory extends ConfigurableService
             )
         );
 
-        if (empty($translatedLabel)) {
-            $this->logWarning(sprintf("Missing property translation for %s on %s", $property->getUri(), $language));
-
-            return $property->getLabel();
-        }
-
-        return $translatedLabel;
+        return !empty($translatedLabel) ? $translatedLabel : $property->getLabel();
     }
 
     private function getPropertyUriPartWithoutNamespace(core_kernel_classes_Property $property): string


### PR DESCRIPTION
Related tickets: [AUT-2171](https://oat-sa.atlassian.net/browse/AUT-2171)
The issue was that already existing fix was not deployed on that env, it is done now

Nevertheless I decided to do a small refactoring for that fix introduced here: https://github.com/oat-sa/tao-core/pull/3484
Initial feature caused a bug: https://github.com/oat-sa/tao-core/pull/3463

[AUT-2171]: https://oat-sa.atlassian.net/browse/AUT-2171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ