### PR TITLE
feature: update tao-core-sdk to 1.23

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -739,9 +739,9 @@
             "integrity": "sha512-1fAwH0INmP/Xmqn/lvD5Amcpncm8KSMk1IOS2/SZehkspQQnTq4zCOiUwBKttGr18nzzflySX3CUVY4xMuA/LA=="
         },
         "@oat-sa/tao-core-sdk": {
-            "version": "1.22.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.22.0.tgz",
-            "integrity": "sha512-e2cAYI2mJfZ6rlzph9bs352riCZsmfztddjtIM5Mjn5HZvPj8zSiQYHz6t4lI/Yrkfsa2a6vFpkvDpk/QUinzg==",
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-1.23.0.tgz",
+            "integrity": "sha512-JL+sEp1rI0TP8tkBAlgLxb+pJ8N6F7ffvlaAKdqW1swfzIOFSFhWUBZrY0nYwswEuEKAqe4swkPqHzlvYcljFw==",
             "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",
                 "idb-wrapper": "1.7.0",

--- a/views/package.json
+++ b/views/package.json
@@ -15,7 +15,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/expr-eval": "1.3.1",
         "@oat-sa/tao-core-libs": "^0.5.1",
-        "@oat-sa/tao-core-sdk": "^1.22.0",
+        "@oat-sa/tao-core-sdk": "^1.23.0",
         "@oat-sa/tao-core-shared-libs": "1.5.2",
         "@oat-sa/tao-core-ui": "1.66.0",
         "codemirror": "^5.54.0",


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-1010

## What's Changed

- Update tao-core-sdk to 1.23 - Add fallback for new BE error response

## Dependencies PRs

- https://github.com/oat-sa/tao-core-sdk-fe/pull/166
- https://github.com/oat-sa/extension-tao-testqti-previewer/pull/187