### PR TITLE
feat: decrease query count by cacheing some RDF property fields 

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -43,6 +43,7 @@ use oat\tao\model\featureFlag\FeatureFlagServiceProvider;
 use oat\tao\model\featureVisibility\FeatureVisibilityServiceProvider;
 use oat\tao\model\import\ServiceProvider\ImportServiceProvider;
 use oat\tao\model\LanguageServiceProvider;
+use oat\tao\model\listener\PropertyServiceProvider;
 use oat\tao\model\Lists\ServiceProvider\ListsServiceProvider;
 use oat\tao\model\menu\MenuServiceProvider;
 use oat\tao\model\metadata\ServiceProvider\MetadataServiceProvider;
@@ -413,6 +414,7 @@ return [
         ClientConfigServiceProvider::class,
         HelperServiceProvider::class,
         MenuServiceProvider::class,
+        PropertyServiceProvider::class,
     ],
     'middlewares' => [
         MiddlewareConfig::class,

--- a/models/classes/listener/ClassPropertyCacheWarmupListener.php
+++ b/models/classes/listener/ClassPropertyCacheWarmupListener.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\listener;
+
+use ArrayIterator;
+use helpers_PropertyCache;
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\generis\model\data\Ontology;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\update\OntologyUpdater;
+
+class ClassPropertyCacheWarmupListener
+{
+    private Ontology $model;
+
+    public function __construct(Ontology $model)
+    {
+        $this->model = $model;
+    }
+
+    public function handleEvent(CacheWarmupEvent $event): void
+    {
+        $existingTriples = OntologyUpdater::getCurrentTriples($this->model);
+
+        $properties = [];
+        foreach ($existingTriples as $triple) {
+            $properties[$triple->predicate][] = $triple->subject;
+        }
+
+        helpers_PropertyCache::warmupCachedValues(new ArrayIterator(array_keys($properties)));
+
+        $event->addReport(Report::createInfo('Generated property cache.'));
+    }
+}

--- a/models/classes/listener/ClassPropertyCacheWarmupListener.php
+++ b/models/classes/listener/ClassPropertyCacheWarmupListener.php
@@ -48,7 +48,7 @@ class ClassPropertyCacheWarmupListener
             $properties[$triple->predicate][] = $triple->subject;
         }
 
-        helpers_PropertyCache::warmupCachedValues(new ArrayIterator(array_keys($properties)));
+        helpers_PropertyCache::warmupCachedValuesByProperties(array_keys($properties));
 
         $event->addReport(Report::createInfo('Generated property cache.'));
     }

--- a/models/classes/listener/PropertyServiceProvider.php
+++ b/models/classes/listener/PropertyServiceProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\listener;
+
+use common_ext_ExtensionsManager;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\oatbox\cache\SimpleCache;
+use oat\tao\model\ClientLibConfigRegistry;
+use oat\tao\model\featureFlag\Listener\FeatureFlagCacheWarmupListener;
+use oat\tao\model\featureFlag\Repository\FeatureFlagRepository;
+use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+/**
+ * @codeCoverageIgnore
+ */
+class PropertyServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services
+            ->set(ClassPropertyCacheWarmupListener::class, ClassPropertyCacheWarmupListener::class)
+            ->public()
+            ->args(
+                [
+                    service(Ontology::SERVICE_ID)
+                ]
+            );
+    }
+}

--- a/scripts/install/RegisterEvents.php
+++ b/scripts/install/RegisterEvents.php
@@ -24,12 +24,13 @@ declare(strict_types=1);
 namespace oat\tao\scripts\install;
 
 use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\extension\InstallAction;
-use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\reporting\Report;
 use oat\tao\model\featureFlag\Listener\FeatureFlagCacheWarmupListener;
 use oat\tao\model\Language\Listener\LanguageCacheWarmupListener;
+use oat\tao\model\listener\ClassPropertyCacheWarmupListener;
 use oat\tao\model\menu\Listener\MenuCacheWarmupListener;
 use oat\tao\model\migrations\MigrationsService;
 use oat\tao\model\routing\Listener\AnnotationCacheWarmupListener;
@@ -65,6 +66,10 @@ class RegisterEvents extends InstallAction
         $eventManager->attach(
             CacheWarmupEvent::class,
             [MenuCacheWarmupListener::class, 'handleEvent']
+        );
+        $eventManager->attach(
+            CacheWarmupEvent::class,
+            [ClassPropertyCacheWarmupListener::class, 'handleEvent']
         );
         $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
 

--- a/scripts/update/OntologyUpdater.php
+++ b/scripts/update/OntologyUpdater.php
@@ -46,7 +46,7 @@ class OntologyUpdater
         self::logDiff($diff);
 
         $diff->applyTo($currentModel);
-        helpers_PropertyCache::clearCachedValues($diff->getTriplesToRemove());
+        helpers_PropertyCache::clearCachedValuesByTriples($diff->getTriplesToRemove());
     }
 
     public static function correctModelId($rdfFile)

--- a/scripts/update/OntologyUpdater.php
+++ b/scripts/update/OntologyUpdater.php
@@ -25,6 +25,7 @@ namespace oat\tao\scripts\update;
 use AppendIterator;
 use common_ext_ExtensionsManager;
 use helpers_RdfDiff;
+use helpers_PropertyCache;
 use oat\generis\model\data\Model;
 use oat\generis\model\data\ModelManager;
 use oat\generis\model\GenerisRdf;
@@ -45,6 +46,7 @@ class OntologyUpdater
         self::logDiff($diff);
 
         $diff->applyTo($currentModel);
+        helpers_PropertyCache::clearCachedValues($diff->getTriplesToRemove());
     }
 
     public static function correctModelId($rdfFile)


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/REL-1279

## Goal
Decrease query count by cacheing some RDF property fields

## Changelog
- feat: added cache for fields isLgDependent, isMultiple, isRelationship and control changes on set and delete data in the database

## How to test
1. Run `tao/scripts/taoInit.php` to check warmup
2. To check how to works method `OntologyUpdater::modelSync` you can add it to `tao/scripts/taoInit.php` because running it in an update depends on the version and does not run every time 