### PR TITLE
fix: return type of oat\tao\model\taskQueue\Queue::count() should be int

### DIFF
--- a/models/classes/taskQueue/Queue.php
+++ b/models/classes/taskQueue/Queue.php
@@ -203,10 +203,8 @@ class Queue implements QueueInterface, TaskLogAwareInterface
 
     /**
      * Count of messages in the queue.
-     *
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->getBroker()->count();
     }

--- a/test/unit/model/taskQueue/QueueTest.php
+++ b/test/unit/model/taskQueue/QueueTest.php
@@ -223,7 +223,7 @@ class QueueTest extends TestCase
         $queueBrokerMock = $this->getMockForAbstractClass(QueueBrokerInterface::class);
 
         $queueBrokerMock->expects($this->once())
-            ->method('count');
+            ->method('count')->willReturn(1);
 
         /** @var Queue|MockObject $queueMock */
         $queueMock = $this->getMockBuilder(Queue::class)


### PR DESCRIPTION
## What's Changed
- Fixed return type of oat\tao\model\taskQueue\Queue::count(): int

## TODO 

- [x] Unit tests
- [x] E2E tests

## How to test
- Run worker process
- Watch logs:
`tail -f /var/www/html/tao.log`
- No errors should be visible in logs:
`Return type of oat\tao\model\taskQueue\Queue::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`