### PR TITLE
Feature/TR-5014/Text converter

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -739,7 +739,7 @@
             "integrity": "sha512-1fAwH0INmP/Xmqn/lvD5Amcpncm8KSMk1IOS2/SZehkspQQnTq4zCOiUwBKttGr18nzzflySX3CUVY4xMuA/LA=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#ef18a6779a856dbc28f33a0f34a76dea22099a06",
+            "version": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#28a9335c17417c42ef1c3b481ee4cc22d2a5df08",
             "from": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#feature/TR-5014/text-converter",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -739,9 +739,8 @@
             "integrity": "sha512-1fAwH0INmP/Xmqn/lvD5Amcpncm8KSMk1IOS2/SZehkspQQnTq4zCOiUwBKttGr18nzzflySX3CUVY4xMuA/LA=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.21.1.tgz",
-            "integrity": "sha512-VI1JK8Qxn3dxTS0TfYdYVVtF6nriBf1ra2lFY+jhrnbmn6oPrODqW0eeTdYiFohL0Lit44YeUGxTQfcQHuTwkw==",
+            "version": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#ef18a6779a856dbc28f33a0f34a76dea22099a06",
+            "from": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#feature/TR-5014/text-converter",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",
                 "idb-wrapper": "1.7.0",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -739,8 +739,9 @@
             "integrity": "sha512-1fAwH0INmP/Xmqn/lvD5Amcpncm8KSMk1IOS2/SZehkspQQnTq4zCOiUwBKttGr18nzzflySX3CUVY4xMuA/LA=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#28a9335c17417c42ef1c3b481ee4cc22d2a5df08",
-            "from": "git+https://github.com/oat-sa/tao-core-sdk-fe.git#feature/TR-5014/text-converter",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.22.0.tgz",
+            "integrity": "sha512-e2cAYI2mJfZ6rlzph9bs352riCZsmfztddjtIM5Mjn5HZvPj8zSiQYHz6t4lI/Yrkfsa2a6vFpkvDpk/QUinzg==",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",
                 "idb-wrapper": "1.7.0",

--- a/views/package.json
+++ b/views/package.json
@@ -15,7 +15,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.1",
         "@oat-sa/tao-core-libs": "^0.5.1",
-        "@oat-sa/tao-core-sdk": "https://github.com/oat-sa/tao-core-sdk-fe.git#feature/TR-5014/text-converter",
+        "@oat-sa/tao-core-sdk": "^1.22.0",
         "@oat-sa/tao-core-shared-libs": "1.5.1",
         "@oat-sa/tao-core-ui": "1.65.0",
         "codemirror": "^5.54.0",

--- a/views/package.json
+++ b/views/package.json
@@ -15,7 +15,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.1",
         "@oat-sa/tao-core-libs": "^0.5.1",
-        "@oat-sa/tao-core-sdk": "^1.21.1",
+        "@oat-sa/tao-core-sdk": "https://github.com/oat-sa/tao-core-sdk-fe.git#feature/TR-5014/text-converter",
         "@oat-sa/tao-core-shared-libs": "1.5.1",
         "@oat-sa/tao-core-ui": "1.65.0",
         "codemirror": "^5.54.0",


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5014

### Requires

- [ ] https://github.com/oat-sa/tao-core-sdk-fe/pull/163

### Summary

Add a text converter for sanitizing text.

This first version includes a converter for replacing ambiguous symbols with plain ASCII chars.

### Details
The converter is supplied through the package `@oat-sa/tao-core-sdk`.

 Several components have been added:
- `'util/converter/factory'` a converter factory, registering a list of processors for converting the text
- `'util/converter/ambiguousSymbols'` an ambiguous symbols processor for replacing Japanese number with ASCII numbers
- `'util/converter'` a default converter bundled with the builtin converted (for now only the `ambiguousSymbols` processor)

Note: the list of ambiguous symbols to replace might not be finalized yet. Additions may be done soon if we get the final list.

### How to test
- checkout the branch
- see the companion PR for more details