### PR TITLE
chore: bump to safe guzzlehttp/psr7 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "doctrine/dbal": "^2.10",
         "ezyang/htmlpurifier": "^4.9",
         "guzzlehttp/guzzle": "^6.5.7",
-        "guzzlehttp/psr7": "1.6.1",
+        "guzzlehttp/psr7": "^1.8.4",
         "imsglobal/lti": "^3.0",
         "justinrainbow/json-schema": "5.2.1",
         "oat-sa/jig": "~0.1",


### PR DESCRIPTION
Related issue: https://github.com/oat-sa/tao-core/pull/3551