### PR TITLE
feat: add support for service from container for advanced search

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: CI
-        uses: oat-sa/tao-extension-ci-action@v1
+        uses: oat-sa/tao-extension-ci-action@v1.0.2
         with:
           php: ${{ matrix.php-version }}
           coverage: ${{ matrix.coverage }}

--- a/models/classes/AdvancedSearch/AdvancedSearchChecker.php
+++ b/models/classes/AdvancedSearch/AdvancedSearchChecker.php
@@ -23,11 +23,11 @@ declare(strict_types=1);
 namespace oat\tao\model\AdvancedSearch;
 
 use oat\tao\model\search\SearchProxy;
-use oat\tao\elasticsearch\ElasticSearch;
 use oat\tao\model\search\SearchInterface;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch;
 
 // @TODO Move to the AdvancedSearch extension and deprecate this one.
 class AdvancedSearchChecker extends ConfigurableService

--- a/models/classes/search/SearchProxy.php
+++ b/models/classes/search/SearchProxy.php
@@ -251,6 +251,10 @@ class SearchProxy extends ConfigurableService implements Search
         /** @var SearchInterface $search */
         $search = $this->getOption($option);
 
+        if (is_string($search)) {
+            return $this->getServiceManager()->getContainer()->get($search);
+        }
+
         $this->propagate($search);
 
         return $search;

--- a/models/classes/search/tasks/UpdateDataAccessControlInIndex.php
+++ b/models/classes/search/tasks/UpdateDataAccessControlInIndex.php
@@ -79,7 +79,7 @@ class UpdateDataAccessControlInIndex implements Action, ServiceLocatorAwareInter
         } catch (Throwable $exception) {
             $type = Report::TYPE_ERROR;
             $message = 'Failed during update search index';
-            $logMessage = 'Data Access Control failure: (' . get_class($exception) . ')' . $exception->getMessage();
+            $logMessage = 'Data Access Control failure: (' . get_class($exception) . ') ' . $exception->getMessage();
         }
 
         $this->logInfo($logMessage);

--- a/models/classes/search/tasks/UpdateDataAccessControlInIndex.php
+++ b/models/classes/search/tasks/UpdateDataAccessControlInIndex.php
@@ -29,10 +29,10 @@ use core_kernel_classes_Resource;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\action\Action;
 use oat\oatbox\log\LoggerAwareTrait;
-use oat\tao\elasticsearch\Exception\FailToUpdatePropertiesException;
 use oat\tao\model\search\index\IndexUpdaterInterface;
 use oat\tao\model\taskQueue\Task\TaskAwareInterface;
 use oat\tao\model\taskQueue\Task\TaskAwareTrait;
+use Throwable;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
@@ -76,10 +76,10 @@ class UpdateDataAccessControlInIndex implements Action, ServiceLocatorAwareInter
 
         try {
             $indexUpdater->updatePropertyValue($resourceUri, $parentClasses, self::READ_ACCESS_PROPERTY, $newPermissions);
-        } catch (FailToUpdatePropertiesException $exception) {
+        } catch (Throwable $exception) {
             $type = Report::TYPE_ERROR;
             $message = 'Failed during update search index';
-            $logMessage = 'Data Access Control failure: ' . $exception->getMessage();
+            $logMessage = 'Data Access Control failure: (' . get_class($exception) . ')' . $exception->getMessage();
         }
 
         $this->logInfo($logMessage);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -40,7 +40,6 @@ use oat\oatbox\service\ServiceNotFoundException;
 use oat\oatbox\task\TaskService;
 use oat\oatbox\user\UserService;
 use oat\tao\controller\api\Users;
-use oat\tao\elasticsearch\IndexUpdater;
 use oat\tao\helpers\dateFormatter\EuropeanFormatter;
 use oat\tao\helpers\form\ValidationRuleRegistry;
 use oat\tao\model\accessControl\func\AccessRule;

--- a/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
+++ b/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
@@ -134,22 +134,28 @@ class AdvancedSearchCheckerTest extends TestCase
 
     public function pingProvider(): array
     {
-        return [
-            [
-                'advancedSearch' => $this->createMock(ElasticSearch::class),
-                'advancedSearchPing' => true,
-                'expected' => true,
-            ],
-            [
-                'advancedSearch' => $this->createMock(ElasticSearch::class),
-                'advancedSearchPing' => false,
-                'expected' => false,
-            ],
+        $data = [
             [
                 'advancedSearch' => null,
                 'advancedSearchPing' => null,
                 'expected' => false,
-            ],
+            ]
         ];
+
+        if (class_exists('oat\\taoAdvancedSearch\\model\\SearchEngine\\Driver\\Elasticsearch\\ElasticSearch')) {
+            $data[] = [
+                'advancedSearch' => $this->createMock(ElasticSearch::class),
+                'advancedSearchPing' => true,
+                'expected' => true,
+            ];
+
+            $data[] = [
+                'advancedSearch' => $this->createMock(ElasticSearch::class),
+                'advancedSearchPing' => false,
+                'expected' => false,
+            ];
+        }
+
+        return $data;
     }
 }

--- a/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
+++ b/test/unit/AdvancedSearch/AdvancedSearchCheckerTest.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 namespace oat\tao\test\unit\AdvancedSearch;
 
 use oat\generis\test\TestCase;
-use oat\tao\elasticsearch\ElasticSearch;
 use oat\tao\model\search\SearchInterface;
 use oat\tao\model\search\SearchProxy;
+use oat\taoAdvancedSearch\model\SearchEngine\Driver\Elasticsearch\ElasticSearch;
 use PHPUnit\Framework\MockObject\MockObject;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;

--- a/test/unit/models/classes/search/tasks/UpdateDataAccessControlInIndexTest.php
+++ b/test/unit/models/classes/search/tasks/UpdateDataAccessControlInIndexTest.php
@@ -94,7 +94,7 @@ class UpdateDataAccessControlInIndexTest extends TestCase
 
         $this->logger->expects($this->once())
             ->method('info')
-            ->with('Data Access Control failure: Error During Update the Properties fail. Please, check previous exception for more details.');
+            ->with('Data Access Control failure: (Exception) fail');
 
         $this->indexUpdater->expects($this->once())->method('updatePropertyValue')
             ->with($documentUri, [''], 'read_access', [])

--- a/test/unit/models/classes/search/tasks/UpdateDataAccessControlInIndexTest.php
+++ b/test/unit/models/classes/search/tasks/UpdateDataAccessControlInIndexTest.php
@@ -25,10 +25,10 @@ use common_exception_MissingParameter;
 use common_report_Report as Report;
 use core_kernel_classes_Class;
 use core_kernel_classes_Resource;
+use Exception;
 use oat\generis\model\data\Ontology;
 use oat\generis\test\TestCase;
 use oat\oatbox\log\LoggerService;
-use oat\tao\elasticsearch\Exception\FailToUpdatePropertiesException;
 use oat\tao\model\search\index\IndexUpdaterInterface;
 use oat\tao\model\search\tasks\UpdateDataAccessControlInIndex;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -81,10 +81,6 @@ class UpdateDataAccessControlInIndexTest extends TestCase
 
     public function testInvokeTaskFailureShouldReportError(): void
     {
-        if (!class_exists('oat\\tao\\elasticsearch\\Exception\\FailToUpdatePropertiesException')) { //@todo refactor
-            $this->markTestSkipped('No elastic lib found');
-        }
-
         $documentUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
         $resource = $this->createMock(core_kernel_classes_Resource::class);
         $class = $this->createMock(core_kernel_classes_Class::class);
@@ -102,7 +98,7 @@ class UpdateDataAccessControlInIndexTest extends TestCase
 
         $this->indexUpdater->expects($this->once())->method('updatePropertyValue')
             ->with($documentUri, [''], 'read_access', [])
-            ->willThrowException(new FailToUpdatePropertiesException('fail'));
+            ->willThrowException(new Exception('fail'));
 
         $report = $this->sut->__invoke(
             [$documentUri, []]


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1163

# Goal

- Make tao-core not use the ElasticSearch library anymore
- Use the new taoAdvancedSearch implementation instead

# Related PRs

- https://github.com/oat-sa/extension-tao-advanced-search/pull/65