### PR TITLE
Feature/ADF-1197/Hide criteria on demand

### DIFF
--- a/views/js/layout/search.js
+++ b/views/js/layout/search.js
@@ -105,6 +105,9 @@ define([
         const searchModalInstance = searchModal({
             criterias,
             url,
+            classesUrl: urlHelper.route('getAll', 'RestResource', 'tao'),
+            classMappingUrl: urlHelper.route('getWithMapping', 'ClassMetadata', 'tao'),
+            statusUrl: urlHelper.route('status', 'AdvancedSearch', 'tao'),
             searchOnInit,
             rootClassUri,
             hideResourceSelector: isResultPage,

--- a/views/js/layout/search.js
+++ b/views/js/layout/search.js
@@ -108,6 +108,7 @@ define([
             searchOnInit,
             rootClassUri,
             hideResourceSelector: isResultPage,
+            hideCriteria: isResultPage,
             placeholder
         });
 


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1197

### Summary

Requires: 
 - [x] https://github.com/oat-sa/tao-core-ui-fe/pull/496
 - [ ] update the package.json file once the PR is released

Hides the criteria from the advanced search when the module is the Results.

### Details

Set the hide criteria option when the module is the Results.

### How to test
- checkout the branch in the extension and in `tao/views/node_module/@oat-sa/tao-core-ui`
- checkout the integration branches in the other repositories
- check the search in each module. With the Results module, the criteria must not show up.