### PR TITLE
feature: display asset export errors

### DIFF
--- a/views/templates/form/export.tpl
+++ b/views/templates/form/export.tpl
@@ -54,6 +54,17 @@
                     return params;
                 },
                 taskReportContainer : $container
+            }).on('finished', function(result) {
+                if (result.task
+                    && result.task.report
+                    && _.isArray(result.task.report.children)
+                    && result.task.report.children.length
+                    && result.task.report.children[0]
+                    && result.task.report.children[0].type
+                    && 'error' === result.task.report.children[0].type
+                ) {
+                    this.displayReport(result.task.report.children[0], __('Error'));
+                }
             }).on('error', function(err){
                 //format and display error message to user
                 feedback().error(err);

--- a/views/templates/form/export.tpl
+++ b/views/templates/form/export.tpl
@@ -63,7 +63,7 @@
                     && result.task.report.children[0].type
                     && 'error' === result.task.report.children[0].type
                 ) {
-                    this.displayReport(result.task.report.children[0], __('Error'));
+                    this.displayReport(result.task.report.children[0], __('Error'), '', false);
                 }
             }).on('error', function(err){
                 //format and display error message to user


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/ADF-961

## What's Changed
- Display Asset Export errors in the export report display block.

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update composer with packages

## How to test
- Create a new Passage Asset.
- In Authoring Edit the Asset and embed and image.
- Delete the embedded image - so there will be a broken link in the Asset.
- Try to Export the Asset.
- You should be able to notice the errors in the export report display block.
![error](https://github.com/oat-sa/tao-core/assets/8711268/b91c8bce-8ee3-405b-ac2b-ebdf5164f3c8)
