### PR TITLE
feature/REL 985/application cache warmup after instance refresh

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "oat-sa/jig": "~0.2",
         "oat-sa/composer-npm-bridge": "~0.4.2||dev-master",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.24",
+        "oat-sa/generis": ">=15.25",
         "composer/package-versions-deprecated": "^1.11",
         "paragonie/random_compat": "^2.0",
         "phpdocumentor/reflection-docblock": "^5.2",

--- a/migrations/Version202306211310042234_tao.php
+++ b/migrations/Version202306211310042234_tao.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023(original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\event\EventManager;
+use oat\tao\model\featureFlag\Listener\FeatureFlagCacheWarmupListener;
+use oat\tao\model\Language\Listener\LanguageCacheWarmupListener;
+use oat\tao\model\menu\Listener\MenuCacheWarmupListener;
+use oat\tao\model\routing\Listener\AnnotationCacheWarmupListener;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Migration to register cache warmup listeners
+ */
+final class Version202306211310042234_tao extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register cache warmup listeners.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->attach(CacheWarmupEvent::class, [AnnotationCacheWarmupListener::class, 'handleEvent']);
+        $eventManager->attach(CacheWarmupEvent::class, [FeatureFlagCacheWarmupListener::class, 'handleEvent']);
+        $eventManager->attach(CacheWarmupEvent::class, [LanguageCacheWarmupListener::class, 'handleEvent']);
+        $eventManager->attach(CacheWarmupEvent::class, [MenuCacheWarmupListener::class, 'handleEvent']);
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+
+    public function down(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->detach(CacheWarmupEvent::class, [AnnotationCacheWarmupListener::class, 'handleEvent']);
+        $eventManager->detach(CacheWarmupEvent::class, [FeatureFlagCacheWarmupListener::class, 'handleEvent']);
+        $eventManager->detach(CacheWarmupEvent::class, [LanguageCacheWarmupListener::class, 'handleEvent']);
+        $eventManager->detach(CacheWarmupEvent::class, [MenuCacheWarmupListener::class, 'handleEvent']);
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+}

--- a/models/classes/Language/Listener/LanguageCacheWarmupListener.php
+++ b/models/classes/Language/Listener/LanguageCacheWarmupListener.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\Language\Listener;
+
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\reporting\Report;
+
+class LanguageCacheWarmupListener
+{
+    private \tao_models_classes_LanguageService $languageService;
+
+    public function __construct(\tao_models_classes_LanguageService $languageService)
+    {
+        $this->languageService = $languageService;
+    }
+
+    public function handleEvent(CacheWarmupEvent $event): void
+    {
+        $this->languageService->generateAll();
+        $event->addReport(Report::createInfo('Generated translations cache.'));
+    }
+}

--- a/models/classes/LanguageServiceProvider.php
+++ b/models/classes/LanguageServiceProvider.php
@@ -26,6 +26,7 @@ use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\tao\model\Language\Business\Contract\LanguageRepositoryInterface;
 use oat\tao\model\Language\Repository\LanguageRepository;
+use oat\tao\model\Language\Listener\LanguageCacheWarmupListener;
 use Symfony\Component\DependencyInjection\Loader\Configurator\Traits\FactoryTrait;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use tao_models_classes_LanguageService;
@@ -36,6 +37,9 @@ use oat\tao\model\Language\Business\Specification\LanguageClassSpecification;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
+/**
+ * @codeCoverageIgnore
+ */
 class LanguageServiceProvider implements ContainerServiceProviderInterface
 {
     use FactoryTrait;
@@ -65,6 +69,15 @@ class LanguageServiceProvider implements ContainerServiceProviderInterface
             ->args(
                 [
                     service(Ontology::SERVICE_ID),
+                    service(tao_models_classes_LanguageService::class),
+                ]
+            );
+
+        $services
+            ->set(LanguageCacheWarmupListener::class, LanguageCacheWarmupListener::class)
+            ->public()
+            ->args(
+                [
                     service(tao_models_classes_LanguageService::class),
                 ]
             );

--- a/models/classes/featureFlag/FeatureFlagServiceProvider.php
+++ b/models/classes/featureFlag/FeatureFlagServiceProvider.php
@@ -27,12 +27,16 @@ use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\oatbox\cache\SimpleCache;
 use oat\tao\model\ClientLibConfigRegistry;
+use oat\tao\model\featureFlag\Listener\FeatureFlagCacheWarmupListener;
 use oat\tao\model\featureFlag\Repository\FeatureFlagRepository;
 use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
+/**
+ * @codeCoverageIgnore
+ */
 class FeatureFlagServiceProvider implements ContainerServiceProviderInterface
 {
     public function __invoke(ContainerConfigurator $configurator): void
@@ -66,6 +70,15 @@ class FeatureFlagServiceProvider implements ContainerServiceProviderInterface
                 [
                     service(Ontology::SERVICE_ID),
                     service(SimpleCache::SERVICE_ID),
+                ]
+            );
+
+        $services
+            ->set(FeatureFlagCacheWarmupListener::class, FeatureFlagCacheWarmupListener::class)
+            ->public()
+            ->args(
+                [
+                    service(FeatureFlagRepositoryInterface::class)
                 ]
             );
     }

--- a/models/classes/featureFlag/Listener/FeatureFlagCacheWarmupListener.php
+++ b/models/classes/featureFlag/Listener/FeatureFlagCacheWarmupListener.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\featureFlag\Listener;
+
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\reporting\Report;
+use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
+
+class FeatureFlagCacheWarmupListener
+{
+    private FeatureFlagRepositoryInterface $featureFlagRepo;
+
+    public function __construct(
+        FeatureFlagRepositoryInterface $featureFlagRepo
+    ) {
+        $this->featureFlagRepo = $featureFlagRepo;
+    }
+
+    public function handleEvent(CacheWarmupEvent $event): void
+    {
+        $this->featureFlagRepo->list();
+        $event->addReport(Report::createInfo('Generated feature flags cache.'));
+    }
+}

--- a/models/classes/menu/Listener/MenuCacheWarmupListener.php
+++ b/models/classes/menu/Listener/MenuCacheWarmupListener.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\menu\Listener;
+
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\reporting\Report;
+use oat\tao\model\menu\MenuService;
+
+/**
+ * @codeCoverageIgnore Ignore because it uses static method which can't be easily tested
+ */
+class MenuCacheWarmupListener
+{
+    public function handleEvent(CacheWarmupEvent $event): void
+    {
+        MenuService::readStructure();
+        $event->addReport(Report::createInfo('Generated menu cache.'));
+    }
+}

--- a/models/classes/menu/MenuServiceProvider.php
+++ b/models/classes/menu/MenuServiceProvider.php
@@ -25,8 +25,12 @@ declare(strict_types=1);
 namespace oat\tao\model\menu;
 
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\tao\model\menu\Listener\MenuCacheWarmupListener;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+/**
+ * @codeCoverageIgnore
+ */
 class MenuServiceProvider implements ContainerServiceProviderInterface
 {
     public function __invoke(ContainerConfigurator $configurator): void
@@ -34,5 +38,8 @@ class MenuServiceProvider implements ContainerServiceProviderInterface
         $services = $configurator->services();
 
         $services->set(MenuService::class, MenuService::class);
+        $services
+            ->set(MenuCacheWarmupListener::class, MenuCacheWarmupListener::class)
+            ->public();
     }
 }

--- a/models/classes/routing/Listener/AnnotationCacheWarmupListener.php
+++ b/models/classes/routing/Listener/AnnotationCacheWarmupListener.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\routing\Listener;
+
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\reporting\Report;
+use oat\tao\helpers\ControllerHelper;
+use oat\tao\model\routing\AnnotationReaderService;
+
+/**
+ * @codeCoverageIgnore Ignore because it uses static method which can't be easily tested
+ */
+class AnnotationCacheWarmupListener
+{
+    private AnnotationReaderService $annotationReader;
+    private \common_ext_ExtensionsManager $extensionsManager;
+
+    public function __construct(
+        AnnotationReaderService $annotationReader,
+        \common_ext_ExtensionsManager $extensionsManager
+    ) {
+        $this->annotationReader = $annotationReader;
+        $this->extensionsManager = $extensionsManager;
+    }
+
+    public function handleEvent(CacheWarmupEvent $event): void
+    {
+        foreach ($this->extensionsManager->getInstalledExtensionsIds() as $extId) {
+            foreach (ControllerHelper::getControllers($extId) as $controllerClassName) {
+                $this->annotationReader->getAnnotations($controllerClassName, '');
+                foreach (ControllerHelper::getActions($controllerClassName) as $actionName) {
+                    $this->annotationReader->getAnnotations($controllerClassName, $actionName);
+                }
+            }
+        }
+        $event->addReport(Report::createInfo('Generated annotations cache.'));
+    }
+}

--- a/models/classes/routing/ServiceProvider/RoutingServiceProvider.php
+++ b/models/classes/routing/ServiceProvider/RoutingServiceProvider.php
@@ -25,12 +25,17 @@ namespace oat\tao\model\routing\ServiceProvider;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\oatbox\log\LoggerService;
 use oat\oatbox\service\ServiceManager;
+use oat\tao\model\routing\AnnotationReaderService;
+use oat\tao\model\routing\Listener\AnnotationCacheWarmupListener;
 use oat\tao\model\routing\ResolverFactory;
 use oat\tao\model\routing\Service\ActionFinder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
+/**
+ * @codeCoverageIgnore
+ */
 class RoutingServiceProvider implements ContainerServiceProviderInterface
 {
     public function __invoke(ContainerConfigurator $configurator): void
@@ -51,6 +56,16 @@ class RoutingServiceProvider implements ContainerServiceProviderInterface
             ->args(
                 [
                     service(ServiceManager::class),
+                ]
+            );
+
+        $services
+            ->set(AnnotationCacheWarmupListener::class, AnnotationCacheWarmupListener::class)
+            ->public()
+            ->args(
+                [
+                    service(AnnotationReaderService::class),
+                    service(\common_ext_ExtensionsManager::SERVICE_ID)
                 ]
             );
     }

--- a/scripts/install/RegisterEvents.php
+++ b/scripts/install/RegisterEvents.php
@@ -23,10 +23,16 @@ declare(strict_types=1);
 
 namespace oat\tao\scripts\install;
 
+use oat\generis\model\data\event\CacheWarmupEvent;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\extension\InstallAction;
 use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\reporting\Report;
+use oat\tao\model\featureFlag\Listener\FeatureFlagCacheWarmupListener;
+use oat\tao\model\Language\Listener\LanguageCacheWarmupListener;
+use oat\tao\model\menu\Listener\MenuCacheWarmupListener;
 use oat\tao\model\migrations\MigrationsService;
+use oat\tao\model\routing\Listener\AnnotationCacheWarmupListener;
 
 /**
  * Class RegisterEvents
@@ -44,8 +50,24 @@ class RegisterEvents extends InstallAction
             \common_ext_event_ExtensionInstalled::class,
             [MigrationsService::SERVICE_ID, 'extensionInstalled']
         );
+        $eventManager->attach(
+            CacheWarmupEvent::class,
+            [AnnotationCacheWarmupListener::class, 'handleEvent']
+        );
+        $eventManager->attach(
+            CacheWarmupEvent::class,
+            [FeatureFlagCacheWarmupListener::class, 'handleEvent']
+        );
+        $eventManager->attach(
+            CacheWarmupEvent::class,
+            [LanguageCacheWarmupListener::class, 'handleEvent']
+        );
+        $eventManager->attach(
+            CacheWarmupEvent::class,
+            [MenuCacheWarmupListener::class, 'handleEvent']
+        );
         $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
 
-        return new \common_report_Report(\common_report_Report::TYPE_SUCCESS, 'Events registered');
+        return Report::createSuccess('Events registered');
     }
 }

--- a/test/unit/models/classes/Language/Listener/LanguageCacheWarmupListenerTest.php
+++ b/test/unit/models/classes/Language/Listener/LanguageCacheWarmupListenerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\tao\test\unit\model\Language\Listener;
+
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\reporting\Report;
+use oat\tao\model\Language\Listener\LanguageCacheWarmupListener;
+use PHPUnit\Framework\TestCase;
+
+class LanguageCacheWarmupListenerTest extends TestCase
+{
+    /**
+     * @var \tao_models_classes_LanguageService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $languageService;
+    private LanguageCacheWarmupListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->languageService = $this->createMock(\tao_models_classes_LanguageService::class);
+        $this->listener = new LanguageCacheWarmupListener(
+            $this->languageService
+        );
+    }
+
+    public function testHandleEvent(): void
+    {
+        $this->languageService
+            ->expects($this->once())
+            ->method('generateAll');
+
+        $this->listener->handleEvent(new CacheWarmupEvent());
+    }
+
+    public function testReportCreated(): void
+    {
+        $testEvent = new CacheWarmupEvent();
+        $this->listener->handleEvent($testEvent);
+
+        $reports = $testEvent->getReports();
+        $this->assertCount(1, $reports);
+        $this->assertInstanceOf(Report::class, $reports[0]);
+        $this->assertEquals('Generated translations cache.', $reports[0]->getMessage());
+    }
+}

--- a/test/unit/models/classes/featureFlag/Listener/FeatureFlagCacheWarmupListenerTest.php
+++ b/test/unit/models/classes/featureFlag/Listener/FeatureFlagCacheWarmupListenerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\tao\unit\test\model\featureFlag\Listener;
+
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\reporting\Report;
+use oat\tao\model\featureFlag\Listener\FeatureFlagCacheWarmupListener;
+use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+class FeatureFlagCacheWarmupListenerTest extends TestCase
+{
+    /**
+     * @var FeatureFlagRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private $featureFlagRepoMock;
+    private FeatureFlagCacheWarmupListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->featureFlagRepoMock = $this->createMock(FeatureFlagRepositoryInterface::class);
+
+        $this->listener = new FeatureFlagCacheWarmupListener(
+            $this->featureFlagRepoMock
+        );
+    }
+
+    public function testHandleEvent(): void
+    {
+        $this->featureFlagRepoMock
+            ->expects($this->once())
+            ->method('list');
+
+        $this->listener->handleEvent(new CacheWarmupEvent());
+    }
+
+    public function testReportCreated(): void
+    {
+        $testEvent = new CacheWarmupEvent();
+
+        $this->listener->handleEvent($testEvent);
+
+        $reports = $testEvent->getReports();
+        $this->assertCount(1, $reports);
+        $this->assertInstanceOf(Report::class, $reports[0]);
+        $this->assertEquals('Generated feature flags cache.', $reports[0]->getMessage());
+    }
+}


### PR DESCRIPTION
## Goal
Premium EC2 instances are recycled every night. This clears the application cache and results in slow first requests until the cache is refilled. The purpose of this PR is to implement a solution for warming up the cache after the instance refresh to improve the performance of the first requests.

## Changelog
- feat: add new command which allow to warmup of the application cache.

## How to test / use
You can run following command to execute  command. `--clear` flag clens up cache before warming it up and can be useful in case of issues or interrupted execution of previous command
```bash
php index.php 'oat\generis\scripts\tools\ApplicationCacheWarmup' --clear
```

## Dependencies
- https://github.com/oat-sa/generis/pull/1051