### PR TITLE
fix: fix markers population in generis.conf

### DIFF
--- a/install/class.Setup.php
+++ b/install/class.Setup.php
@@ -154,6 +154,13 @@ class tao_install_Setup implements Action
         }
 
         $global = $parameters['configuration']['global'];
+
+        $markers = new ConfigurationMarkers(
+            new SerializableSecretDtoFactory(),
+            $this->getLogger()
+        );
+
+        $global = $markers->replaceMarkers($global);
         $options['module_namespace'] = $global['namespace'];
         $options['instance_name'] = $global['instance_name'];
         $options['module_url'] = $global['url'];
@@ -228,10 +235,6 @@ class tao_install_Setup implements Action
         }
 
         //@TODO use $serviceManager->getContainer(ConfigurationMarkers::class) after refactoring taoSetup to use full DI
-        $markers = new ConfigurationMarkers(
-            new SerializableSecretDtoFactory(),
-            $this->getLogger()
-        );
         $parameters = $markers->replaceMarkers($parameters);
 
         foreach ($parameters['configuration'] as $extension => $configs) {

--- a/install/init.php
+++ b/install/init.php
@@ -38,11 +38,11 @@ if (function_exists("date_default_timezone_set")) {
 
 require_once($root . 'vendor/autoload.php');
 
+new DotEnvReader();
+
 if (tao_install_utils_System::isTAOInstalled()) {
     require_once($root . 'config/generis.conf.php');
 }
-
-new DotEnvReader();
 
 // Logger service initialization.
 $loggerService = new \oat\oatbox\log\LoggerService();

--- a/install/utils/class.ConfigWriter.php
+++ b/install/utils/class.ConfigWriter.php
@@ -123,6 +123,8 @@ class tao_install_utils_ConfigWriter
                     $content = preg_replace('/(\'' . $name . '\')(.*?)$/ms', '$1, ' . $val . ');', $content);
                 } elseif (is_numeric($val)) {
                     $content = preg_replace('/(\'' . $name . '\')(.*?)$/ms', '$1, ' . $val . ');', $content);
+                } elseif ((method_exists($val, '__toPhpCode'))) {
+                    $content = preg_replace('/(\'' . $name . '\')(.*?)$/ms', '$1, ' . $val->__toPhpCode() . ');', $content);
                 }
             }
             file_put_contents($this->file, $content);


### PR DESCRIPTION
Fix for markers placement in `generis.conf.php`.

Example of .env usage:
<pre>AWS_STACK_CONFIG_ORIGIN=tao-community.docker.localhost/
AWS_STACK_CONFIG_SOURCE=ontologies/tao.rdf
AWS_STACK_CONFIG_NAMESPACE=https://${AWS_STACK_CONFIG_ORIGIN}${AWS_STACK_CONFIG_SOURCE}</pre>

Example of `seed.json` usage:
<pre>"global": {
      "lang": "en-US",
      "mode": "debug",
      "instance_name": "tao-community",
      "namespace": "$ENV{AWS_STACK_CONFIG_NAMESPACE}",
      "url": "https://tao.docker.localhost/",
      "session_name": "tao_community",
      "timezone": "Europe/Luxembourg",
      "import_data": true
    },</pre>