### PR TITLE
feat: changed ResponseEmitter to replace existing headers to avoid duplicates

### DIFF
--- a/models/classes/http/ResponseEmitter.php
+++ b/models/classes/http/ResponseEmitter.php
@@ -49,7 +49,7 @@ class ResponseEmitter
             header($http_line, true, $response->getStatusCode());
             foreach ($response->getHeaders() as $name => $values) {
                 foreach ($values as $value) {
-                    header("$name: $value", false);
+                    header("$name: $value");
                 }
             }
         }


### PR DESCRIPTION
This PR changes the ResponseEmitter to replace new headers instead of duplicate them, because in some cases it could result in multiple `Content-Type` headers, that causes issues on the frontend side, because of the strict mime rules.