### PR TITLE
fix: Fix warnings from login page under PHP 8

### DIFF
--- a/models/classes/security/xsrf/Token.php
+++ b/models/classes/security/xsrf/Token.php
@@ -85,7 +85,7 @@ class Token implements JsonSerializable
     /**
      * @inheritdoc
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             self::TOKEN_KEY     => $this->getValue(),

--- a/models/classes/session/Business/Domain/SessionCookieAttributeCollection.php
+++ b/models/classes/session/Business/Domain/SessionCookieAttributeCollection.php
@@ -26,6 +26,7 @@ namespace oat\tao\model\session\Business\Domain;
 
 use IteratorAggregate;
 use oat\tao\model\session\Business\Contract\SessionCookieAttributeInterface;
+use ReturnTypeWillChange;
 
 final class SessionCookieAttributeCollection implements IteratorAggregate
 {
@@ -44,6 +45,7 @@ final class SessionCookieAttributeCollection implements IteratorAggregate
     /**
      * @return iterable|SessionCookieAttributeInterface[]
      */
+    #[ReturnTypeWillChange]
     public function getIterator(): iterable
     {
         yield from $this->attributes;

--- a/models/classes/session/Business/Domain/SessionCookieAttributeCollection.php
+++ b/models/classes/session/Business/Domain/SessionCookieAttributeCollection.php
@@ -26,7 +26,6 @@ namespace oat\tao\model\session\Business\Domain;
 
 use IteratorAggregate;
 use oat\tao\model\session\Business\Contract\SessionCookieAttributeInterface;
-use ReturnTypeWillChange;
 
 final class SessionCookieAttributeCollection implements IteratorAggregate
 {
@@ -45,7 +44,6 @@ final class SessionCookieAttributeCollection implements IteratorAggregate
     /**
      * @return iterable|SessionCookieAttributeInterface[]
      */
-    #[ReturnTypeWillChange]
     public function getIterator(): iterable
     {
         yield from $this->attributes;

--- a/views/templates/blocks/login.tpl
+++ b/views/templates/blocks/login.tpl
@@ -21,7 +21,7 @@ use oat\tao\model\theme\Theme;
             'controller/login': {
                 'message' : {
                     'info': <?=json_encode(get_data('msg'))?>,
-                    'error': <?=json_encode(urldecode(get_data('errorMessage')))?>
+                    'error': <?=json_encode(urldecode(get_data('errorMessage') ?? ''))?>
                 },
                 'disableAutocomplete' : <?=get_data('autocompleteDisabled')?>,
                 'enablePasswordReveal' : <?=get_data('passwordRevealEnabled')?>,


### PR DESCRIPTION
**Associated Jira issue:** [ADF-1105](https://oat-sa.atlassian.net/browse/ADF-1105)

This PR fixes some warnings found on a fresh installation running PHP8 when reaching the login page.

The errors trigger Javascript parsing errors, which in turn prevents the login form from being shown.