### PR TITLE
fix: Change regex to accept CamelCase Migration Names

### DIFF
--- a/scripts/tools/migrations/TaoComparator.php
+++ b/scripts/tools/migrations/TaoComparator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2020-2023 (original work) Open Assessment Technologies SA
  *
  */
 
@@ -53,7 +54,7 @@ class TaoComparator implements Comparator
         $this->extensionHelper = $extensionHelper;
     }
 
-    public function compare(Version $a, Version $b) : int
+    public function compare(Version $a, Version $b): int
     {
         $merged = array_merge(
             $this->extensionsManager->getInstalledExtensions(),
@@ -77,7 +78,11 @@ class TaoComparator implements Comparator
     protected function getMissingExtensions()
     {
         $result = [];
-        foreach ($this->extensionHelper::getMissingExtensionIds($this->extensionsManager->getInstalledExtensions()) as $extId) {
+        $missingExtensions = $this->extensionHelper::getMissingExtensionIds(
+            $this->extensionsManager->getInstalledExtensions()
+        );
+
+        foreach ($missingExtensions as $extId) {
             $result[$extId] = $this->extensionsManager->getExtensionById($extId);
         }
         return $result;

--- a/scripts/tools/migrations/TaoComparator.php
+++ b/scripts/tools/migrations/TaoComparator.php
@@ -27,7 +27,6 @@ use Doctrine\Migrations\Version\Version;
 use common_ext_ExtensionsManager as ExtensionsManager;
 use common_ext_Extension as Extension;
 use helpers_ExtensionHelper as ExtensionHelper;
-use League\Csv\Exception;
 
 /**
  * Class TaoComparator is used by a migration repository to sort migrations by extensions according to
@@ -84,11 +83,10 @@ class TaoComparator implements Comparator
         return $result;
     }
 
-    private function matchExtensionName(string $versionA): array
+    private function matchExtensionName(string $version): array
     {
-        preg_match(self::VERSION_REGEX, $versionA, $matches);
-        $extName = $matches[2];
-        $matches[2] = strtolower($extName[0]) . substr($extName, 1);
+        preg_match(self::VERSION_REGEX, $version, $matches);
+        $matches[2] = lcfirst($matches[2]);
         return $matches;
     }
 }

--- a/scripts/tools/migrations/TaoComparator.php
+++ b/scripts/tools/migrations/TaoComparator.php
@@ -86,6 +86,7 @@ class TaoComparator implements Comparator
     private function matchExtensionName(string $version): array
     {
         preg_match(self::VERSION_REGEX, $version, $matches);
+        //Make sure that extension name is starting from small letter
         $matches[2] = lcfirst($matches[2]);
         return $matches;
     }

--- a/test/unit/scripts/tools/migrations/TaoComparatorTest.php
+++ b/test/unit/scripts/tools/migrations/TaoComparatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -14,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2020-2023 (original work) Open Assessment Technologies SA
  *
  */
 
@@ -35,7 +36,6 @@ use helpers_ExtensionHelper as ExtensionHelper;
  */
 class TaoComparatorTest extends TestCase
 {
-
     public function testCompare()
     {
         $extensionsManagerMock = $this->getExtensionManagerMock();

--- a/test/unit/scripts/tools/migrations/TaoComparatorTest.php
+++ b/test/unit/scripts/tools/migrations/TaoComparatorTest.php
@@ -46,6 +46,7 @@ class TaoComparatorTest extends TestCase
             $extensionBar4 = new Version('Version4_bar'),
             $extensionBar2 = new Version('Version2_bar'),
             $extensionBaz1 = new Version('Version1_baz'),
+            $illigalVersion = new Version('Version1Baz'),
         ];
 
         usort($versions, [$comparator, 'compare']);
@@ -57,6 +58,7 @@ class TaoComparatorTest extends TestCase
             'Version3_foo',
             'Version5_foo',
             'Version1_baz',
+            'Version1Baz',
             'Version2_bar',
             'Version4_bar',
         ], $versionKeys);

--- a/test/unit/scripts/tools/migrations/TaoComparatorTest.php
+++ b/test/unit/scripts/tools/migrations/TaoComparatorTest.php
@@ -46,7 +46,8 @@ class TaoComparatorTest extends TestCase
             $extensionBar4 = new Version('Version4_bar'),
             $extensionBar2 = new Version('Version2_bar'),
             $extensionBaz1 = new Version('Version1_baz'),
-            $illigalVersion = new Version('Version1Baz'),
+            $camelCaseVersion = new Version('Version1Baz'),
+            $smallLetterExtension = new Version('Version1baz'),
         ];
 
         usort($versions, [$comparator, 'compare']);
@@ -59,6 +60,7 @@ class TaoComparatorTest extends TestCase
             'Version5_foo',
             'Version1_baz',
             'Version1Baz',
+            'Version1baz',
             'Version2_bar',
             'Version4_bar',
         ], $versionKeys);


### PR DESCRIPTION
In the qtiItemPci extension according to camel case class name rules, we changed migration names that did not match to regex used to sort migrations. 

- Version202209131056091465QtiItemPci.php
- Version202209141533261465QtiItemPci.php
- Version202211031046021465QtiItemPci.php

This fix will match those migrations and order them in the correct way. 