### PR TITLE
fix/ADF-1146: Distinguish which method requiresRight cached data belongs to

### DIFF
--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -153,7 +153,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
                     }
                 }
 
-                if ($this->isEmptyLabel($element)) { // Don't show empty labels
+                if ($this->isEmptyLabel($element)) {
                     continue;
                 }
 

--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -254,7 +254,6 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
     private function isEmptyLabel($element): bool
     {
         return $element instanceof tao_helpers_form_elements_Label
-            && (($element->getRawValue() === null)
-                || (strlen($element->getRawValue()) === 0));
+            && empty($element->getRawValue());
     }
 }

--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -153,8 +153,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
                     }
                 }
 
-                // don't show empty labels
-                if ($element instanceof tao_helpers_form_elements_Label && strlen($element->getRawValue()) === 0) {
+                if ($this->isEmptyLabel($element)) { // Don't show empty labels
                     continue;
                 }
 
@@ -250,5 +249,12 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
         return $range->isSubClassOf(
             new core_kernel_classes_Class(TaoOntology::CLASS_URI_LIST)
         );
+    }
+
+    private function isEmptyLabel($element): bool
+    {
+        return $element instanceof tao_helpers_form_elements_Label
+            && (($element->getRawValue() === null)
+                || (strlen($element->getRawValue()) === 0));
     }
 }

--- a/models/classes/controllerMap/ActionDescription.php
+++ b/models/classes/controllerMap/ActionDescription.php
@@ -32,15 +32,8 @@ use ReflectionMethod;
  */
 class ActionDescription
 {
-    /**
-     * Data cache for DocBlock information used by getDocBlock().
-     *
-     * The method name the docblock is found in is used as the array index
-     * (i.e. it works as a "cache key")
-     *
-     * @var DocBlock[]
-     */
-    private static $docBlock = [];
+    /** @var DocBlock[] */
+    private static $docBlocks = [];
 
     /**
      * The method implementing the action
@@ -66,16 +59,16 @@ class ActionDescription
     {
         $cacheKey = "{$this->method->class}::{$this->method->name}";
 
-        if (!isset(self::$docBlock[$cacheKey])) {
+        if (!isset(self::$docBlocks[$cacheKey])) {
             $factory = DocBlockFactory::createInstance();
             $factory->registerTagHandler('requiresRight', RequiresRightTag::class);
 
-            self::$docBlock[$cacheKey] = is_string($this->method->getDocComment())
+            self::$docBlocks[$cacheKey] = is_string($this->method->getDocComment())
                 ? $factory->create($this->method)
                 : new DocBlock();
         }
 
-        return self::$docBlock[$cacheKey];
+        return self::$docBlocks[$cacheKey];
     }
 
     /**

--- a/models/classes/controllerMap/ActionDescription.php
+++ b/models/classes/controllerMap/ActionDescription.php
@@ -16,8 +16,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2014-2022 (original work) Open Assessment Technologies SA;
- *
- *
  */
 
 namespace oat\tao\model\controllerMap;
@@ -34,8 +32,15 @@ use ReflectionMethod;
  */
 class ActionDescription
 {
-    /** @var DocBlock|null */
-    private static $docBlock;
+    /**
+     * Data cache for DocBlock information used by getDocBlock().
+     *
+     * The method name the docblock is found in is used as the array index
+     * (i.e. it works as a "cache key")
+     *
+     * @var DocBlock[]
+     */
+    private static $docBlock = [];
 
     /**
      * The method implementing the action
@@ -55,21 +60,22 @@ class ActionDescription
     }
 
     /**
-     *
      * @return DocBlock
      */
     protected function getDocBlock()
     {
-        if (!self::$docBlock instanceof DocBlock) {
+        $cacheKey = "{$this->method->class}::{$this->method->name}";
+
+        if (!isset(self::$docBlock[$cacheKey])) {
             $factory = DocBlockFactory::createInstance();
             $factory->registerTagHandler('requiresRight', RequiresRightTag::class);
 
-            self::$docBlock = is_string($this->method->getDocComment())
+            self::$docBlock[$cacheKey] = is_string($this->method->getDocComment())
                 ? $factory->create($this->method)
                 : new DocBlock();
         }
 
-        return self::$docBlock;
+        return self::$docBlock[$cacheKey];
     }
 
     /**
@@ -96,7 +102,7 @@ class ActionDescription
     /**
      * Returns an array of all rights required to execute the action
      *
-     * The array uses the name of the parmeter as key and the value is
+     * The array uses the name of the parameter as key and the value is
      * a string identifying the right
      *
      * @return string[]

--- a/models/classes/mvc/error/HtmlResponse.php
+++ b/models/classes/mvc/error/HtmlResponse.php
@@ -29,7 +29,6 @@ use oat\tao\helpers\Template;
  */
 class HtmlResponse extends ResponseAbstract
 {
-
     protected $contentType = 'text/html';
 
     public function send()
@@ -38,10 +37,12 @@ class HtmlResponse extends ResponseAbstract
             $message = $this->exception->getMessage();
             $trace = $this->exception->getTraceAsString();
         }
-        $referer = $_SERVER['HTTP_REFERER'];
+
+        $referer = $_SERVER['HTTP_REFERER'] ?? '';
         $returnUrl = (parse_url($referer, PHP_URL_HOST) === parse_url(ROOT_URL, PHP_URL_HOST))
             ? htmlentities($referer, ENT_QUOTES)
             : false;
+
         require $this->createTemplatePath();
     }
 


### PR DESCRIPTION
**Associated Jira issue:** [ADF-1146](https://oat-sa.atlassian.net/browse/ADF-1146)

This fix enables sharing the `@requiresRight` cache between `ActionDescription` instances while keeping track about which method the cached data belongs to, so it avoids using permissions stored previously for a different action in later calls.

There are also two small changes introduced while debugging to avoid errors when running TAO in PHP 8:

- A deprecated warning when calling `strlen()` with a `null` value.
- A warning when no HTTP Referer header is present that may end up polluting the HTML output if E_ALL is enabled

Related PR: https://github.com/oat-sa/extension-tao-item/pull/595 (it has been closed, as this fix in tao-core alone solves the issue)
