### PR TITLE
fix: fix copy of copied classes

### DIFF
--- a/models/classes/resources/CopierServiceProvider.php
+++ b/models/classes/resources/CopierServiceProvider.php
@@ -142,6 +142,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
 
         $services
             ->set(ResourceTransferProxy::class, ResourceTransferProxy::class)
+            ->share(false)
             ->public()
             ->args(
                 [


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1545

We need to fix the possibility of copying already copied classes.

How to test:

1. Go to items and create a new folder/class
2. Copy this class
3. Try to copy the folder you got in step 2

**After switching to the new version cache should be deleted to generate a new DI cache**