### PR TITLE
fix: Fix call to EventManager::trigger()

### DIFF
--- a/models/classes/resources/Service/ClassMover.php
+++ b/models/classes/resources/Service/ClassMover.php
@@ -84,7 +84,7 @@ class ClassMover implements ResourceTransferInterface
         $status = $from->editPropertyValues($this->ontology->getProperty(OntologyRdfs::RDFS_SUBCLASSOF), $to);
 
         if ($status) {
-            $this->eventManager->trigger(ClassMovedEvent::class);
+            $this->eventManager->trigger(new ClassMovedEvent($from));
 
             if (isset($this->permissionCopier) && $command->useDestinationAcl()) {
                 $this->changePermissions($to, $from);

--- a/test/unit/models/classes/resources/Service/ClassMoverTest.php
+++ b/test/unit/models/classes/resources/Service/ClassMoverTest.php
@@ -148,6 +148,14 @@ class ClassMoverTest extends TestCase
             ->with($subclassOfProperty, $toClass)
             ->willReturn(true);
 
+        $classMovedEvent = $this->createMock(ClassMovedEvent::class);
+        $classMovedEvent
+            ->method('getName')
+            ->willReturn(ClassMovedEvent::class);
+        $classMovedEvent
+            ->method('getClass')
+            ->willReturn($fromClass);
+
         $this->eventManager
             ->expects($this->once())
             ->method('trigger')

--- a/test/unit/models/classes/resources/Service/ClassMoverTest.php
+++ b/test/unit/models/classes/resources/Service/ClassMoverTest.php
@@ -151,7 +151,7 @@ class ClassMoverTest extends TestCase
         $this->eventManager
             ->expects($this->once())
             ->method('trigger')
-            ->with(ClassMovedEvent::class);
+            ->with(new ClassMovedEvent($fromClass));
 
         if ($issetPermissionCopier) {
             $this->sut->withPermissionCopier($this->permissionCopier);


### PR DESCRIPTION
**Associated Jira issue:** [AUT-3113](https://oat-sa.atlassian.net/browse/AUT-3113)

Fixes a call to `EventManager::trigger()` so it provides a proper event instance instead of just the event name.

This is needed so the event carries the URI for the moved class: AdvancedSearch expects the event to be a `ClassMovedEvent` for that purpose [here](https://github.com/oat-sa/extension-tao-advanced-search/blob/master/model/Metadata/Listener/ClassMovedListener.php#L41).

<details>
<summary>Result for unit tests</summary>

```
root@0c0fdaa88445:/var/www/html# vendor/bin/phpunit tao/test/unit/
PHPUnit 8.5.33 by Sebastian Bergmann and contributors.

.............................................................   61 / 1694 (  3%)
.............................................................  122 / 1694 (  7%)
.............................................................  183 / 1694 ( 10%)
.............................................................  244 / 1694 ( 14%)
.............................................................  305 / 1694 ( 18%)
.............................................................  366 / 1694 ( 21%)
.............................................................  427 / 1694 ( 25%)
.............................................................  488 / 1694 ( 28%)
.............................................................  549 / 1694 ( 32%)
.............................................................  610 / 1694 ( 36%)
.........I...................................................  671 / 1694 ( 39%)
.............................................................  732 / 1694 ( 43%)
.............................................................  793 / 1694 ( 46%)
.............................................................  854 / 1694 ( 50%)
..................................II.........................  915 / 1694 ( 54%)
.............................................................  976 / 1694 ( 57%)
............................................................. 1037 / 1694 ( 61%)
......................................................SSSS... 1098 / 1694 ( 64%)
..I..................S....................................... 1159 / 1694 ( 68%)
............................................................. 1220 / 1694 ( 72%)
............................................................. 1281 / 1694 ( 75%)
............................................................. 1342 / 1694 ( 79%)
............................................................. 1403 / 1694 ( 82%)
............................................................. 1464 / 1694 ( 86%)
............................................................. 1525 / 1694 ( 90%)
............................................................. 1586 / 1694 ( 93%)
............................................................. 1647 / 1694 ( 97%)
...............................................               1694 / 1694 (100%)

Time: 6.58 seconds, Memory: 66.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 1694, Assertions: 4638, Skipped: 5, Incomplete: 4.
root@0c0fdaa88445:/var/www/html# 

```

</details>

[AUT-3113]: https://oat-sa.atlassian.net/browse/AUT-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ