### PR TITLE
Fix TR-4529 impossible to edit a Delivery form

### DIFF
--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -101,20 +101,15 @@
             this.htmlEditors = {};
 
             $(document).ajaxComplete(function (event, request, settings) {
-                var testedUrl;
-
                 //initialize regarding the requested action
                 //async request waiting for html or not defined
                 if (settings.dataType !== 'html' && settings.dataType) {
                     return;
                 }
 
-                if (settings.url.indexOf('?') !== -1) {
-                    testedUrl = settings.url.substr(0, settings.url.indexOf('?'));
-                }
-                else {
-                    testedUrl = settings.url;
-                }
+                const testedUrl = settings.url.indexOf('?') === -1
+                    ? settings.url
+                    : settings.url.substr(0, settings.url.indexOf('?'));
 
                 /**
                  * Prevent manage-schema form initialization when the targeted url is related to authoring

--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -110,12 +110,13 @@
                 const testedUrl = settings.url.indexOf('?') === -1
                     ? settings.url
                     : settings.url.substr(0, settings.url.indexOf('?'));
+                const authoringRequestSuffix = 'authoring';
 
                 /**
                  * Prevent manage-schema form initialization when the targeted url is related to authoring
                  * associated action is "launchEditor"
                 */
-                if (!testedUrl.includes('authoring')) {
+                if (testedUrl.indexOf(authoringRequestSuffix, testedUrl.length - authoringRequestSuffix.length) === -1) {
                     self.initRendering();
                 }
 

--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -105,29 +105,31 @@
 
                 //initialize regarding the requested action
                 //async request waiting for html or not defined
-                if (settings.dataType === 'html' || !settings.dataType) {
-                    if (settings.url.indexOf('?') !== -1) {
-                        testedUrl = settings.url.substr(0, settings.url.indexOf('?'));
-                    }
-                    else {
-                        testedUrl = settings.url;
-                    }
+                if (settings.dataType !== 'html' && settings.dataType) {
+                    return;
+                }
 
-                    /**
-                     * Prevent manage-schema form initialization when the targeted url is related to authoring
-                     * associated action is "launchEditor"
-                    */
-                    if (!testedUrl.includes('authoring')) {
-                        self.initRendering();
-                    }
+                if (settings.url.indexOf('?') !== -1) {
+                    testedUrl = settings.url.substr(0, settings.url.indexOf('?'));
+                }
+                else {
+                    testedUrl = settings.url;
+                }
 
-                    self.initElements();
-                    if (self.initGenerisFormPattern.test(testedUrl)) {
-                        self.initOntoForms();
-                    }
-                    if (self.initTranslationFormPattern.test(testedUrl)) {
-                        self.initTranslationForm();
-                    }
+                /**
+                 * Prevent manage-schema form initialization when the targeted url is related to authoring
+                 * associated action is "launchEditor"
+                */
+                if (!testedUrl.includes('authoring')) {
+                    self.initRendering();
+                }
+
+                self.initElements();
+                if (self.initGenerisFormPattern.test(testedUrl)) {
+                    self.initOntoForms();
+                }
+                if (self.initTranslationFormPattern.test(testedUrl)) {
+                    self.initTranslationForm();
                 }
             });
             this.initRendering();


### PR DESCRIPTION
# [TR-4529](https://oat-sa.atlassian.net/browse/TR-4529)

This PR aims to fix the condition that currently prevents a resource form initialization when a currently handled ajax request URI has the word `authoring` within it. Apparently, that was done to suppress some initialization errors on the Item and Test authoring screens.

Below, you can see a proof that the form initialization would resolve the issue.

https://user-images.githubusercontent.com/2943256/183646666-7d82b5f8-89d9-4ca6-bbd9-db5c11e0942c.mov

## Caused by
#3347 

## How to test

1. Have TAO 3.x running under a domain name with `authoring` in its name
2. Open a Delivery form
3. Save it