### PR TITLE
fix: pass option to element attribute for resource identification

### DIFF
--- a/helpers/form/class.Form.php
+++ b/helpers/form/class.Form.php
@@ -41,6 +41,7 @@ declare(strict_types=1);
  * @package tao
 
  */
+// phpcs:ignore
 abstract class tao_helpers_form_Form
 {
     /**

--- a/helpers/form/class.Form.php
+++ b/helpers/form/class.Form.php
@@ -18,7 +18,7 @@
  *
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- *               2021 (original work) Open Assessment Technologies SA
+ *               2021-2022 (original work) Open Assessment Technologies SA
  */
 // phpcs:enable
 

--- a/helpers/form/class.Form.php
+++ b/helpers/form/class.Form.php
@@ -440,6 +440,9 @@ abstract class tao_helpers_form_Form
                 $element->addClass('error');
             }
 
+            //Pass Resource Type
+            $element->addAttribute('resourceType', $this->options['resourceType'] ?? null);
+
             //render element
             $returnValue .= $element->render();
 

--- a/helpers/form/class.Form.php
+++ b/helpers/form/class.Form.php
@@ -1,5 +1,6 @@
 <?php
 
+// phpcs:disable Generic.Files.LineLength
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -19,6 +20,7 @@
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
  *               2021 (original work) Open Assessment Technologies SA
  */
+// phpcs:enable
 
 declare(strict_types=1);
 
@@ -41,7 +43,6 @@ declare(strict_types=1);
  */
 abstract class tao_helpers_form_Form
 {
-
     /**
      * the form name
      *
@@ -313,7 +314,9 @@ abstract class tao_helpers_form_Form
 
         foreach ($actions as $action) {
             if (!$action instanceof tao_helpers_form_FormElement) {
-                throw new Exception('The actions parameter must only contains instances of tao_helpers_form_FormElement');
+                throw new Exception(
+                    'The actions parameter must only contains instances of tao_helpers_form_FormElement'
+                );
             }
             $this->actions[$context][] = $action;
         }

--- a/helpers/form/xhtml/class.Form.php
+++ b/helpers/form/xhtml/class.Form.php
@@ -15,9 +15,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
- *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- *
+ * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung
+ * (under the project TAO-TRANSFER);
+ *              2009-2012 (update and modification) Public Research Centre Henri Tudor
+ * (under the project TAO-SUSTAIN & TAO-DEV);
  */
 
 use oat\oatbox\log\LoggerAwareTrait;
@@ -36,13 +37,6 @@ use \tao_helpers_form_FormFactory as FormFactory;
 class tao_helpers_form_xhtml_Form extends tao_helpers_form_Form
 {
     use LoggerAwareTrait;
-
-    // --- ASSOCIATIONS ---
-
-
-    // --- ATTRIBUTES ---
-
-    // --- OPERATIONS ---
 
     /**
      * Short description of method getValues
@@ -108,7 +102,9 @@ class tao_helpers_form_xhtml_Form extends tao_helpers_form_Form
         $returnValue = '';
 
         $requestUri = $_SERVER['REQUEST_URI'] ?? '';
-        $action = strpos($requestUri, '?') > 0 ? substr($requestUri, 0, strpos($requestUri, '?')) : $requestUri;
+        $action = strpos($requestUri, '?') > 0
+            ? substr($requestUri, 0, strpos($requestUri, '?'))
+            : $requestUri;
 
         // Defensive code, prevent double leading slashes issue.
         if (strpos($action, '//') === 0) {

--- a/helpers/form/xhtml/class.Form.php
+++ b/helpers/form/xhtml/class.Form.php
@@ -19,6 +19,7 @@
  * (under the project TAO-TRANSFER);
  *              2009-2012 (update and modification) Public Research Centre Henri Tudor
  * (under the project TAO-SUSTAIN & TAO-DEV);
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
  */
 
 use oat\oatbox\log\LoggerAwareTrait;

--- a/helpers/form/xhtml/class.Form.php
+++ b/helpers/form/xhtml/class.Form.php
@@ -22,9 +22,6 @@
  */
 
 use oat\oatbox\log\LoggerAwareTrait;
-use oat\tao\helpers\form\elements\xhtml\CsrfToken;
-use oat\tao\model\security\xsrf\TokenService;
-use \tao_helpers_form_FormFactory as FormFactory;
 
 /**
  * Short description of class tao_helpers_form_xhtml_Form
@@ -34,6 +31,7 @@ use \tao_helpers_form_FormFactory as FormFactory;
  * @package tao
 
  */
+// phpcs:ignore
 class tao_helpers_form_xhtml_Form extends tao_helpers_form_Form
 {
     use LoggerAwareTrait;

--- a/test/unit/helpers/form/FormContainerTest.php
+++ b/test/unit/helpers/form/FormContainerTest.php
@@ -116,9 +116,9 @@ HTML
     <form method='post' id='test' name='test' action=''>
     <input type='hidden' class='global' name='test_sent' value='1'/>
     <div>
-        <input id="test" name="test" type="text" value="" data-testid="Test"/>
+        <input id="test" name="test" resourceType="" type="text" value="" data-testid="Test"/>
     </div>
-    <input id="X-CSRF-Token" name="X-CSRF-Token" type="hidden" value="$token"/>
+    <input id="X-CSRF-Token" name="X-CSRF-Token" resourceType="" type="hidden" value="$token"/>
         <div class='form-toolbar'>
             <button type='submit' name='Save' id='Save' class='form-submitter btn-success small' value="Save" data-testid="save">
                 <span class="icon-save"></span> Save</button>
@@ -137,7 +137,7 @@ HTML
 <div class='xhtml_form'>
     <form method='post' id='test' name='test' action=''>
     <input type='hidden' class='global' name='test_sent' value='1'/>
-    <input id="X-CSRF-Token" name="X-CSRF-Token" type="hidden" value="$token"/>
+    <input id="X-CSRF-Token" name="X-CSRF-Token" resourceType="" type="hidden" value="$token"/>
         <div class='form-toolbar'>
             <button type='submit' name='Save' id='Save' class='form-submitter btn-success small' value="Save" data-testid="save">
                 <span class="icon-save"></span> Save</button>
@@ -172,7 +172,7 @@ HTML
 <div class='xhtml_form'>
     <form method='post' id='test' name='test' action=''>
     <input type='hidden' class='global' name='test_sent' value='1'/>
-    <input id="X-CSRF-Token" name="X-CSRF-Token" type="hidden" value="$token"/>
+    <input id="X-CSRF-Token" name="X-CSRF-Token" resourceType="" type="hidden" value="$token"/>
         <div class='form-toolbar'>
             <button disabled="disabled" type='submit' name='Save' id='Save' class='form-submitter btn-success small' value="Save" data-testid="save">
                 <span class="icon-save"></span> Save</button>
@@ -192,9 +192,9 @@ HTML
     <form method='post' id='test' name='test' action=''>
     <input type='hidden' class='global' name='test_sent' value='1'/>
     <div>
-        <input disabled="disabled" id="test" name="test" type="text" value="" data-testid="Test"/>
+        <input disabled="disabled" id="test" name="test" resourceType="" type="text" value="" data-testid="Test"/>
     </div>
-    <input id="X-CSRF-Token" name="X-CSRF-Token" type="hidden" value="$token"/>
+    <input id="X-CSRF-Token" name="X-CSRF-Token" resourceType="" type="hidden" value="$token"/>
         <div class='form-toolbar'>
             <button disabled="disabled" type='submit' name='Save' id='Save' class='form-submitter btn-success small' value="Save" data-testid="save">
                 <span class="icon-save"></span> Save</button>

--- a/test/unit/helpers/form/FormContainerTest.php
+++ b/test/unit/helpers/form/FormContainerTest.php
@@ -1,4 +1,22 @@
-<?php declare(strict_types=1);
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA;
+ */
 
 namespace oat\tao\helpers\test\unit\helpers\form;
 
@@ -99,7 +117,7 @@ class FormContainerTest extends GenerisTestCase
         return [
             'Simple form' => [
                 'expected' => <<<HTML
-<div class='xhtml_form'>
+<div class='xhtml_form'> 
     <form method='post' id='test' name='test' action=''>
     <input type='hidden' class='global' name='test_sent' value='1'/>
         <div class='form-toolbar'>

--- a/test/unit/helpers/form/FormContainerTest.php
+++ b/test/unit/helpers/form/FormContainerTest.php
@@ -113,7 +113,7 @@ class FormContainerTest extends GenerisTestCase
     public function dataProvider(): array
     {
         $token = self::TOKEN_VALUE;
-
+        // phpcs:disable Generic.Files.LineLength
         return [
             'Simple form' => [
                 'expected' => <<<HTML
@@ -228,6 +228,7 @@ HTML
                 new tao_helpers_form_elements_xhtml_Textbox('test'),
             ],
         ];
+        // phpcs:enable
     }
 
     private function createApplicationServiceTestDouble(): ApplicationService


### PR DESCRIPTION
Related to https://github.com/oat-sa/extension-tao-resource-workflow/pull/42

Assign resourceType attribute from an option passed from the resource edit form. This attribute may be used to define the initial state of the resource when not defined. 

How to reproduce:

- Ensure your instance has taoResourceWorkflow installed
- Create item with content
- Export Item
- Open another environment with taoResourceWorkflow installed
- Import item
- Ensure the item has initially stated and defined in the workflow