### PR TITLE
fix: check application cache directory during update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "oat-sa/jig": "~0.1",
         "oat-sa/composer-npm-bridge": "~0.4.2||dev-master",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.20.0",
+        "oat-sa/generis": ">=15.20.3",
         "composer/package-versions-deprecated": "^1.11",
         "paragonie/random_compat": "^2.0",
         "phpdocumentor/reflection-docblock": "2.*",

--- a/install/class.Installator.php
+++ b/install/class.Installator.php
@@ -245,12 +245,8 @@ class tao_install_Installator
             }
 
             $setupFileCache = $this->getServiceManager()->get(SetupFileCache::class);
-            $cachePath = $file_path . 'generis' . DIRECTORY_SEPARATOR . 'cache';
-            if ($setupFileCache->createDirectory($cachePath)) {
-                $this->log('d', $cachePath . ' directory was created!');
-            } else {
-                throw new Exception($cachePath . ' directory creation has failed!');
-            }
+            $setupFileCache->createDirectory($file_path . 'generis' . DIRECTORY_SEPARATOR . 'cache');
+            $this->log('d', $cachePath . ' directory was created!');
 
             foreach ((array)$installData['extra_persistences'] as $k => $persistence) {
                 $persistenceManager->registerPersistence($k, $persistence);

--- a/install/class.Installator.php
+++ b/install/class.Installator.php
@@ -245,7 +245,8 @@ class tao_install_Installator
             }
 
             $setupFileCache = $this->getServiceManager()->get(SetupFileCache::class);
-            $setupFileCache->createDirectory($file_path . 'generis' . DIRECTORY_SEPARATOR . 'cache');
+            $cachePath = $file_path . 'generis' . DIRECTORY_SEPARATOR . 'cache';
+            $setupFileCache->createDirectory($cachePath);
             $this->log('d', $cachePath . ' directory was created!');
 
             foreach ((array)$installData['extra_persistences'] as $k => $persistence) {

--- a/install/class.Installator.php
+++ b/install/class.Installator.php
@@ -22,6 +22,7 @@
  */
 
 use oat\generis\persistence\DriverConfigurationFeeder;
+use oat\oatbox\cache\SetupFileCache;
 use oat\tao\helpers\InstallHelper;
 use oat\oatbox\install\Installer;
 use oat\oatbox\service\ServiceManager;
@@ -242,11 +243,13 @@ class tao_install_Installator
                     throw new Exception($file_path . ' directory creation was failed!');
                 }
             }
+
+            $setupFileCache = $this->getServiceManager()->get(SetupFileCache::class);
             $cachePath = $file_path . 'generis' . DIRECTORY_SEPARATOR . 'cache';
-            if (mkdir($cachePath, 0700, true)) {
+            if ($setupFileCache->createDirectory($cachePath)) {
                 $this->log('d', $cachePath . ' directory was created!');
             } else {
-                throw new Exception($cachePath . ' directory creation was failed!');
+                throw new Exception($cachePath . ' directory creation has failed!');
             }
 
             foreach ((array)$installData['extra_persistences'] as $k => $persistence) {
@@ -263,11 +266,7 @@ class tao_install_Installator
              * 5b - Create cache persistence
             */
             $this->log('d', 'Creating cache persistence..');
-            $persistenceManager->registerPersistence('cache', [
-                'driver' => 'phpfile'
-            ]);
-            $persistenceManager->getPersistenceById('cache')->purge();
-            $this->getServiceManager()->register(PersistenceManager::SERVICE_ID, $persistenceManager);
+            $setupFileCache->createPersistence();
 
             /*
              * 6 - Finish Generis Install

--- a/scripts/taoUpdate.php
+++ b/scripts/taoUpdate.php
@@ -20,12 +20,17 @@
 
 require_once dirname(__FILE__) . '/../includes/raw_start.php';
 
+use oat\oatbox\cache\SetupFileCache;
 use oat\oatbox\reporting\Report;
 use oat\tao\model\extension\UpdateExtensions;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
 
 $serviceManager = ServiceManager::getServiceManager();
+
+if (!$serviceManager->get(SetupFileCache::class)->createDirectory(GENERIS_CACHE_PATH)) {
+    throw new \Exception(sprintf( 'Could not create application cache at "%s"', GENERIS_CACHE_PATH ) );
+}
 
 $action = new UpdateExtensions();
 $action->setServiceLocator($serviceManager);

--- a/scripts/taoUpdate.php
+++ b/scripts/taoUpdate.php
@@ -28,9 +28,7 @@ use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
 
 $serviceManager = ServiceManager::getServiceManager();
 
-if (!$serviceManager->get(SetupFileCache::class)->createDirectory(GENERIS_CACHE_PATH)) {
-    throw new \Exception(sprintf( 'Could not create application cache at "%s"', GENERIS_CACHE_PATH ) );
-}
+$serviceManager->get(SetupFileCache::class)->createDirectory(GENERIS_CACHE_PATH);
 
 $action = new UpdateExtensions();
 $action->setServiceLocator($serviceManager);


### PR DESCRIPTION
When TAO instance is recreated and `taoUpdate.php` gets called, any migration trying to access DI container will fail with an error of missing cache directory. This change ensures the directory is present  

Related to : https://oat-sa.atlassian.net/browse/REL-783
  
#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/generis/pull/1013
  