### PR TITLE
fix: bump core-ui-fe lib to correct icon issue

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -747,9 +747,9 @@
             "integrity": "sha512-R6Kad0TZ/wGYqXHYrgmNrYqjbIdiML4l4ozQhZtmR8g5hthh7vocJgiukgIY+ulFrs6epcpcPANVx162w+eO8w=="
         },
         "@oat-sa/tao-core-ui": {
-            "version": "1.60.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.60.1.tgz",
-            "integrity": "sha512-lDMagZZsefB2NiidpX9PW5v6qPahBm+d+fzSkjfeJC04UbKLOFa+Q10iNVR+6LO0nWniGVpzBHbnB1ScQjK3YQ=="
+            "version": "1.60.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-1.60.2.tgz",
+            "integrity": "sha512-4XOW2tiCg8zVclLyCyMMDUl/CF/LMw/eCsNCEWWzF2OZP3zGHqlKPmRNYTlG5+7hj4CGP97Q8iqk/Srnt+qidw=="
         },
         "@types/node": {
             "version": "14.18.5",

--- a/views/package.json
+++ b/views/package.json
@@ -17,7 +17,7 @@
         "@oat-sa/tao-core-libs": "0.4.5",
         "@oat-sa/tao-core-sdk": "1.20.0",
         "@oat-sa/tao-core-shared-libs": "1.4.1",
-        "@oat-sa/tao-core-ui": "1.60.1",
+        "@oat-sa/tao-core-ui": "1.60.2",
         "codemirror": "^5.54.0",
         "decimal.js": "10.1.1",
         "dompurify": "1.0.11",


### PR DESCRIPTION
Related to styleManager issues fixes:  bump npm package to include fix for  [icons in media player not displaying]

[AUT- 2654](https://oat-sa.atlassian.net/browse/AUT-2654)

**Steps to check;**
- install npm pakage `tao-core-ui-fe`  new version `1.60.2`

**Expected behavior:**
- Package installs without any errors.
- Fix from package is present and Media player displays icons for play, stop, pause and music symbol correctly

![image](https://user-images.githubusercontent.com/60346520/193807900-dd5033bb-0174-4aa1-aed5-53489456a391.png)

