### PR TITLE
fix: update @oat-sa/tao-core-ui to 1.54.3

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -747,9 +747,9 @@
             "integrity": "sha512-sx5rs986iv3nacasx+M3pEC9PNglUlBM3zPCY5olPW4MNpXvAZ2ItCwNTgCLi19r6zf4gv4BasE7WQ/K/+V5tg=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.54.2",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.54.2.tgz",
-            "integrity": "sha512-7f+Fqu2c764rRjg5TA5Xa56L+pQaU54h3MmEQ4mK/5ZkzgO1BPjmf12dpE5YjQWnleuppPWZQ/MIJDUtdya45Q=="
+            "version": "1.54.3",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.54.3.tgz",
+            "integrity": "sha512-+JP1/B/jNX+b3kLaHrrfPJmQWqCT8vXQzACVw3dlJTVvPb1EJc6zoua/pH+tPIg6amgo7IDYm3xG2XBN5oEICQ=="
         },
         "@types/node": {
             "version": "14.18.12",

--- a/views/package.json
+++ b/views/package.json
@@ -17,7 +17,7 @@
         "@oat-sa/tao-core-libs": "0.4.5",
         "@oat-sa/tao-core-sdk": "1.19.1",
         "@oat-sa/tao-core-shared-libs": "1.2.0",
-        "@oat-sa/tao-core-ui": "1.54.2",
+        "@oat-sa/tao-core-ui": "1.54.3",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",
         "dompurify": "1.0.11",


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-2021,  https://oat-sa.atlassian.net/browse/AUT-2092
Depends on:
- [x] https://github.com/oat-sa/tao-core-ui-fe/pull/455 
- [x] https://github.com/oat-sa/tao-core-ui-fe/pull/457

Update @oat-sa/tao-core-ui to [1.54.3](https://github.com/oat-sa/tao-core-ui-fe/releases/tag/v1.54.3)
