### PR TITLE
fix: jsonSerialize return type array

### DIFF
--- a/models/classes/datatable/implementation/AbstractDatatablePayload.php
+++ b/models/classes/datatable/implementation/AbstractDatatablePayload.php
@@ -286,10 +286,7 @@ abstract class AbstractDatatablePayload implements DatatablePayloadInterface, Se
         return $payload;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->getPayload();
     }

--- a/models/classes/datatable/implementation/AbstractDatatablePayload.php
+++ b/models/classes/datatable/implementation/AbstractDatatablePayload.php
@@ -84,7 +84,7 @@ abstract class AbstractDatatablePayload implements DatatablePayloadInterface, Se
      * Template method to find data.
      * Any step (such as filtration, pagination, sorting e.t.c. can be changed in concrete class).
      */
-    public function getPayload()
+    public function getPayload(): array
     {
         $queryBuilder = $this->getSearchService()->query();
 
@@ -92,9 +92,8 @@ abstract class AbstractDatatablePayload implements DatatablePayloadInterface, Se
         $this->doPagination($queryBuilder);
         $this->doSorting($queryBuilder);
         $searchResult = $this->doSearch($queryBuilder);
-        $result = $this->doPostProcessing($searchResult);
 
-        return $result;
+        return  $this->doPostProcessing($searchResult);
     }
 
     /**
@@ -162,11 +161,7 @@ abstract class AbstractDatatablePayload implements DatatablePayloadInterface, Se
         return $this->getSearchService()->getGateway()->search($queryBuilder);
     }
 
-    /**
-     * @param TaoResultSet $result
-     * @return array
-     */
-    protected function doPostProcessing(TaoResultSet $result)
+    protected function doPostProcessing(TaoResultSet $result): array
     {
         $payload = [
             'data' => $result->getArrayCopy(),
@@ -259,10 +254,9 @@ abstract class AbstractDatatablePayload implements DatatablePayloadInterface, Se
      * Fetch all the values of properties listed in properties map
      *
      * @param $payload
-     * @return mixed
      * @throws \common_exception_InvalidArgumentType
      */
-    protected function fetchPropertyValues($payload)
+    protected function fetchPropertyValues($payload): array
     {
         $propertyMap = $this->getPropertiesMap();
         $data = [];

--- a/models/classes/event/AbstractExportEvent.php
+++ b/models/classes/event/AbstractExportEvent.php
@@ -48,7 +48,7 @@ abstract class AbstractExportEvent implements Event, \JsonSerializable
         return $this->exportedResource;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'exportedResource' => $this->exportedResource->getUri()

--- a/models/classes/event/AbstractImportEvent.php
+++ b/models/classes/event/AbstractImportEvent.php
@@ -48,7 +48,7 @@ abstract class AbstractImportEvent implements Event, \JsonSerializable
         return $this->report;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'report' => $this->report->toArray()

--- a/models/classes/event/AbstractRoleEvent.php
+++ b/models/classes/event/AbstractRoleEvent.php
@@ -26,7 +26,6 @@ use oat\oatbox\event\Event;
 
 abstract class AbstractRoleEvent implements Event, JsonSerializable
 {
-
     /** @var  string */
     protected $roleUri;
 

--- a/models/classes/event/AbstractRoleEvent.php
+++ b/models/classes/event/AbstractRoleEvent.php
@@ -48,14 +48,7 @@ abstract class AbstractRoleEvent implements Event, JsonSerializable
         return get_class($this);
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'roleUri' => $this->roleUri

--- a/models/classes/event/ClassFormUpdatedEvent.php
+++ b/models/classes/event/ClassFormUpdatedEvent.php
@@ -52,14 +52,7 @@ class ClassFormUpdatedEvent implements Event, JsonSerializable
         return get_class($this);
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'uri' => $this->class->getUri(),

--- a/models/classes/event/LoginFailedEvent.php
+++ b/models/classes/event/LoginFailedEvent.php
@@ -32,14 +32,7 @@ class LoginFailedEvent implements Event, JsonSerializable
         return __CLASS__;
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    function jsonSerialize(): array
+    public function jsonSerialize(): array
     {
         return [
             'login' => $this->getLogin()

--- a/models/classes/event/LoginFailedEvent.php
+++ b/models/classes/event/LoginFailedEvent.php
@@ -39,7 +39,7 @@ class LoginFailedEvent implements Event, JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4.0
      */
-    function jsonSerialize()
+    function jsonSerialize(): array
     {
         return [
             'login' => $this->getLogin()

--- a/models/classes/event/LoginSucceedEvent.php
+++ b/models/classes/event/LoginSucceedEvent.php
@@ -65,14 +65,7 @@ class LoginSucceedEvent implements Event, JsonSerializable
         return $this->time;
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'login' => $this->getLogin()

--- a/models/classes/event/LogoutSucceedEvent.php
+++ b/models/classes/event/LogoutSucceedEvent.php
@@ -70,14 +70,7 @@ class LogoutSucceedEvent implements Event, JsonSerializable
         return $this->time;
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             $this->getLogin(),

--- a/models/classes/event/RoleChangedEvent.php
+++ b/models/classes/event/RoleChangedEvent.php
@@ -26,7 +26,7 @@ class RoleChangedEvent extends AbstractRoleEvent
     protected $essence;
     protected $changes;
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'roleUri' => $this->roleUri,

--- a/models/classes/event/UserCreatedEvent.php
+++ b/models/classes/event/UserCreatedEvent.php
@@ -53,14 +53,7 @@ class UserCreatedEvent implements Event, JsonSerializable, WebhookSerializableEv
         return get_class($this);
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'uri' => $this->user->getUri(),

--- a/models/classes/event/UserRemovedEvent.php
+++ b/models/classes/event/UserRemovedEvent.php
@@ -54,14 +54,7 @@ class UserRemovedEvent implements Event, JsonSerializable, WebhookSerializableEv
         return self::EVENT_NAME;
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'uri' => $this->userUri,

--- a/models/classes/event/UserUpdatedEvent.php
+++ b/models/classes/event/UserUpdatedEvent.php
@@ -27,7 +27,6 @@ use oat\oatbox\event\Event;
 
 class UserUpdatedEvent implements Event, JsonSerializable
 {
-
     /** @var  string */
     protected $user;
     protected $data;

--- a/models/classes/event/UserUpdatedEvent.php
+++ b/models/classes/event/UserUpdatedEvent.php
@@ -52,14 +52,7 @@ class UserUpdatedEvent implements Event, JsonSerializable
         return get_class($this);
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'uri' => $this->user->getUri(),

--- a/models/classes/export/JsonLdExport.php
+++ b/models/classes/export/JsonLdExport.php
@@ -131,10 +131,7 @@ class JsonLdExport implements JsonSerializable
         return $this;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $data = [
             '@context' => [],

--- a/models/classes/modules/DynamicModule.php
+++ b/models/classes/modules/DynamicModule.php
@@ -169,10 +169,7 @@ class DynamicModule implements JsonSerializable
         return in_array($this->tags, $tag);
     }
 
-    /**
-     * @see JsonSerializable::jsonSerialize
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/models/classes/security/xsrf/Token.php
+++ b/models/classes/security/xsrf/Token.php
@@ -82,10 +82,7 @@ class Token implements JsonSerializable
         return $this->tokenTimeStamp;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             self::TOKEN_KEY     => $this->getValue(),

--- a/models/classes/security/xsrf/Token.php
+++ b/models/classes/security/xsrf/Token.php
@@ -14,8 +14,8 @@ class Token implements JsonSerializable
 {
     use TokenGenerator;
 
-    const TOKEN_KEY = 'token';
-    const TIMESTAMP_KEY = 'ts';
+    public const TOKEN_KEY = 'token';
+    public const TIMESTAMP_KEY = 'ts';
 
     /**
      * @var string

--- a/models/classes/service/class.ConstantParameter.php
+++ b/models/classes/service/class.ConstantParameter.php
@@ -20,7 +20,7 @@
  */
 
 use oat\tao\model\WfEngineOntology;
-use \oat\generis\model\data\Ontology;
+use oat\generis\model\data\Ontology;
 
 /**
  * Represents tao service parameter
@@ -28,7 +28,7 @@ use \oat\generis\model\data\Ontology;
  * @access public
  * @author Joel Bout, <joel@taotesting.com>
  * @package tao
-
+ * phpcs:disable Squiz.Classes.ValidClassName
  */
 class tao_models_classes_service_ConstantParameter extends tao_models_classes_service_Parameter
 {
@@ -36,7 +36,7 @@ class tao_models_classes_service_ConstantParameter extends tao_models_classes_se
      * @var string
      */
     private $value;
-    
+
     /**
      * Instantiates a parameter that takes
      * a constant value
@@ -47,9 +47,11 @@ class tao_models_classes_service_ConstantParameter extends tao_models_classes_se
     public function __construct(core_kernel_classes_Resource $definition, $value)
     {
         parent::__construct($definition);
-        $this->value = is_object($value) && $value instanceof core_kernel_classes_Resource ? $value->getUri() : (string)$value;
+        $this->value = is_object($value) && $value instanceof core_kernel_classes_Resource
+            ? $value->getUri()
+            : (string)$value;
     }
-    
+
     /**
      * Returns the actual value associated to this parameter
      *
@@ -59,7 +61,7 @@ class tao_models_classes_service_ConstantParameter extends tao_models_classes_se
     {
         return $this->value;
     }
-    
+
     /**
      * (non-PHPdoc)
      * @see tao_models_classes_service_Parameter::serialize()

--- a/models/classes/service/class.ConstantParameter.php
+++ b/models/classes/service/class.ConstantParameter.php
@@ -74,7 +74,7 @@ class tao_models_classes_service_ConstantParameter extends tao_models_classes_se
         return $resource;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'def' => $this->getDefinition()->getUri(),

--- a/models/classes/service/class.Parameter.php
+++ b/models/classes/service/class.Parameter.php
@@ -20,7 +20,7 @@
  */
 
 use oat\tao\model\WfEngineOntology;
-use \oat\generis\model\data\Ontology;
+use oat\generis\model\data\Ontology;
 
 /**
  * Represents tao service parameter
@@ -28,7 +28,7 @@ use \oat\generis\model\data\Ontology;
  * @access public
  * @author Joel Bout, <joel@taotesting.com>
  * @package tao
-
+ * phpcs:disable Squiz.Classes.ValidClassName
  */
 abstract class tao_models_classes_service_Parameter implements JsonSerializable
 {
@@ -36,7 +36,7 @@ abstract class tao_models_classes_service_Parameter implements JsonSerializable
      * @var core_kernel_classes_Resource
      */
     private $definition;
-    
+
     /**
      * Base constructor of abstract parameter
      *
@@ -46,7 +46,7 @@ abstract class tao_models_classes_service_Parameter implements JsonSerializable
     {
         $this->definition = $definition;
     }
-    
+
     /**
      * Returns the formal definition of this parameter
      *
@@ -56,6 +56,7 @@ abstract class tao_models_classes_service_Parameter implements JsonSerializable
     {
         return $this->definition;
     }
+
     /**
      * @return core_kernel_classes_Resource
      */
@@ -78,7 +79,7 @@ abstract class tao_models_classes_service_Parameter implements JsonSerializable
         }
         return $param;
     }
-    
+
     /**
      * Builds a service call parameter from it's serialized form
      *
@@ -93,9 +94,15 @@ abstract class tao_models_classes_service_Parameter implements JsonSerializable
             WfEngineOntology::PROPERTY_ACTUAL_PARAMETER_PROCESS_VARIABLE
         ]);
         if (count($values[WfEngineOntology::PROPERTY_ACTUAL_PARAMETER_FORMAL_PARAMETER]) != 1) {
-            throw new common_exception_InconsistentData('Actual variable ' . $resource->getUri() . ' missing formal parameter');
+            throw new common_exception_InconsistentData(
+                'Actual variable ' . $resource->getUri() . ' missing formal parameter'
+            );
         }
-        if (count($values[WfEngineOntology::PROPERTY_ACTUAL_PARAMETER_CONSTANT_VALUE]) + count($values[WfEngineOntology::PROPERTY_ACTUAL_PARAMETER_PROCESS_VARIABLE]) != 1) {
+
+        if (
+            count($values[WfEngineOntology::PROPERTY_ACTUAL_PARAMETER_CONSTANT_VALUE])
+            + count($values[WfEngineOntology::PROPERTY_ACTUAL_PARAMETER_PROCESS_VARIABLE]) != 1
+        ) {
             throw new common_exception_InconsistentData('Actual variable ' . $resource->getUri() . ' invalid, '
                 . count($values[WfEngineOntology::PROPERTY_ACTUAL_PARAMETER_CONSTANT_VALUE]) . ' constant values and '
                 . count($values[WfEngineOntology::PROPERTY_ACTUAL_PARAMETER_PROCESS_VARIABLE]) . ' process variables');

--- a/models/classes/service/class.Parameter.php
+++ b/models/classes/service/class.Parameter.php
@@ -62,7 +62,7 @@ abstract class tao_models_classes_service_Parameter implements JsonSerializable
      */
     abstract public function toOntology(Ontology $model);
 
-    abstract public function jsonSerialize(): array;
+    abstract public function jsonSerialize();
 
     public static function fromJson($data)
     {

--- a/models/classes/service/class.Parameter.php
+++ b/models/classes/service/class.Parameter.php
@@ -61,7 +61,7 @@ abstract class tao_models_classes_service_Parameter implements JsonSerializable
      */
     abstract public function toOntology(Ontology $model);
 
-    abstract public function jsonSerialize();
+    abstract public function jsonSerialize(): array;
 
     public static function fromJson($data)
     {

--- a/models/classes/service/class.ServiceCall.php
+++ b/models/classes/service/class.ServiceCall.php
@@ -19,7 +19,6 @@
  *
  */
 
-use \oat\tao\model\exceptions\UserErrorException;
 use oat\generis\model\OntologyAwareTrait;
 use oat\generis\model\OntologyRdfs;
 use oat\tao\model\WfEngineOntology;
@@ -30,6 +29,7 @@ use oat\tao\model\WfEngineOntology;
  * @access public
  * @author Joel Bout, <joel@taotesting.com>
  * @package tao
+ * phpcs:disable Squiz.Classes.ValidClassName
  */
 class tao_models_classes_service_ServiceCall implements JsonSerializable
 {
@@ -38,7 +38,7 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
     /**
      * @var core_kernel_classes_Resource
      */
-    
+
     private $serviceDefinitionId = null;
 
     /**
@@ -47,14 +47,14 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
      * @var array
      */
     private $inParameters = [];
-    
+
     /**
      * Variable parameter to which the outcome of the service is send
      *
      * @var tao_models_classes_service_VariableParameter
      */
     private $outParameter = null;
-    
+
     /**
      * Instantiates a new service call
      *
@@ -66,7 +66,7 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
            ? $serviceDefinition->getUri()
            : $serviceDefinition;
     }
-    
+
     /**
      * Adds an input parameter
      *
@@ -76,7 +76,7 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
     {
         $this->inParameters[] = $param;
     }
-    
+
     /**
      * Sets the output parameter, does not except constants
      *
@@ -86,7 +86,7 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
     {
         $this->outParameter = $param;
     }
-    
+
     /**
      * returns the definition of the called service
      *
@@ -96,7 +96,7 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
     {
         return $this->serviceDefinitionId;
     }
-    
+
     /**
      * returns the call parameters
      *
@@ -122,7 +122,7 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
         }
         return $variables;
     }
-    
+
     /**
      * Stores a service call in the ontology
      *
@@ -146,10 +146,10 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
             WfEngineOntology::PROPERTY_CALL_OF_SERVICES_WIDTH                => '100',
             WfEngineOntology::PROPERTY_CALL_OF_SERVICES_HEIGHT               => '100'
         ]);
-             
+
         return $resource;
     }
-    
+
     /**
      * Builds a service call from it's serialized form
      *
@@ -170,12 +170,15 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
             $serviceCall->addInParameter($param);
         }
         if (!empty($values[WfEngineOntology::PROPERTY_CALL_OF_SERVICES_ACTUAL_PARAMETER_OUT])) {
-            $param = tao_models_classes_service_Parameter::fromResource(current($values[WfEngineOntology::PROPERTY_CALL_OF_SERVICES_ACTUAL_PARAMETER_OUT]));
+            $param = tao_models_classes_service_Parameter::fromResource(
+                current($values[WfEngineOntology::PROPERTY_CALL_OF_SERVICES_ACTUAL_PARAMETER_OUT])
+            );
+
             $serviceCall->setOutParameter($param);
         }
         return $serviceCall;
     }
-    
+
     /**
      * Serialize the current serivceCall object to a string
      *

--- a/models/classes/service/class.ServiceCall.php
+++ b/models/classes/service/class.ServiceCall.php
@@ -205,10 +205,7 @@ class tao_models_classes_service_ServiceCall implements JsonSerializable
         return self::fromJson($data);
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'service' => $this->serviceDefinitionId,

--- a/models/classes/service/class.VariableParameter.php
+++ b/models/classes/service/class.VariableParameter.php
@@ -19,7 +19,7 @@
  *
  */
 
-use \oat\generis\model\data\Ontology;
+use oat\generis\model\data\Ontology;
 use oat\tao\model\WfEngineOntology;
 
 /**
@@ -29,7 +29,7 @@ use oat\tao\model\WfEngineOntology;
  * @access public
  * @author Joel Bout, <joel@taotesting.com>
  * @package tao
-
+ * phpcs:disable Squiz.Classes.ValidClassName
  */
 class tao_models_classes_service_VariableParameter extends tao_models_classes_service_Parameter
 {
@@ -37,7 +37,7 @@ class tao_models_classes_service_VariableParameter extends tao_models_classes_se
      * @var core_kernel_classes_Resource
      */
     private $variable;
-    
+
     /**
      * Instantiates an new variable parameter
      *
@@ -49,7 +49,7 @@ class tao_models_classes_service_VariableParameter extends tao_models_classes_se
         parent::__construct($definition);
         $this->variable = $variable;
     }
-    
+
     /**
      * Returns the variable proividing the value
      * for this parameter
@@ -60,7 +60,7 @@ class tao_models_classes_service_VariableParameter extends tao_models_classes_se
     {
         return $this->variable;
     }
-    
+
     /**
      * (non-PHPdoc)
      * @see tao_models_classes_service_Parameter::serialize()

--- a/models/classes/service/class.VariableParameter.php
+++ b/models/classes/service/class.VariableParameter.php
@@ -75,7 +75,7 @@ class tao_models_classes_service_VariableParameter extends tao_models_classes_se
         return $resource;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'def' => $this->getDefinition()->getUri(),

--- a/models/classes/taskQueue/Task/AbstractTask.php
+++ b/models/classes/taskQueue/Task/AbstractTask.php
@@ -278,7 +278,7 @@ abstract class AbstractTask implements TaskInterface
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $cloneMetadata = $this->metadata;
 

--- a/models/classes/taskQueue/Task/CallbackTask.php
+++ b/models/classes/taskQueue/Task/CallbackTask.php
@@ -98,7 +98,7 @@ final class CallbackTask extends AbstractTask implements CallbackTaskInterface
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $callableClassOrArray = $this->getCallable();
 

--- a/models/classes/taskQueue/TaskLog/DataTablePayload.php
+++ b/models/classes/taskQueue/TaskLog/DataTablePayload.php
@@ -55,8 +55,11 @@ class DataTablePayload implements DataTablePayloadInterface, \Countable
      * @param TaskLogBrokerInterface    $broker
      * @param DatatableRequestInterface $request
      */
-    public function __construct(TaskLogFilter $filter, TaskLogBrokerInterface $broker, DatatableRequestInterface $request)
-    {
+    public function __construct(
+        TaskLogFilter $filter,
+        TaskLogBrokerInterface $broker,
+        DatatableRequestInterface $request
+    ) {
         $this->taskLogFilter = $filter;
         $this->broker = $broker;
         $this->request = $request;
@@ -65,7 +68,8 @@ class DataTablePayload implements DataTablePayloadInterface, \Countable
     }
 
     /**
-     * You can pass an anonymous function to customise the final payload: either to change the value of a field or to add extra field(s);
+     * You can pass an anonymous function to customise the final payload: either to change the value of a field or
+     * to add extra field(s);
      *
      * The function will be bind to the task log entity (TaskLogEntity) so $this can be used inside of the closure.
      * The return value needs to be an array.

--- a/models/classes/taskQueue/TaskLog/DataTablePayload.php
+++ b/models/classes/taskQueue/TaskLog/DataTablePayload.php
@@ -183,10 +183,7 @@ class DataTablePayload implements DataTablePayloadInterface, \Countable
         }
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->getPayload();
     }

--- a/models/classes/taskQueue/TaskLog/DataTablePayload.php
+++ b/models/classes/taskQueue/TaskLog/DataTablePayload.php
@@ -97,10 +97,7 @@ class DataTablePayload implements DataTablePayloadInterface, \Countable
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getPayload()
+    public function getPayload(): array
     {
         $countTotal = $this->count();
 
@@ -121,15 +118,13 @@ class DataTablePayload implements DataTablePayloadInterface, \Countable
         // get customised data
         $customisedData = $this->getCustomisedData($collection);
 
-        $data = [
+        return [
             'rows'    => $limit,
             'page'    => $page,
             'amount'  => count($collection),
             'total'   => ceil($countTotal / $limit),
             'data'    => $customisedData ?: $collection->toArray(),
         ];
-
-        return $data;
     }
 
     /**

--- a/models/classes/taskQueue/TaskLog/Decorator/CategoryEntityDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/CategoryEntityDecorator.php
@@ -41,10 +41,7 @@ class CategoryEntityDecorator extends TaskLogEntityDecorator
         $this->taskLogService = $taskLogService;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/models/classes/taskQueue/TaskLog/Decorator/HasFileEntityDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/HasFileEntityDecorator.php
@@ -45,8 +45,11 @@ class HasFileEntityDecorator extends TaskLogEntityDecorator
      */
     private $fileReferenceSerializer;
 
-    public function __construct(EntityInterface $entity, FileSystemService $fileSystemService, FileReferenceSerializer $fileReferenceSerializer)
-    {
+    public function __construct(
+        EntityInterface $entity,
+        FileSystemService $fileSystemService,
+        FileReferenceSerializer $fileReferenceSerializer
+    ) {
         parent::__construct($entity);
 
         $this->fileSystemService = $fileSystemService;

--- a/models/classes/taskQueue/TaskLog/Decorator/HasFileEntityDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/HasFileEntityDecorator.php
@@ -53,10 +53,7 @@ class HasFileEntityDecorator extends TaskLogEntityDecorator
         $this->fileReferenceSerializer = $fileReferenceSerializer;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/models/classes/taskQueue/TaskLog/Decorator/RedirectUrlEntityDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/RedirectUrlEntityDecorator.php
@@ -21,6 +21,7 @@
 
 namespace oat\tao\model\taskQueue\TaskLog\Decorator;
 
+use common_Logger;
 use oat\oatbox\user\User;
 use oat\tao\model\accessControl\AclProxy;
 use oat\tao\model\taskQueue\TaskLog\Entity\EntityInterface;
@@ -93,10 +94,17 @@ class RedirectUrlEntityDecorator extends TaskLogEntityDecorator
             );
             if ($hasAccess) {
                 $data = array_merge($data, [
-                    'redirectUrl' => _url('redirectTaskToInstance', 'Redirector', 'taoBackOffice', $params)
+                    'redirectUrl' => _url(
+                        'redirectTaskToInstance',
+                        'Redirector',
+                        'taoBackOffice',
+                        $params
+                    )
                 ]);
             } else {
-                \common_Logger::w('User \'' . $user->getIdentifier() . '\' does not have access to redirectTaskToInstance');
+                common_Logger::w(
+                    'User \'' . $user->getIdentifier() . '\' does not have access to redirectTaskToInstance'
+                );
             }
         }
 

--- a/models/classes/taskQueue/TaskLog/Decorator/RedirectUrlEntityDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/RedirectUrlEntityDecorator.php
@@ -55,10 +55,7 @@ class RedirectUrlEntityDecorator extends TaskLogEntityDecorator
         $this->user = $user;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/models/classes/taskQueue/TaskLog/Decorator/SimpleManagementCollectionDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/SimpleManagementCollectionDecorator.php
@@ -58,8 +58,13 @@ class SimpleManagementCollectionDecorator extends TaskLogCollectionDecorator
      */
     private $fileReferenceSerializer;
 
-    public function __construct(CollectionInterface $collection, TaskLogInterface $taskLogService, FileSystemService $fileSystemService, FileReferenceSerializer $fileReferenceSerializer, $reportIncluded)
-    {
+    public function __construct(
+        CollectionInterface $collection,
+        TaskLogInterface $taskLogService,
+        FileSystemService $fileSystemService,
+        FileReferenceSerializer $fileReferenceSerializer,
+        $reportIncluded
+    ) {
         parent::__construct($collection);
 
         $this->fileSystemService = $fileSystemService;

--- a/models/classes/taskQueue/TaskLog/Decorator/SimpleManagementCollectionDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/SimpleManagementCollectionDecorator.php
@@ -99,10 +99,7 @@ class SimpleManagementCollectionDecorator extends TaskLogCollectionDecorator
         return $data;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/models/classes/taskQueue/TaskLog/Decorator/TaskLogCollectionDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/TaskLogCollectionDecorator.php
@@ -99,10 +99,7 @@ abstract class TaskLogCollectionDecorator implements CollectionInterface
         return $this->collection->getIds();
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->collection->jsonSerialize();
     }

--- a/models/classes/taskQueue/TaskLog/Decorator/TaskLogEntityDecorator.php
+++ b/models/classes/taskQueue/TaskLog/Decorator/TaskLogEntityDecorator.php
@@ -146,10 +146,7 @@ abstract class TaskLogEntityDecorator implements EntityInterface
         return $this->entity->getResourceUriFromReport();
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->entity->jsonSerialize();
     }

--- a/models/classes/taskQueue/TaskLog/Entity/TaskLogEntity.php
+++ b/models/classes/taskQueue/TaskLog/Entity/TaskLogEntity.php
@@ -116,13 +116,17 @@ class TaskLogEntity implements EntityInterface
             $row[TaskLogBrokerInterface::COLUMN_PARENT_ID],
             $row[TaskLogBrokerInterface::COLUMN_TASK_NAME],
             CategorizedStatus::createFromString($row[TaskLogBrokerInterface::COLUMN_STATUS]),
-            isset($row[TaskLogBrokerInterface::COLUMN_PARAMETERS]) ? json_decode($row[TaskLogBrokerInterface::COLUMN_PARAMETERS], true) : [],
+            isset($row[TaskLogBrokerInterface::COLUMN_PARAMETERS])
+                ? json_decode($row[TaskLogBrokerInterface::COLUMN_PARAMETERS], true)
+                : [],
             isset($row[TaskLogBrokerInterface::COLUMN_LABEL]) ? $row[TaskLogBrokerInterface::COLUMN_LABEL] : '',
             isset($row[TaskLogBrokerInterface::COLUMN_OWNER]) ? $row[TaskLogBrokerInterface::COLUMN_OWNER] : '',
             self::parseDateTime($row, TaskLogBrokerInterface::COLUMN_CREATED_AT, $dateFormat),
             self::parseDateTime($row, TaskLogBrokerInterface::COLUMN_UPDATED_AT, $dateFormat),
             NewReport::jsonUnserialize($row[TaskLogBrokerInterface::COLUMN_REPORT]),
-            isset($row[TaskLogBrokerInterface::COLUMN_MASTER_STATUS]) ? $row[TaskLogBrokerInterface::COLUMN_MASTER_STATUS] : false
+            isset($row[TaskLogBrokerInterface::COLUMN_MASTER_STATUS])
+                ? $row[TaskLogBrokerInterface::COLUMN_MASTER_STATUS]
+                : false
         );
     }
 
@@ -232,7 +236,8 @@ class TaskLogEntity implements EntityInterface
     /**
      * Returns the file name from the generated report.
      *
-     * NOTE: it is not 100% sure that the returned string is really a file name because different reports set different values as data.
+     * NOTE: it is not 100% sure that the returned string is really a file name because different reports set different
+     * values as data.
      * So this return value can be any kind of string. Please check the file whether it exist or not before usage.
      *
      * @return string
@@ -308,12 +313,19 @@ class TaskLogEntity implements EntityInterface
 
         if ($this->createdAt instanceof \DateTime) {
             $rs['createdAt'] = $this->createdAt->getTimestamp();
-            $rs['createdAtElapsed'] = (new \DateTime('now', new \DateTimeZone('UTC')))->getTimestamp() - $this->createdAt->getTimestamp();
+            $rs['createdAtElapsed'] = (new \DateTime(
+                'now',
+                new \DateTimeZone('UTC')
+            )
+                )->getTimestamp() - $this->createdAt->getTimestamp();
         }
 
         if ($this->updatedAt instanceof \DateTime) {
             $rs['updatedAt'] = $this->updatedAt->getTimestamp();
-            $rs['updatedAtElapsed'] = (new \DateTime('now', new \DateTimeZone('UTC')))->getTimestamp() - $this->updatedAt->getTimestamp();
+            $rs['updatedAtElapsed'] = (new \DateTime(
+                'now',
+                new \DateTimeZone('UTC')
+            ))->getTimestamp() - $this->updatedAt->getTimestamp();
         }
 
         if ($this->report instanceof Report) {

--- a/models/classes/taskQueue/TaskLog/Entity/TaskLogEntity.php
+++ b/models/classes/taskQueue/TaskLog/Entity/TaskLogEntity.php
@@ -282,10 +282,7 @@ class TaskLogEntity implements EntityInterface
         return $uri;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/models/classes/taskQueue/TaskLog/TaskLogCollection.php
+++ b/models/classes/taskQueue/TaskLog/TaskLogCollection.php
@@ -63,9 +63,6 @@ class TaskLogCollection implements CollectionInterface
         return new static([]);
     }
 
-    /**
-     * @inheritdoc
-     */
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/models/classes/taskQueue/TaskLog/TasksLogsStats.php
+++ b/models/classes/taskQueue/TaskLog/TasksLogsStats.php
@@ -25,9 +25,9 @@ use JsonSerializable;
 
 class TasksLogsStats implements JsonSerializable
 {
-    const COMPLETED_TASKS = 'completedtasks';
-    const FAILED_TASKS = 'failedtasks';
-    const IN_PROGRESS_TASKS = 'inprogresstasks';
+    public const COMPLETED_TASKS = 'completedtasks';
+    public const FAILED_TASKS = 'failedtasks';
+    public const IN_PROGRESS_TASKS = 'inprogresstasks';
 
     /** @var  int */
     private $numberOfTasksCompleted;
@@ -57,7 +57,11 @@ class TasksLogsStats implements JsonSerializable
      */
     public static function buildFromArray(array $rawData)
     {
-        return new self($rawData[static::COMPLETED_TASKS], $rawData[static::FAILED_TASKS], $rawData[static::IN_PROGRESS_TASKS]);
+        return new self(
+            $rawData[static::COMPLETED_TASKS],
+            $rawData[static::FAILED_TASKS],
+            $rawData[static::IN_PROGRESS_TASKS]
+        );
     }
 
     /**

--- a/models/classes/taskQueue/TaskLog/TasksLogsStats.php
+++ b/models/classes/taskQueue/TaskLog/TasksLogsStats.php
@@ -84,10 +84,7 @@ class TasksLogsStats implements JsonSerializable
         return $this->numberOfTasksInProgress;
     }
 
-    /**
-     * @inheritdoc
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'numberOfTasksCompleted' => $this->numberOfTasksCompleted,


### PR DESCRIPTION
Missing return type for jsonSerialise cause a massive amount of warnings in logs. 