### PR TITLE
chore: bump up TAO_VERSION to 2023.05

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -348,9 +348,9 @@ return [
     ],
     'constants' => [
         #TAO version number
-        'TAO_VERSION' => '2023.04',
+        'TAO_VERSION' => '2023.05',
         #TAO version label
-        'TAO_VERSION_NAME' => '2023.04',
+        'TAO_VERSION_NAME' => '2023.05',
         #the name to display
         'PRODUCT_NAME' => 'TAO',
         #TAO release status, use to add specific footer to TAO, available alpha, beta, demo, stable


### PR DESCRIPTION
just bump up manifest version before creating stabilization branch