### PR TITLE
chore: preparing to remove AdvancedSearch references from tao-core

### DIFF
--- a/models/classes/resources/AddToAdvancedSearch.php
+++ b/models/classes/resources/AddToAdvancedSearch.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017-2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\tao\model\resources;
+
+use common_http_Request;
+use core_kernel_classes_Class;
+use core_kernel_classes_Resource;
+use oat\generis\model\data\event\ResourceCreated;
+use oat\generis\model\data\event\ResourceDeleted;
+use oat\generis\model\data\event\ResourceUpdated;
+use oat\generis\model\OntologyAwareTrait;
+use oat\generis\model\OntologyRdfs;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
+use oat\tao\model\search\index\IndexUpdaterInterface;
+use oat\tao\model\search\Search;
+use oat\tao\model\search\tasks\UpdateClassInIndex;
+use oat\tao\model\search\tasks\UpdateResourceInIndex;
+use oat\tao\model\TaoOntology;
+use oat\tao\model\taskQueue\QueueDispatcherInterface;
+
+/**
+ * @TODO FIXME TMP Class
+ */
+class AddToAdvancedSearch extends ConfigurableService // Remove me after refactoring
+{
+    use OntologyAwareTrait;
+
+    /**
+     * @TODO Move this logic to AdvancedSearch when handling all the events the ResourceWatcher does
+     */
+    private function createResourceIndexingTask(core_kernel_classes_Resource $resource, string $message): void
+    {
+        //@TODO FIXME make sure it only indexes if AdvancedSearch is ENABLED
+
+        /** @var QueueDispatcherInterface $queueDispatcher */
+        $queueDispatcher = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
+
+        if ($this->hasClassSupport($resource) && !$this->ignoreEditIemClassUpdates()) {
+            $queueDispatcher->createTask(new UpdateClassInIndex(), [$resource->getUri()], $message);
+            return;
+        }
+
+        if ($this->hasResourceSupport($resource)) {
+            $queueDispatcher->createTask(new UpdateResourceInIndex(), [$resource->getUri()], $message);
+        }
+    }
+
+    private function hasResourceSupport(core_kernel_classes_Resource $resource): bool
+    {
+        $resourceTypeIds = array_map(
+            function (core_kernel_classes_Class $resourceType): string {
+                return $resourceType->getUri();
+            },
+            $resource->getTypes()
+        );
+
+        $checkedResourceTypes = [OntologyRdfs::RDFS_RESOURCE, TaoOntology::CLASS_URI_OBJECT];
+        $resourceTypeIds = array_diff($resourceTypeIds, [OntologyRdfs::RDFS_RESOURCE, TaoOntology::CLASS_URI_OBJECT]);
+
+        while (!empty($resourceTypeIds)) {
+            $classUri = array_pop($resourceTypeIds);
+
+            $hasClassSupport = $this->getServiceLocator()
+                ->get(IndexUpdaterInterface::SERVICE_ID)
+                ->hasClassSupport(
+                    $classUri
+                );
+
+            if ($hasClassSupport) {
+                return true;
+            }
+
+            $class = $this->getClass($classUri);
+
+            foreach ($class->getParentClasses() as $parent) {
+                if (!in_array($parent->getUri(), $checkedResourceTypes)) {
+                    $resourceTypeIds[] = $parent->getUri();
+                }
+            }
+            $checkedResourceTypes[] = $class->getUri();
+        }
+
+        return false;
+    }
+
+    private function hasClassSupport(core_kernel_classes_Resource $resource): bool
+    {
+        return $resource instanceof core_kernel_classes_Class;
+    }
+
+    private function ignoreEditIemClassUpdates(): bool
+    {
+        try {
+            $url = parse_url(common_http_Request::currentRequest()->getUrl());
+        } catch (\common_exception_Error $e) {
+            return false;
+        }
+
+        return isset($url['path']) && $url['path'] === '/taoItems/Items/editItemClass';
+    }
+}

--- a/models/classes/search/index/IndexIteratorFactory.php
+++ b/models/classes/search/index/IndexIteratorFactory.php
@@ -26,6 +26,7 @@ use oat\tao\model\resources\ResourceIterator;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
+//@TODO Move to advancedSearch
 class IndexIteratorFactory
 {
     use ServiceLocatorAwareTrait;

--- a/models/classes/search/tasks/AddSearchIndexFromArray.php
+++ b/models/classes/search/tasks/AddSearchIndexFromArray.php
@@ -36,6 +36,8 @@ use oat\generis\model\OntologyAwareTrait;
  *
  * @author Aleksej Tikhanovich <aleksej@taotesting.com>
  * @package oat\tao\model\search\tasks
+ *
+ * @TODO Remove references and use AdvancedSearch
  */
 class AddSearchIndexFromArray implements Action, ServiceLocatorAwareInterface, TaskAwareInterface
 {

--- a/models/classes/search/tasks/UpdateClassInIndex.php
+++ b/models/classes/search/tasks/UpdateClassInIndex.php
@@ -35,6 +35,9 @@ use oat\tao\model\taskQueue\Task\TaskAwareTrait;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
+/**
+ * @TODO Deprecate, remove content and Move to AdvancedSearch
+ */
 class UpdateClassInIndex implements Action, ServiceLocatorAwareInterface, TaskAwareInterface
 {
     use ServiceLocatorAwareTrait;

--- a/models/classes/search/tasks/UpdateResourceInIndex.php
+++ b/models/classes/search/tasks/UpdateResourceInIndex.php
@@ -37,6 +37,8 @@ use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
 /**
  * @author Ilya Yarkavets <ilya@taotesting.com>
+ *
+ * @TODO Deprecate, clear methods and move to AdvancedSearch
  */
 class UpdateResourceInIndex implements Action, ServiceLocatorAwareInterface, TaskAwareInterface
 {

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -43,6 +43,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use Psr\Log\LoggerInterface;
 
+//@TODO Fix this test
 class ResourceWatcherTest extends TestCase
 {
     /** @var ResourceWatcher|MockObject */

--- a/test/unit/models/classes/search/index/IndexIteratorFactoryTest.php
+++ b/test/unit/models/classes/search/index/IndexIteratorFactoryTest.php
@@ -25,6 +25,7 @@ use oat\generis\test\TestCase;
 use oat\tao\model\search\index\IndexIterator;
 use oat\tao\model\search\index\IndexIteratorFactory;
 
+//@TODO Move to advancedSearch
 class IndexIteratorFactoryTest extends TestCase
 {
     public function testMakeIterator(): void

--- a/test/unit/models/classes/search/tasks/UpdateClassInIndexTest.php
+++ b/test/unit/models/classes/search/tasks/UpdateClassInIndexTest.php
@@ -32,6 +32,7 @@ use oat\tao\model\search\tasks\UpdateClassInIndex;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
+// @TODO Move to AdvancedSearch
 class UpdateClassInIndexTest extends TestCase
 {
     /** @var UpdateClassInIndex */


### PR DESCRIPTION
PISA25-188

- Remove advancedSearch indexation work from tao-core
- Move it to taoAdvancedSearch extension
- Centralize the place where we handle events ETL to ElasticSearch.