### PR TITLE
Fix/solar 270/allow section visibility filter apply on get navigation elements by group

### DIFF
--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -407,7 +407,7 @@ class tao_actions_Main extends tao_actions_CommonModule
          * @var  Perspective $perspective
          */
         foreach (MenuService::getPerspectivesByGroup($groupId) as $i => $perspective) {
-            if (!$this->sectionVisibilityFilter->isVisible($perspective->getId())) {
+            if (!$this->getSectionVisibilityFilter()->isVisible($perspective->getId())) {
                 $this->logDebug(
                     sprintf(
                         "Perspective %s has been ignored base on Section Visibility Filter",

--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -401,7 +401,22 @@ class tao_actions_Main extends tao_actions_CommonModule
     private function getNavigationElementsByGroup($groupId)
     {
         $entries = [];
+
+        /**
+         * @var int $i
+         * @var  Perspective $perspective
+         */
         foreach (MenuService::getPerspectivesByGroup($groupId) as $i => $perspective) {
+            if (!$this->sectionVisibilityFilter->isVisible($perspective->getId())) {
+                $this->logDebug(
+                    sprintf(
+                        "Perspective %s has been ignored base on Section Visibility Filter",
+                        $perspective->getId()
+                    )
+                );
+                continue;
+            }
+
             $binding = $perspective->getBinding();
             $children = $this->getMenuElementChildren($perspective);
 


### PR DESCRIPTION
This change will allow disabling all navigation buttons using the feature flag with SectionVisibilityFilter config. 

How to use: 
- Create migration that will add desired section (perspective) to be disabled base on feature flag
- Define feature flag
- Clear cache