### PR TITLE
fix: add ids to normalized so ACL is applied in the FE

### DIFF
--- a/models/classes/search/ResultSetResponseNormalizer.php
+++ b/models/classes/search/ResultSetResponseNormalizer.php
@@ -85,7 +85,7 @@ class ResultSetResponseNormalizer extends ConfigurableService
                 if ($hasReadAccess === false) {
                     $content = [
                         'label' => __('Access Denied'),
-                        'id' => ''
+                        'id' => $resourceId,
                     ];
                 }
 

--- a/test/unit/models/classes/search/ResultSetResponseNormalizerTest.php
+++ b/test/unit/models/classes/search/ResultSetResponseNormalizerTest.php
@@ -137,11 +137,11 @@ class ResultSetResponseNormalizerTest extends TestCase
                 'data' => [
                     [
                         'label' => 'Access Denied',
-                        'id' => '',
+                        'id' => 'uri1',
                     ],
                     [
                         'label' => 'Access Denied',
-                        'id' => '',
+                        'id' => 'uri2',
                     ],
                 ],
                 'readonly' => [


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1244

# Goal

Make the view button disabled in case the resource has no read access for the user

# How to test

- Disable read access for user in an item folder
- Login with the user without read access and search for the restricted item
- Check the button is disabled