### PR TITLE
fix: Create item or class from subclasses from search result items in left sidebar (Search by label) for TAO Enterprise INVALSI PHP 8.1

### DIFF
--- a/models/classes/resources/ListResourceLookup.php
+++ b/models/classes/resources/ListResourceLookup.php
@@ -21,7 +21,6 @@
 
 namespace oat\tao\model\resources;
 
-use core_kernel_classes_Class;
 use core_kernel_classes_Resource;
 use oat\generis\model\OntologyRdf;
 use oat\generis\model\OntologyAwareTrait;
@@ -157,10 +156,11 @@ class ListResourceLookup extends ConfigurableService implements ResourceLookup
                 'label'             => $resource->getLabel(),
                 'type'              => 'instance',
                 'signature'         => $this->getSignatureGenerator()->generate($resource->getUri()),
-                'classSignature'    => $this->getSignatureGenerator()->generate(
-                    $this->getParentClass($resource)->getUri()
-                ),
             ];
+            $parentClassUri = $this->getParentClassUri($resource);
+            if ($parentClassUri !== null) {
+                $data['classSignature'] = $this->getSignatureGenerator()->generate($parentClassUri);
+            }
         }
         return $data;
     }
@@ -180,12 +180,11 @@ class ListResourceLookup extends ConfigurableService implements ResourceLookup
         return $this->getServiceManager()->get(SignatureGenerator::class);
     }
 
-    private function getParentClass(core_kernel_classes_Resource $resource): ?core_kernel_classes_Class
+    private function getParentClassUri(core_kernel_classes_Resource $resource): ?string
     {
         $parentClassUri = $resource->getOnePropertyValue($resource->getProperty(OntologyRdf::RDF_TYPE));
-        
         return $parentClassUri !== null
-            ? $resource->getClass($parentClassUri)
+            ? $parentClassUri->getUri()
             : null;
     }
 }

--- a/models/classes/resources/ListResourceLookup.php
+++ b/models/classes/resources/ListResourceLookup.php
@@ -151,11 +151,11 @@ class ListResourceLookup extends ConfigurableService implements ResourceLookup
         if (!is_null($resource) && $resource->exists()) {
             $resourceTypes = array_keys($resource->getTypes());
             $data = [
-                'uri'               => $resource->getUri(),
-                'classUri'          => $resourceTypes[0],
-                'label'             => $resource->getLabel(),
-                'type'              => 'instance',
-                'signature'         => $this->getSignatureGenerator()->generate($resource->getUri()),
+                'uri'        => $resource->getUri(),
+                'classUri'   => $resourceTypes[0],
+                'label'      => $resource->getLabel(),
+                'type'       => 'instance',
+                'signature'  => $this->getSignatureGenerator()->generate($resource->getUri()),
             ];
             $parentClassUri = $this->getParentClassUri($resource);
             if ($parentClassUri !== null) {

--- a/views/js/provider/resources.js
+++ b/views/js/provider/resources.js
@@ -21,7 +21,7 @@
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
- define([
+define([
     'lodash',
     'i18n',
     'util/url',

--- a/views/js/provider/resources.js
+++ b/views/js/provider/resources.js
@@ -21,7 +21,7 @@
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-define([
+ define([
     'lodash',
     'i18n',
     'util/url',
@@ -89,7 +89,7 @@ define([
                 applyClassSignatures(resources.children, resources.signature || signature);
             }
             if (resources.nodes) {
-                applyClassSignatures(resources.nodes, resources.classSignature);
+                applyClassSignatures(resources.nodes, resources.nodes.classSignature);
             }
         }
         return resources;


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/LSI-1825

**Description**: Fix 500 error when clicking on 'New class'/'New Item' on search result items in left sidebar (Search by label) for TAO Enterprise INVALSI PHP 8.1

Whenever a user tries to click on 'New class'/'New Item' on search result items if the item is under subclasses, there’s a 500 error message popping up related to Security Exception and missing signature of the parent class. 

![image](https://user-images.githubusercontent.com/57711251/220572357-03eae584-31f3-4ba3-8f3d-5e6b73894bef.png)

This issue can be reproduced in the following environment
http://test-invalsi_php_8_1.playground.kitchen.it.taocloud.org:49721/
admin/admin

To test this fix or enable the left sidebar search, you will need to activate the resourceSelector. In the config file config/tao/client_lib_config_registry.conf.php, simply add:

```
        'layout/tree/loader' => array(
            'treeProvider' => 'resource-selector'
        ),
```
The fix has been deployed to the following environment
http://test-chinnu.playground.kitchen.it.taocloud.org:41411/tao/Main/login
admin/admin