### PR TITLE
chore: bump to safe guzzlehttp/guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "ext-mbstring": "*",
         "doctrine/dbal": "^2.10",
         "ezyang/htmlpurifier": "^4.9",
-        "guzzlehttp/guzzle": "6.5.5",
+        "guzzlehttp/guzzle": "^6.5.7",
         "guzzlehttp/psr7": "1.6.1",
         "imsglobal/lti": "^3.0",
         "justinrainbow/json-schema": "5.2.1",


### PR DESCRIPTION
Fixing issue: https://oatsa.slack.com/archives/CHV6WAE90/p1655210839713339