### PR TITLE
feat: Extend DataAccessControlChangedEvent to support updates skipping nested resources

### DIFF
--- a/models/classes/event/DataAccessControlChangedEvent.php
+++ b/models/classes/event/DataAccessControlChangedEvent.php
@@ -29,7 +29,7 @@ class DataAccessControlChangedEvent implements Event
     /** @var string */
     private $resourceId;
 
-    /** @var string */
+    /** @var ?string */
     private $rootResourceId;
 
     /** @var array */
@@ -45,16 +45,16 @@ class DataAccessControlChangedEvent implements Event
 
     public function __construct(
         string $resourceId,
-        string $rootResourceId, // @todo Update unit tests
         array $addRemove,
         bool $isRecursive = false,
-        bool $applyToNestedResources = false
+        bool $applyToNestedResources = false,
+        string $rootResourceId = null
     ) {
         $this->resourceId = $resourceId;
-        $this->rootResourceId = $rootResourceId;
         $this->addRemove = $addRemove;
         $this->isRecursive = $isRecursive;
         $this->applyToNestedResources = $applyToNestedResources;
+        $this->rootResourceId = $rootResourceId;
     }
 
     public function getName(): string
@@ -67,7 +67,7 @@ class DataAccessControlChangedEvent implements Event
         return $this->resourceId;
     }
 
-    public function getRrootResourceId(): string
+    public function getRootResourceId(): ?string
     {
         return $this->rootResourceId;
     }

--- a/models/classes/event/DataAccessControlChangedEvent.php
+++ b/models/classes/event/DataAccessControlChangedEvent.php
@@ -39,18 +39,18 @@ class DataAccessControlChangedEvent implements Event
     private $isRecursive;
 
     /** @var bool */
-    private $processNestedResources;
+    private $applyToNestedResources;
 
     public function __construct(
         string $resourceId,
         array $addRemove,
         bool $isRecursive = false,
-        bool $processNestedResources = false
+        bool $applyToNestedResources = false
     ) {
         $this->resourceId = $resourceId;
         $this->addRemove = $addRemove;
         $this->isRecursive = $isRecursive;
-        $this->processNestedResources = $processNestedResources;
+        $this->applyToNestedResources = $applyToNestedResources;
     }
 
     public function getName(): string
@@ -69,15 +69,15 @@ class DataAccessControlChangedEvent implements Event
     }
 
     /**
-     * @deprecated Use isProcessNestedResources cause processing recursively causes performance issues
+     * @deprecated Use applyToNestedResources because processing recursively causes performance issues
      */
     public function isRecursive(): bool
     {
         return $this->isRecursive;
     }
 
-    public function isProcessNestedResources(): bool
+    public function applyToNestedResources(): bool
     {
-        return $this->processNestedResources;
+        return $this->applyToNestedResources;
     }
 }

--- a/models/classes/event/DataAccessControlChangedEvent.php
+++ b/models/classes/event/DataAccessControlChangedEvent.php
@@ -38,8 +38,7 @@ class DataAccessControlChangedEvent implements Event
      */
     private $isRecursive;
 
-    /** @var bool */
-    private $applyToNestedResources;
+    private bool $applyToNestedResources;
 
     public function __construct(
         string $resourceId,

--- a/models/classes/event/DataAccessControlChangedEvent.php
+++ b/models/classes/event/DataAccessControlChangedEvent.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2023 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/models/classes/event/DataAccessControlChangedEvent.php
+++ b/models/classes/event/DataAccessControlChangedEvent.php
@@ -29,6 +29,9 @@ class DataAccessControlChangedEvent implements Event
     /** @var string */
     private $resourceId;
 
+    /** @var string */
+    private $rootResourceId;
+
     /** @var array */
     private $addRemove;
 
@@ -42,11 +45,13 @@ class DataAccessControlChangedEvent implements Event
 
     public function __construct(
         string $resourceId,
+        string $rootResourceId, // @todo Update unit tests
         array $addRemove,
         bool $isRecursive = false,
         bool $applyToNestedResources = false
     ) {
         $this->resourceId = $resourceId;
+        $this->rootResourceId = $rootResourceId;
         $this->addRemove = $addRemove;
         $this->isRecursive = $isRecursive;
         $this->applyToNestedResources = $applyToNestedResources;
@@ -60,6 +65,11 @@ class DataAccessControlChangedEvent implements Event
     public function getResourceId(): string
     {
         return $this->resourceId;
+    }
+
+    public function getRrootResourceId(): string
+    {
+        return $this->rootResourceId;
     }
 
     public function getOperations(string $operation): array

--- a/models/classes/event/DataAccessControlChangedEvent.php
+++ b/models/classes/event/DataAccessControlChangedEvent.php
@@ -33,7 +33,7 @@ class DataAccessControlChangedEvent implements Event
     private $addRemove;
 
     /**
-     * @deprecated Use $processNestedResources cause processing recursively causes performance issues
+     * @deprecated Use $applyToNestedResources cause processing recursively causes performance issues
      * @var bool
      */
     private $isRecursive;

--- a/models/classes/event/DataAccessControlChangedEvent.php
+++ b/models/classes/event/DataAccessControlChangedEvent.php
@@ -32,14 +32,25 @@ class DataAccessControlChangedEvent implements Event
     /** @var array */
     private $addRemove;
 
-    /** @var bool */
+    /**
+     * @deprecated Use $processNestedResources cause processing recursively causes performance issues
+     * @var bool
+     */
     private $isRecursive;
 
-    public function __construct(string $resourceId, array $addRemove, bool $isRecursive = false)
-    {
+    /** @var bool */
+    private $processNestedResources;
+
+    public function __construct(
+        string $resourceId,
+        array $addRemove,
+        bool $isRecursive = false,
+        bool $processNestedResources = false
+    ) {
         $this->resourceId = $resourceId;
         $this->addRemove = $addRemove;
         $this->isRecursive = $isRecursive;
+        $this->processNestedResources = $processNestedResources;
     }
 
     public function getName(): string
@@ -57,8 +68,16 @@ class DataAccessControlChangedEvent implements Event
         return array_keys($this->addRemove[$operation] ?? []);
     }
 
+    /**
+     * @deprecated Use isProcessNestedResources cause processing recursively causes performance issues
+     */
     public function isRecursive(): bool
     {
         return $this->isRecursive;
+    }
+
+    public function isProcessNestedResources(): bool
+    {
+        return $this->processNestedResources;
     }
 }

--- a/models/classes/listener/DataAccessControlChangedListener.php
+++ b/models/classes/listener/DataAccessControlChangedListener.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2023 (original work) Open Assessment Technologies SA;
  *
  */
 

--- a/models/classes/listener/DataAccessControlChangedListener.php
+++ b/models/classes/listener/DataAccessControlChangedListener.php
@@ -50,15 +50,6 @@ class DataAccessControlChangedListener extends ConfigurableService
         $resource = $this->getResource($event->getResourceId());
 
         if ($event->getResourceId() !== $event->getRootResourceId()) {
-            $this->getLogger()->debug(
-                sprintf(
-                    'Not triggering %s for non-root resource %s [%s]',
-                    UpdateDataAccessControlInIndex::class,
-                    $resource->getLabel(),
-                    $resource->getUri()
-                )
-            );
-
             return;
         }
 

--- a/models/classes/listener/DataAccessControlChangedListener.php
+++ b/models/classes/listener/DataAccessControlChangedListener.php
@@ -49,7 +49,11 @@ class DataAccessControlChangedListener extends ConfigurableService
         /** @noinspection PhpUnhandledExceptionInspection */
         $resource = $this->getResource($event->getResourceId());
 
-        if ($resource->isClass() && !$event->isRecursive()) {
+        /**
+         * @TODO Verify if we already had a bug before when a class ACL is updated,
+         * but not marking `recursive` if it never applied
+         */
+        if ($resource->isClass() && !$event->isProcessNestedResources()) {
             return;
         }
 

--- a/models/classes/listener/DataAccessControlChangedListener.php
+++ b/models/classes/listener/DataAccessControlChangedListener.php
@@ -49,11 +49,7 @@ class DataAccessControlChangedListener extends ConfigurableService
         /** @noinspection PhpUnhandledExceptionInspection */
         $resource = $this->getResource($event->getResourceId());
 
-        /**
-         * @TODO Verify if we already had a bug before when a class ACL is updated,
-         * but not marking `recursive` if it never applied
-         */
-        if ($resource->isClass() && !$event->applyToNestedResources()) {
+        if ($resource->isClass() && !$event->applyToNestedResources() && !$event->isRecursive()) {
             return;
         }
 

--- a/models/classes/listener/DataAccessControlChangedListener.php
+++ b/models/classes/listener/DataAccessControlChangedListener.php
@@ -49,7 +49,7 @@ class DataAccessControlChangedListener extends ConfigurableService
         /** @noinspection PhpUnhandledExceptionInspection */
         $resource = $this->getResource($event->getResourceId());
 
-        if ($event->getResourceId() !== $event->getRrootResourceId()) {
+        if ($event->getResourceId() !== $event->getRootResourceId()) {
             $this->getLogger()->debug(
                 sprintf(
                     'Not triggering %s for non-root resource %s [%s]',

--- a/models/classes/listener/DataAccessControlChangedListener.php
+++ b/models/classes/listener/DataAccessControlChangedListener.php
@@ -38,8 +38,6 @@ class DataAccessControlChangedListener extends ConfigurableService
 
     public function handleEvent(DataAccessControlChangedEvent $event): void
     {
-        $this->getLogger()->debug('triggering index update on DataAccessControlChanged event');
-
         if (!$this->getServiceLocator()->get(AdvancedSearchChecker::class)->isEnabled()) {
             return;
         }
@@ -53,7 +51,8 @@ class DataAccessControlChangedListener extends ConfigurableService
          * @TODO Verify if we already had a bug before when a class ACL is updated,
          * but not marking `recursive` if it never applied
          */
-        if ($resource->isClass() && !$event->isProcessNestedResources()) {
+        if ($resource->isClass() && !$event->applyToNestedResources()) {
+            $this->getLogger()->debug('Exit early from ' . self::class);
             return;
         }
 

--- a/models/classes/listener/DataAccessControlChangedListener.php
+++ b/models/classes/listener/DataAccessControlChangedListener.php
@@ -38,6 +38,8 @@ class DataAccessControlChangedListener extends ConfigurableService
 
     public function handleEvent(DataAccessControlChangedEvent $event): void
     {
+        $this->getLogger()->debug('triggering index update on DataAccessControlChanged event');
+
         if (!$this->getServiceLocator()->get(AdvancedSearchChecker::class)->isEnabled()) {
             return;
         }
@@ -52,7 +54,6 @@ class DataAccessControlChangedListener extends ConfigurableService
          * but not marking `recursive` if it never applied
          */
         if ($resource->isClass() && !$event->applyToNestedResources()) {
-            $this->getLogger()->debug('Exit early from ' . self::class);
             return;
         }
 

--- a/models/classes/taskQueue/Worker/AbstractWorker.php
+++ b/models/classes/taskQueue/Worker/AbstractWorker.php
@@ -236,7 +236,7 @@ abstract class AbstractWorker implements WorkerInterface, ServiceManagerAwareInt
     {
         return strlen($task->getLabel()) > 255
             ? '...' . substr($task->getLabel(), -252)
-            : $task->getLabel();
+            :  $task->getLabel();
     }
 
 

--- a/models/classes/taskQueue/Worker/AbstractWorker.php
+++ b/models/classes/taskQueue/Worker/AbstractWorker.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2017-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 

--- a/models/classes/taskQueue/Worker/AbstractWorker.php
+++ b/models/classes/taskQueue/Worker/AbstractWorker.php
@@ -236,7 +236,7 @@ abstract class AbstractWorker implements WorkerInterface, ServiceManagerAwareInt
     {
         return strlen($task->getLabel()) > 255
             ? '...' . substr($task->getLabel(), -252)
-            :  $task->getLabel();
+            : $task->getLabel();
     }
 
 

--- a/models/classes/taskQueue/Worker/AbstractWorker.php
+++ b/models/classes/taskQueue/Worker/AbstractWorker.php
@@ -73,7 +73,17 @@ abstract class AbstractWorker implements WorkerInterface, ServiceManagerAwareInt
             $report = Report::createInfo(__('Running task %s', $task->getId()));
             try {
                 $this->startUserSession($task);
-                $this->logInfo(sprintf('Processing task %s [%s]', $task->getLabel(), $task->getId()), $this->getLogContext());
+
+                $this->logInfo(
+                    sprintf(
+                        'Processing task %s [%s]',
+                        (strlen($task->getLabel()) > 255
+                            ? '...' . substr($task->getLabel(), -252)
+                            : $task->getLabel()),
+                        $task->getId()
+                    ),
+                    $this->getLogContext()
+                );
 
                 //Database operation in task log
                 $rowsTouched = $this->taskLog->setStatus($task->getId(), TaskLogInterface::STATUS_RUNNING, TaskLogInterface::STATUS_DEQUEUED);

--- a/models/classes/taskQueue/Worker/AbstractWorker.php
+++ b/models/classes/taskQueue/Worker/AbstractWorker.php
@@ -73,7 +73,7 @@ abstract class AbstractWorker implements WorkerInterface, ServiceManagerAwareInt
             $report = Report::createInfo(__('Running task %s', $task->getId()));
             try {
                 $this->startUserSession($task);
-                $this->logInfo('Processing task ' . $task->getId(), $this->getLogContext());
+                $this->logInfo(sprintf('Processing task %s [%s]', $task->getLabel(), $task->getId()), $this->getLogContext());
 
                 //Database operation in task log
                 $rowsTouched = $this->taskLog->setStatus($task->getId(), TaskLogInterface::STATUS_RUNNING, TaskLogInterface::STATUS_DEQUEUED);

--- a/test/unit/model/listener/DataAccessControlChangedListenerTest.php
+++ b/test/unit/model/listener/DataAccessControlChangedListenerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2023 (original work) Open Assessment Technologies SA;
  *
  */
 

--- a/test/unit/model/listener/DataAccessControlChangedListenerTest.php
+++ b/test/unit/model/listener/DataAccessControlChangedListenerTest.php
@@ -70,23 +70,35 @@ class DataAccessControlChangedListenerTest extends TestCase
     }
 
     /**
-     * @dataProvider provideSuccessfulCases
+     * @dataProvider handleEventSuccessfulCasesDataProvider
      */
-    public function testHandleEventShouldCreateTaskSuccessfully(bool $isRecursive, bool $isclass): void
+    public function testHandleEventShouldCreateTaskSuccessfully(bool $isRecursive, bool $isClass): void
     {
         $documentUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+
         $resource = $this->createMock(core_kernel_classes_Resource::class);
-        $this->advancedSearchChecker->method('isEnabled')->willReturn(true);
 
-        $resource->expects($this->once())->method('getUri')
+        $this->advancedSearchChecker
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $resource
+            ->expects($this->once())
+            ->method('getUri')
             ->willReturn($documentUri);
-        $resource->expects($this->once())->method('isClass')
-            ->willReturn($isclass);
+        $resource
+            ->expects($this->once())
+            ->method('isClass')
+            ->willReturn($isClass);
 
-        $this->logger->expects($this->once())->method('debug')
+        $this->logger
+            ->expects($this->once())
+            ->method('debug')
             ->with('triggering index update on DataAccessControlChanged event');
 
-        $this->ontology->expects($this->once())->method('getResource')
+        $this->ontology
+            ->expects($this->once())
+            ->method('getResource')
             ->willReturn($resource);
 
         $this->queueDispatcher->expects($this->once())
@@ -102,10 +114,12 @@ class DataAccessControlChangedListenerTest extends TestCase
                 false
             );
 
-        $this->sut->handleEvent(new DataAccessControlChangedEvent($documentUri, [], $isRecursive));
+        $this->sut->handleEvent(
+            new DataAccessControlChangedEvent($documentUri, [], $isRecursive, $isRecursive)
+        );
     }
 
-    public function provideSuccessfulCases(): array
+    public function handleEventSuccessfulCasesDataProvider(): array
     {
         return [
             'case event is recursive and resource is NOT a class' => [

--- a/test/unit/model/taskQueue/Worker/AbstractWorkerTest.php
+++ b/test/unit/model/taskQueue/Worker/AbstractWorkerTest.php
@@ -145,8 +145,11 @@ class AbstractWorkerTest extends TestCase
         ]);
 
         $this->modelMock = $this->createMock(Ontology::class);
-        $this->taskMock = $this->createMock(TaskInterface::class);
         $this->reportMock = $this->createMock(\common_report_Report::class);
+        $this->taskMock = $this->createMock(TaskInterface::class);
+        $this->taskMock
+            ->method('getLabel')
+            ->willReturn('Task Label');
 
         $this->subject = new DummyWorker($this->queue, $this->taskLog);
         $this->subject->setServiceLocator($this->serviceLocatorMock);
@@ -359,7 +362,10 @@ class AbstractWorkerTest extends TestCase
 
     private function getCallbackTask(): CallbackTaskInterface
     {
-        return $this->createMock(CallbackTaskInterface::class);
+        $mock = $this->createMock(CallbackTaskInterface::class);
+        $mock->method('getLabel')->willReturn('Task Label');
+
+        return $mock;
     }
 
     /**
@@ -367,7 +373,10 @@ class AbstractWorkerTest extends TestCase
      */
     private function getTaskMockCallback()
     {
-        return $this->createMock(TaskInterface::class);
+        $mock = $this->createMock(TaskInterface::class);
+        $mock->method('getLabel')->willReturn('Task Label');
+
+        return $mock;
     }
 }
 


### PR DESCRIPTION
**Associated Jira issue:** [ADF-1320](https://oat-sa.atlassian.net/browse/ADF-1320)

Changes in this PR introduce a new flag `applyToNestedResources` in `DataAccessControlChangedEvent` that, when is set, makes `DataAccessControlChangedListener` skip updates in search indexes for the class (previously that was the case when passing the recursive flag instead).

As part of this change, this PR updates unit tests to take into account that change and makes modified files to comply with PSR-12 (preventing validation errors in the pipelines).

Related PRs:
- https://github.com/oat-sa/extension-tao-dac-simple/pull/211
- https://github.com/oat-sa/extension-tao-advanced-search/pull/91

[ADF-1320]: https://oat-sa.atlassian.net/browse/ADF-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ