### PR TITLE
fix: add retryTask for all exceptions

### DIFF
--- a/models/classes/webhooks/WebhookTaskService.php
+++ b/models/classes/webhooks/WebhookTaskService.php
@@ -41,13 +41,13 @@ class WebhookTaskService extends ConfigurableService implements WebhookTaskServi
      * Create and enqueue task for performing webhook
      * @param WebhookTaskParams $webhookTaskParams
      */
-    public function createTask(WebhookTaskParams $webhookTaskParams)
+    public function createTask(WebhookTaskParams $webhookTaskParams, string $label = 'Event Webhook')
     {
         $task = new WebhookTask();
         $this->propagate($task);
 
         /** @var QueueDispatcherInterface $queueDispatcher */
-        $this->getQueueDispatcher()->createTask($task, (array) $webhookTaskParams, 'Event Webhook');
+        $this->getQueueDispatcher()->createTask($task, (array) $webhookTaskParams, $label);
     }
 
     /**

--- a/models/classes/webhooks/WebhookTaskServiceInterface.php
+++ b/models/classes/webhooks/WebhookTaskServiceInterface.php
@@ -39,6 +39,7 @@ interface WebhookTaskServiceInterface
     /**
      * Create and enqueue task for performing webhook
      * @param WebhookTaskParams $webhookTaskParams
+     * @param string $label
      */
-    public function createTask(WebhookTaskParams $webhookTaskParams);
+    public function createTask(WebhookTaskParams $webhookTaskParams, string $label = 'Event Webhook');
 }

--- a/models/classes/webhooks/task/WebhookTask.php
+++ b/models/classes/webhooks/task/WebhookTask.php
@@ -25,7 +25,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
-use common_Exception;
+use Throwable;
 use GuzzleHttp\Psr7\Request;
 use oat\oatbox\extension\AbstractAction;
 use oat\tao\model\taskQueue\Task\TaskAwareInterface;
@@ -127,11 +127,11 @@ class WebhookTask extends AbstractAction implements TaskAwareInterface
                 $this->getTaskContext(),
                 $requestException
             );
-        } catch (common_Exception $requestException) {
+        } catch (Throwable $exception) {
             $this->retryTask();
             $errorReport = $this->getWebhookTaskReports()->reportInternalException(
                 $this->getTaskContext(),
-                $requestException
+                $exception
             );
         }
 


### PR DESCRIPTION
For some cases related to remote publications, webhook can be failed because delivery is not ready yet. 
We can manage all those retries using `retryMax` option in the webhookRegistry.conf.php if it will be needed.

We need also backport it to v51.0.3