### PR TITLE
feat: Add scripts to enbale neo4j persistance after tao install

### DIFF
--- a/scripts/install/CleanGraphDatabase.php
+++ b/scripts/install/CleanGraphDatabase.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ *
+ */
+
+namespace oat\tao\scripts\install;
+
+use common_persistence_Manager;
+use oat\oatbox\extension\InstallAction;
+
+class CleanGraphDatabase extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $persistenceId = $params[0];
+        if (empty($persistenceId)) {
+            throw new \common_Exception('Persistence id should be provided in script parameters');
+        }
+
+        $persistence = $this->getServiceManager()
+            ->get(common_persistence_Manager::SERVICE_ID)
+            ->getPersistenceById($persistenceId);
+
+        $persistence->run('MATCH (n) DETACH DELETE n');
+        $persistence->run('CALL apoc.schema.assert({}, {}, true) YIELD label, key RETURN *');
+    }
+}

--- a/scripts/install/EnableGraphDatabase.php
+++ b/scripts/install/EnableGraphDatabase.php
@@ -46,11 +46,13 @@ class EnableGraphDatabase extends InstallAction
 
         $complexSearchService = $sm->get(ComplexSearchService::SERVICE_ID);
         $serviceOptions = $complexSearchService->getOptions();
-
         $serviceOptions['shared']['search.neo4j.serialyser'] = false;
-        $serviceOptions['invokables']['search.driver.neo4j'] = '\\oat\\generis\\model\\kernel\\persistence\\starsql\\search\\Neo4jEscapeDriver';
-        $serviceOptions['invokables']['search.neo4j.serialyser'] = '\\oat\\generis\\model\\kernel\\persistence\\starsql\\search\\QuerySerializer';
-        $serviceOptions['invokables']['search.tao.gateway'] = '\\oat\\generis\\model\\kernel\\persistence\\starsql\\search\\GateWay';
+        $serviceOptions['invokables']['search.driver.neo4j'] =
+            '\\oat\\generis\\model\\kernel\\persistence\\starsql\\search\\Neo4jEscapeDriver';
+        $serviceOptions['invokables']['search.neo4j.serialyser'] =
+            '\\oat\\generis\\model\\kernel\\persistence\\starsql\\search\\QuerySerializer';
+        $serviceOptions['invokables']['search.tao.gateway'] =
+            '\\oat\\generis\\model\\kernel\\persistence\\starsql\\search\\GateWay';
         $sm->register(ComplexSearchService::SERVICE_ID, new ComplexSearchService($serviceOptions));
     }
 }

--- a/scripts/install/EnableGraphDatabase.php
+++ b/scripts/install/EnableGraphDatabase.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ *
+ */
+
+namespace oat\tao\scripts\install;
+
+use core_kernel_persistence_smoothsql_SmoothModel;
+use core_kernel_persistence_starsql_StarModel;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
+use oat\oatbox\extension\InstallAction;
+
+class EnableGraphDatabase extends InstallAction
+{
+    public function __invoke($params)
+    {
+        $persistenceId = $params[0];
+        if (empty($persistenceId)) {
+            throw new \common_Exception('Persistence id should be provided in script parameters');
+        }
+
+        $sm = $this->getServiceManager();
+
+        $ontologyService = $sm->get(Ontology::SERVICE_ID);
+        $serviceOptions = $ontologyService->getOptions();
+        $serviceOptions[core_kernel_persistence_smoothsql_SmoothModel::OPTION_PERSISTENCE] = $persistenceId;
+        $sm->register(Ontology::SERVICE_ID, new core_kernel_persistence_starsql_StarModel($serviceOptions));
+
+        $complexSearchService = $sm->get(ComplexSearchService::SERVICE_ID);
+        $serviceOptions = $complexSearchService->getOptions();
+
+        $serviceOptions['shared']['search.neo4j.serialyser'] = false;
+        $serviceOptions['invokables']['search.driver.neo4j'] = '\\oat\\generis\\model\\kernel\\persistence\\starsql\\search\\Neo4jEscapeDriver';
+        $serviceOptions['invokables']['search.neo4j.serialyser'] = '\\oat\\generis\\model\\kernel\\persistence\\starsql\\search\\QuerySerializer';
+        $serviceOptions['invokables']['search.tao.gateway'] = '\\oat\\generis\\model\\kernel\\persistence\\starsql\\search\\GateWay';
+        $sm->register(ComplexSearchService::SERVICE_ID, new ComplexSearchService($serviceOptions));
+    }
+}


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/REL-1294

In order to setup neo4j ontology persistence right after tao installation I propose to use already existing migration script with some additional scripts for setup. As long we are going to support sql database along with neo4j this approach has to be valid and allow us to move forward.

How to test:
1. Use `composer.json` and `seed.json` (only postInstall scripts can be borrowed) files provided
2. Call `taoDockerize install` to install tao
3. Authoring should work without issues and use neo4j database

`seed.json` file which I used to install tao:

```
{
  "seed": {
    "identifier": "studio-neo4j"
  },
  "extensions": [
    "generis",
    "tao",
    "funcAcl",
    "taoBackOffice",
    "taoDacSimple",
    "taoDeliverConnect",
    "taoDelivery",
    "taoDeliveryRdf",
    "taoGroups",
    "taoItems",
    "taoLti",
    "taoLtiConsumer",
    "taoMediaManager",
    "taoOauth",
    "taoQtiItem",
    "taoQtiTest",
    "taoQtiTestPreviewer",
    "taoResultServer",
    "taoScheduler",
    "taoStyles",
    "taoSystemStatus",
    "taoTaskQueue",
    "taoTestPreviewUILoader",
    "taoTests",
    "taoTestTaker",
    "xmlEdit",
    "xmlEditRp",
    "qtiItemPci",
    "taoAdvancedSearch",
    "taoStudio"
  ],
  "super-user": {
    "login": "admin",
    "firstname": "John",
    "lastname": "Doe",
    "email": "",
    "password": "admin"
  },
  "configuration": {
    "global": {
      "lang": "en-US",
      "mode": "debug",
      "instance_name": "studio-neo4j",
      "namespace": "https://studio-neo4j.docker.localhost/ontologies/tao.rdf",
      "url": "https://studio-neo4j.docker.localhost/",
      "session_name": "tao_studio-neo4j",
      "timezone": "Europe/Luxembourg",
      "import_data": true
    },
    "generis": {
      "persistences": {
        "default": {
          "driver": "pdo_mysql",
          "host": "studio-neo4j-mariadb",
          "port": 3306,
          "dbname": "studio-neo4j",
          "user": "root",
          "password": "r00t"
        },
        "neo4j": {
          "driver": "phpneo4j",
          "host": "studio-neo4j-neo4j",
          "port": 7687,
          "dbname": "neo4j",
          "user": "neo4j",
          "password": "neo4studio-neo4j"
        },
        "redis": {
          "driver": "phpredis",
          "host": "studio-neo4j-redis",
          "port": 6379
        },
        "authKeyValue": {
          "driver": "phpredis",
          "host": "studio-neo4j-redis",
          "port": 6379
        },
        "keyValueResult": {
          "driver": "phpredis",
          "host": "studio-neo4j-redis",
          "port": 6379
        }
      },
      "log": {
        "type": "configurableService",
        "class": "oat\\oatbox\\log\\LoggerService",
        "options": {
          "logger": {
            "class": "oat\\oatbox\\log\\logger\\TaoMonolog",
            "options": {
              "name": "tao",
              "handlers": [
                {
                  "class": "Monolog\\Handler\\StreamHandler",
                  "options": [
                    "/var/www/html/data/tao/log/tao-community.log",
                    100
                  ]
                }
              ]
            }
          }
        }
      }
    }
  },
  "postInstall": [
    {
      "class": "oat\\tao\\scripts\\install\\CleanGraphDatabase",
      "params": [
        "neo4j"
      ]
    },
    {
      "class": "oat\\tao\\scripts\\install\\EnableGraphDatabase",
      "params": [
        "neo4j"
      ]
    },
    {
      "class": "oat\\tao\\scripts\\tools\\MigrateSqlToNeo4j",
      "params": [
        "-u",
        "-i",
        "-s",
        "10000",
        "-n",
        "10000",
        "-vvvv"
      ]
    }
  ]
}
```

`composer.json` I used:
```
{
  "name": "oat-sa/tao-studio",
  "license": "GPL-2.0-only",
  "config": {
    "platform": {
      "php": "7.4"
    },
    "preferred-install": "source",
    "allow-plugins": {
      "oat-sa/oatbox-extension-installer": true,
      "oat-sa/composer-npm-bridge": true,
      "php-http/discovery": true
    }
  },
  "support": {
    "issues": "http://forge.taotesting.com",
    "forum": "http://forum.taotesting.com"
  },
  "authors": [
    {
      "homepage": "http://www.taotesting.com",
      "name": "Open Assessment Technologies S.A."
    }
  ],
  "keywords": [
    "tao",
    "oat",
    "computer-based-assessment"
  ],
  "repositories": [
    {
      "type": "vcs",
      "url": "git@github.com:oat-sa/extension-tao-advanced-search.git"
    },
    {
      "type": "vcs",
      "url": "git@github.com:oat-sa/extension-tao-deliver-connect.git"
    },
    {
      "type": "vcs",
      "url": "https://github.com/oat-sa/extension-tao-premium.git"
    },
    {
      "type": "vcs",
      "url": "https://github.com/oat-sa/extension-tao-styles.git"
    },
    {
      "type": "vcs",
      "url": "git@github.com:oat-sa/extension-tao-system-status.git"
    },
    {
      "type": "vcs",
      "url": "git@github.com:oat-sa/extension-tao-test-preview-ui-loader.git"
    },
    {
      "type": "vcs",
      "url": "git@github.com:oat-sa/extension-tao-studio.git"
    },
    {
      "type": "vcs",
      "url": "git@github.com:oat-sa/lib-generis-gcp.git"
    }
  ],
  "homepage": "http://www.taotesting.com",
  "prefer-stable": true,
  "require": {
    "oat-sa/generis": "dev-feat/REL-1197/rdf-import-export-neo4j as 15.28.0",
    "oat-sa/tao-core": "dev-feat/REL-1197/rdf-import-export-neo4j as 53.7.0",
    "oat-sa/extension-tao-funcacl": "7.4.1",
    "oat-sa/extension-tao-dac-simple": "7.10.6",
    "oat-sa/extension-tao-itemqti": "30.2.8",
    "oat-sa/extension-tao-testqti": "47.3.0",
    "oat-sa/extension-tao-item": "12.1.1",
    "oat-sa/extension-tao-itemqti-pci": "8.10.2",
    "oat-sa/extension-tao-test": "16.0.4",
    "oat-sa/extension-tao-lti": "dev-feat/REL-1275/script-create-lti-platform as 15.13.4",
    "oat-sa/extension-tao-mediamanager": "12.37.1",
    "oat-sa/extension-tao-backoffice": "6.12.7",
    "oat-sa/extension-tao-task-queue": "6.8.2",
    "oat-sa/extension-tao-testqti-previewer": "dev-feat/REL-1197/rdf-import-export-neo4j as 3.10.0",
    "oat-sa/extension-tao-advanced-search": "1.14.0",
    "oat-sa/extension-tao-styles": "4.0.5",
    "oat-sa/extension-tao-system-status": "1.6.3",
    "oat-sa/extension-tao-test-preview-ui-loader": "1.26.5",
    "oat-sa/extension-tao-outcome": "dev-feat/REL-1197/rdf-import-export-neo4j as 13.7.2",
    "oat-sa/extension-tao-xmledit": "4.2.0",
    "oat-sa/extension-tao-xmledit-responseprocessing": "2.3.0",
    "oat-sa/extension-tao-lti-consumer": "2.4.1",
    "oat-sa/extension-tao-deliver-connect": "5.17.0",
    "oat-sa/extension-tao-studio": "0.3.0",
    "oat-sa/lib-generis-gcp": "0.2.0"
  },
  "require-dev": {
    "mikey179/vfsstream": "~1",
    "nimut/phpunit-merger": "~1",
    "phpdocumentor/reflection-docblock": "5.3.0 as 2.0.5",
    "phpspec/prophecy": "^1.15",
    "phpunit/phpunit": "^8.5"
  },
  "minimum-stability": "dev",
  "description": "TAO is an Open Source e-Testing platform that empowers you to build, deliver, and share innovative and engaging assessments online – in any language or subject matter."
}
```