### PR TITLE
chore: fix generis dependency for release-50.24.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "oat-sa/lib-tao-elasticsearch": "^2.5.1",
         "oat-sa/composer-npm-bridge": "~0.4.2||dev-master",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": "dev-php8-migration as v16.0.0",
+        "oat-sa/generis": ">=15.22",
         "composer/package-versions-deprecated": "^1.11",
         "paragonie/random_compat": "^2.0",
         "phpdocumentor/reflection-docblock": "^5.2",


### PR DESCRIPTION
Fix generis dependency for release-50.24.5

Error:

```
Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - oat-sa/tao-core v50.24.5 requires oat-sa/generis dev-php8-migration as v16.0.0 -> found oat-sa/generis[dev-fix/resource_tostring_do_not_add_label, ..., dev-prototype/spanner-schema, v0.6.1, 2.7-beta, ..., v2.31.6, v3.0.5, ..., v3.37.0, v4.0.0, ..., v4.4.2, v5.2.0, ..., v5.13.0, v6.1.0, ..., v6.18.0, v7.1.1, ..., v7.14.2, v8.1.0, ..., v8.4.0, v9.0.4, v9.0.6, v9.1.0, v10.0.0, v10.1.0, v10.1.0.1, v11.3.1, ..., v11.6.0.1, v12.0.0, ..., v12.33.2, v13.1.0, ..., v13.14.1, v14.0.0, ..., v14.4.0, v15.0.0, ..., v15.23.1] but it does not match the constraint.
    - oat-sa/lib-tao-elasticsearch[v2.5.1, ..., v2.5.2] require oat-sa/tao-core >=50.5.0||dev-develop -> satisfiable by oat-sa/tao-core[dev-develop, v50.5.0, ..., v50.33.0, v51.0.0, ..., v51.11.0, 9999999-dev].
    - oat-sa/tao-core dev-feat/RFE-530/integration-branch requires oat-sa/lib-tao-elasticsearch ^2.5.1 -> satisfiable by oat-sa/lib-tao-elasticsearch[v2.5.1, v2.5.2].
    - You can only install one version of a package, so only one of these can be installed: oat-sa/tao-core[dev-feat/RFE-530/integration-branch, dev-master, dev-develop, v47.0.0, ..., v47.1.10, v48.0.0, ..., v48.88.0, v49.0.0, ..., v49.6.0, v50.5.0, ..., v50.33.0, v51.0.0, ..., v51.11.0].
    - oat-sa/extension-tao-item dev-f463da7d5b2cd83de7730e00eff2504752b82ba0 requires oat-sa/tao-core dev-feat/RFE-530/integration-branch as v52.0 -> satisfiable by oat-sa/tao-core[dev-feat/RFE-530/integration-branch].
    - Root composer.json requires oat-sa/extension-tao-item dev-f463da7d5b2cd83de7730e00eff2504752b82ba0 as v99.99.99 -> satisfiable by oat-sa/extension-tao-item[dev-f463da7d5b2cd83de7730e00eff2504752b82ba0].
```

