### PR TITLE
feat: DI container services availability during install

### DIFF
--- a/install/class.Installator.php
+++ b/install/class.Installator.php
@@ -254,6 +254,7 @@ class tao_install_Installator
             $setupFileCache = $this->getServiceManager()->get(SetupFileCache::class);
             $cachePath = $file_path . 'generis' . DIRECTORY_SEPARATOR . 'cache';
             $setupFileCache->createDirectory($cachePath);
+            $setupFileCache->createDirectory(GENERIS_CACHE_INSTALL_DI_PATH);
             $this->log('d', $cachePath . ' directory was created!');
 
             foreach ((array)$installData['extra_persistences'] as $k => $persistence) {

--- a/manifest.php
+++ b/manifest.php
@@ -111,6 +111,7 @@ return [
         'http://www.tao.lu/middleware/wfEngine.rdf',
     ],
     'install' => [
+        'containerRebuild' => true,
         'rdf' => [
             __DIR__ . '/models/ontology/tao.rdf',
             __DIR__ . '/models/ontology/taoaclrole.rdf',

--- a/models/classes/clientConfig/ClientConfigServiceProvider.php
+++ b/models/classes/clientConfig/ClientConfigServiceProvider.php
@@ -26,6 +26,7 @@ namespace oat\tao\model\clientConfig;
 
 use common_ext_ExtensionsManager;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\oatbox\log\LoggerService;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\UserLanguageServiceInterface;
@@ -49,16 +50,39 @@ class ClientConfigServiceProvider implements ContainerServiceProviderInterface
         $services = $configurator->services();
 
         $services
+            ->set('security-xsrf-token.link', ServiceLink::class)
+            ->args(
+                [
+                    TokenService::SERVICE_ID
+                ]
+            );
+
+        $services
+            ->set('asset.link', ServiceLink::class)
+            ->args(
+                [
+                    AssetService::SERVICE_ID
+                ]
+            );
+        $services
+            ->set('clientConfig.link', ServiceLink::class)
+            ->args(
+                [
+                    ClientConfigService::SERVICE_ID
+                ]
+            );
+
+        $services
             ->set(ClientConfigStorage::class, ClientConfigStorage::class)
             ->public()
             ->args(
                 [
-                    service(TokenService::SERVICE_ID),
+                    service('security-xsrf-token.link'),
                     service(ClientLibRegistry::class),
                     service(FeatureFlagConfigSwitcher::class),
-                    service(AssetService::SERVICE_ID),
+                    service('asset.link'),
                     service(common_ext_ExtensionsManager::SERVICE_ID),
-                    service(ClientConfigService::SERVICE_ID),
+                    service('clientConfig.link'),
                     service(UserLanguageServiceInterface::SERVICE_ID),
                     service(FeatureFlagRepositoryInterface::class),
                     service(ResolverFactory::class),

--- a/models/classes/clientConfig/ClientConfigServiceProvider.php
+++ b/models/classes/clientConfig/ClientConfigServiceProvider.php
@@ -50,7 +50,7 @@ class ClientConfigServiceProvider implements ContainerServiceProviderInterface
         $services = $configurator->services();
 
         $services
-            ->set('security-xsrf-token.link', ServiceLink::class)
+            ->set(TokenService::SERVICE_ID, ServiceLink::class)
             ->args(
                 [
                     TokenService::SERVICE_ID
@@ -58,14 +58,14 @@ class ClientConfigServiceProvider implements ContainerServiceProviderInterface
             );
 
         $services
-            ->set('asset.link', ServiceLink::class)
+            ->set(AssetService::SERVICE_ID, ServiceLink::class)
             ->args(
                 [
                     AssetService::SERVICE_ID
                 ]
             );
         $services
-            ->set('clientConfig.link', ServiceLink::class)
+            ->set(ClientConfigService::SERVICE_ID, ServiceLink::class)
             ->args(
                 [
                     ClientConfigService::SERVICE_ID
@@ -77,12 +77,12 @@ class ClientConfigServiceProvider implements ContainerServiceProviderInterface
             ->public()
             ->args(
                 [
-                    service('security-xsrf-token.link'),
+                    service(TokenService::SERVICE_ID),
                     service(ClientLibRegistry::class),
                     service(FeatureFlagConfigSwitcher::class),
-                    service('asset.link'),
+                    service(AssetService::SERVICE_ID),
                     service(common_ext_ExtensionsManager::SERVICE_ID),
-                    service('clientConfig.link'),
+                    service(ClientConfigService::SERVICE_ID),
                     service(UserLanguageServiceInterface::SERVICE_ID),
                     service(FeatureFlagRepositoryInterface::class),
                     service(ResolverFactory::class),

--- a/models/classes/clientConfig/ClientConfigStorage.php
+++ b/models/classes/clientConfig/ClientConfigStorage.php
@@ -138,7 +138,7 @@ class ClientConfigStorage
             'module' => $query->getModule(),
         ]);
 
-        $taoBaseWww = $this->assetServiceLink->getService()->getJsBaseWww('tao');
+        $taoBaseWww = $this->assetServiceLink->getJsBaseWww('tao');
         $langCode = $this->sessionService->getCurrentSession()->getInterfaceLanguage();
         $timeout = $this->getClientTimeout();
         $extensionId = $resolver->getExtensionId();
@@ -146,11 +146,11 @@ class ClientConfigStorage
         $this->config = array_merge_recursive(
             [
                 TokenService::JS_DATA_KEY => $this->getEncodedValue(
-                    $this->tokenServiceLink->getService()->getClientConfig()
+                    $this->tokenServiceLink->getClientConfig()
                 ),
                 'extensionsAliases' => $this->clientLibRegistry->getLibAliasMap(),
                 'libConfigs' => $this->getLibConfigs(),
-                'buster' => $this->assetServiceLink->getService()->getCacheBuster(),
+                'buster' => $this->assetServiceLink->getCacheBuster(),
                 'locale' => $langCode,
                 'client_timeout' => $timeout,
                 'crossorigin' => $this->isCrossorigin(),
@@ -160,7 +160,7 @@ class ClientConfigStorage
                         'root_url' => ROOT_URL,
                         'base_url' => $this->getExtension($extensionId)->getConstant('BASE_URL'),
                         'taobase_www' => $taoBaseWww,
-                        'base_www' => $this->assetServiceLink->getService()->getJsBaseWww($extensionId),
+                        'base_www' => $this->assetServiceLink->getJsBaseWww($extensionId),
                         'base_lang' => $this->getLang($langCode),
                         'locale' => $langCode,
                         'base_authoring_lang' => $this->userLanguageService->getAuthoringLanguage(),
@@ -178,7 +178,7 @@ class ClientConfigStorage
             $this->config
         );
 
-        foreach ($this->clientConfigLink->getService()->getExtendedConfig() as $key => $value) {
+        foreach ($this->clientConfigLink->getExtendedConfig() as $key => $value) {
             $this->config[$key] = $this->getEncodedValue($value);
         }
 

--- a/models/classes/import/ServiceProvider/ImportServiceProvider.php
+++ b/models/classes/import/ServiceProvider/ImportServiceProvider.php
@@ -42,15 +42,9 @@ class ImportServiceProvider implements ContainerServiceProviderInterface
         $services = $configurator->services();
 
         $services
-            ->set(ServiceLocator::class, ServiceLocator::class)
-            ->args([[]])
-            ->tag('container.service_locator');
-
-        $services
             ->set('upload_service.link', ServiceLink::class)
             ->args(
                 [
-                    service(ServiceLocator::class),
                     UploadService::SERVICE_ID
                 ]
             );

--- a/models/classes/import/ServiceProvider/ImportServiceProvider.php
+++ b/models/classes/import/ServiceProvider/ImportServiceProvider.php
@@ -42,7 +42,7 @@ class ImportServiceProvider implements ContainerServiceProviderInterface
         $services = $configurator->services();
 
         $services
-            ->set('upload_service.link', ServiceLink::class)
+            ->set(UploadService::SERVICE_ID, ServiceLink::class)
             ->args(
                 [
                     UploadService::SERVICE_ID
@@ -54,7 +54,7 @@ class ImportServiceProvider implements ContainerServiceProviderInterface
             ->public()
             ->args(
                 [
-                    service('upload_service.link'),
+                    service(UploadService::SERVICE_ID),
                 ]
             );
 
@@ -63,7 +63,7 @@ class ImportServiceProvider implements ContainerServiceProviderInterface
             ->public()
             ->args(
                 [
-                    service('upload_service.link'),
+                    service(UploadService::SERVICE_ID),
                 ]
             )
             ->call(

--- a/models/classes/import/service/AgnosticImportHandler.php
+++ b/models/classes/import/service/AgnosticImportHandler.php
@@ -22,13 +22,13 @@ declare(strict_types=1);
 
 namespace oat\tao\model\import\service;
 
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\reporting\Report;
 use oat\tao\model\import\Processor\ImportFileErrorHandlerInterface;
 use oat\tao\model\import\Processor\ImportFileProcessorInterface;
-use oat\tao\model\upload\UploadService;
-use tao_helpers_form_Form;
 use oat\tao\model\import\TaskParameterProviderInterface;
+use tao_helpers_form_Form;
 use tao_models_classes_import_CsvUploadForm;
 use tao_models_classes_import_ImportHandler;
 use Throwable;
@@ -37,8 +37,8 @@ class AgnosticImportHandler implements tao_models_classes_import_ImportHandler, 
 {
     public const STATISTICAL_METADATA_SERVICE_ID = self::class . '::STATISTICAL_METADATA';
 
-    /** @var UploadService */
-    private $uploadService;
+    /** @var ServiceLink */
+    private $uploadServiceLink;
 
     /** @var string|null */
     private $label;
@@ -52,9 +52,9 @@ class AgnosticImportHandler implements tao_models_classes_import_ImportHandler, 
     /** @var ImportFileErrorHandlerInterface|null */
     private $errorHandler;
 
-    public function __construct(UploadService $uploadService)
+    public function __construct(ServiceLink $uploadServiceLink)
     {
-        $this->uploadService = $uploadService;
+        $this->uploadServiceLink = $uploadServiceLink;
     }
 
     public function withFileProcessor(ImportFileProcessorInterface $fileProcessor): self
@@ -111,13 +111,13 @@ class AgnosticImportHandler implements tao_models_classes_import_ImportHandler, 
     public function import($class, $form, $userId = null)
     {
         try {
-            $uploadedFile = $this->uploadService->fetchUploadedFile($form);
+            $uploadedFile = $this->uploadServiceLink->getService()->fetchUploadedFile($form);
 
             return $this->processFile($uploadedFile);
         } catch (Throwable $exception) {
             return $this->handleException($exception);
         } finally {
-            $this->uploadService->remove($uploadedFile);
+            $this->uploadServiceLink->getService()->remove($uploadedFile);
         }
     }
 
@@ -126,7 +126,7 @@ class AgnosticImportHandler implements tao_models_classes_import_ImportHandler, 
      */
     public function getTaskParameters(tao_helpers_form_Form $importForm): array
     {
-        $file = $this->uploadService->getUploadedFlyFile($this->getUploadedFile($importForm));
+        $file = $this->uploadServiceLink->getService()->getUploadedFlyFile($this->getUploadedFile($importForm));
 
         return [
             'uploaded_file' => $file->getPrefix(),

--- a/models/classes/import/service/AgnosticImportHandler.php
+++ b/models/classes/import/service/AgnosticImportHandler.php
@@ -111,13 +111,13 @@ class AgnosticImportHandler implements tao_models_classes_import_ImportHandler, 
     public function import($class, $form, $userId = null)
     {
         try {
-            $uploadedFile = $this->uploadServiceLink->getService()->fetchUploadedFile($form);
+            $uploadedFile = $this->uploadServiceLink->fetchUploadedFile($form);
 
             return $this->processFile($uploadedFile);
         } catch (Throwable $exception) {
             return $this->handleException($exception);
         } finally {
-            $this->uploadServiceLink->getService()->remove($uploadedFile);
+            $this->uploadServiceLink->remove($uploadedFile);
         }
     }
 
@@ -126,7 +126,7 @@ class AgnosticImportHandler implements tao_models_classes_import_ImportHandler, 
      */
     public function getTaskParameters(tao_helpers_form_Form $importForm): array
     {
-        $file = $this->uploadServiceLink->getService()->getUploadedFlyFile($this->getUploadedFile($importForm));
+        $file = $this->uploadServiceLink->getUploadedFlyFile($this->getUploadedFile($importForm));
 
         return [
             'uploaded_file' => $file->getPrefix(),

--- a/models/classes/routing/Listener/AnnotationCacheWarmupListener.php
+++ b/models/classes/routing/Listener/AnnotationCacheWarmupListener.php
@@ -24,23 +24,23 @@ declare(strict_types=1);
 namespace oat\tao\model\routing\Listener;
 
 use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\oatbox\reporting\Report;
 use oat\tao\helpers\ControllerHelper;
-use oat\tao\model\routing\AnnotationReaderService;
 
 /**
  * @codeCoverageIgnore Ignore because it uses static method which can't be easily tested
  */
 class AnnotationCacheWarmupListener
 {
-    private AnnotationReaderService $annotationReader;
+    private ServiceLink $annotationReaderLink;
     private \common_ext_ExtensionsManager $extensionsManager;
 
     public function __construct(
-        AnnotationReaderService $annotationReader,
+        ServiceLink $annotationReaderLink,
         \common_ext_ExtensionsManager $extensionsManager
     ) {
-        $this->annotationReader = $annotationReader;
+        $this->annotationReaderLink = $annotationReaderLink;
         $this->extensionsManager = $extensionsManager;
     }
 
@@ -48,9 +48,9 @@ class AnnotationCacheWarmupListener
     {
         foreach ($this->extensionsManager->getInstalledExtensionsIds() as $extId) {
             foreach (ControllerHelper::getControllers($extId) as $controllerClassName) {
-                $this->annotationReader->getAnnotations($controllerClassName, '');
+                $this->annotationReaderLink->getService()->getAnnotations($controllerClassName, '');
                 foreach (ControllerHelper::getActions($controllerClassName) as $actionName) {
-                    $this->annotationReader->getAnnotations($controllerClassName, $actionName);
+                    $this->annotationReaderLink->getService()->getAnnotations($controllerClassName, $actionName);
                 }
             }
         }

--- a/models/classes/routing/Listener/AnnotationCacheWarmupListener.php
+++ b/models/classes/routing/Listener/AnnotationCacheWarmupListener.php
@@ -48,9 +48,9 @@ class AnnotationCacheWarmupListener
     {
         foreach ($this->extensionsManager->getInstalledExtensionsIds() as $extId) {
             foreach (ControllerHelper::getControllers($extId) as $controllerClassName) {
-                $this->annotationReaderLink->getService()->getAnnotations($controllerClassName, '');
+                $this->annotationReaderLink->getAnnotations($controllerClassName, '');
                 foreach (ControllerHelper::getActions($controllerClassName) as $actionName) {
-                    $this->annotationReaderLink->getService()->getAnnotations($controllerClassName, $actionName);
+                    $this->annotationReaderLink->getAnnotations($controllerClassName, $actionName);
                 }
             }
         }

--- a/models/classes/routing/ServiceProvider/RoutingServiceProvider.php
+++ b/models/classes/routing/ServiceProvider/RoutingServiceProvider.php
@@ -61,7 +61,7 @@ class RoutingServiceProvider implements ContainerServiceProviderInterface
             );
 
         $services
-            ->set('AnnotationReaderService.link', ServiceLink::class)
+            ->set(AnnotationReaderService::SERVICE_ID, ServiceLink::class)
             ->args(
                 [
                     AnnotationReaderService::SERVICE_ID
@@ -73,7 +73,7 @@ class RoutingServiceProvider implements ContainerServiceProviderInterface
             ->public()
             ->args(
                 [
-                    service('AnnotationReaderService.link'),
+                    service(AnnotationReaderService::SERVICE_ID),
                     service(\common_ext_ExtensionsManager::SERVICE_ID)
                 ]
             );

--- a/models/classes/routing/ServiceProvider/RoutingServiceProvider.php
+++ b/models/classes/routing/ServiceProvider/RoutingServiceProvider.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\tao\model\routing\ServiceProvider;
 
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\oatbox\log\LoggerService;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\routing\AnnotationReaderService;
@@ -60,11 +61,19 @@ class RoutingServiceProvider implements ContainerServiceProviderInterface
             );
 
         $services
+            ->set('AnnotationReaderService.link', ServiceLink::class)
+            ->args(
+                [
+                    AnnotationReaderService::SERVICE_ID
+                ]
+            );
+
+        $services
             ->set(AnnotationCacheWarmupListener::class, AnnotationCacheWarmupListener::class)
             ->public()
             ->args(
                 [
-                    service(AnnotationReaderService::class),
+                    service('AnnotationReaderService.link'),
                     service(\common_ext_ExtensionsManager::SERVICE_ID)
                 ]
             );

--- a/scripts/taoInit.php
+++ b/scripts/taoInit.php
@@ -30,6 +30,7 @@ $report = Report::createSuccess('Initialize tao application');
 
 $serviceManager = ServiceManager::getServiceManager();
 $serviceManager->get(SetupFileCache::class)->createDirectory(GENERIS_CACHE_PATH);
+$serviceManager->get(SetupFileCache::class)->createDirectory(GENERIS_CACHE_INSTALL_DI_PATH);
 $report->add(Report::createSuccess('Init filesystem complete.'));
 
 $actionList = [

--- a/scripts/taoUpdate.php
+++ b/scripts/taoUpdate.php
@@ -29,6 +29,7 @@ use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
 $serviceManager = ServiceManager::getServiceManager();
 
 $serviceManager->get(SetupFileCache::class)->createDirectory(GENERIS_CACHE_PATH);
+$serviceManager->get(SetupFileCache::class)->createDirectory(GENERIS_CACHE_INSTALL_DI_PATH);
 
 $action = new UpdateExtensions();
 $action->setServiceLocator($serviceManager);

--- a/test/unit/ServiceLinkStub.php
+++ b/test/unit/ServiceLinkStub.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace oat\tao\test\unit;
-
-use oat\generis\model\DependencyInjection\ServiceLink;
-
-class ServiceLinkStub extends ServiceLink
-{
-}

--- a/test/unit/ServiceLinkStub.php
+++ b/test/unit/ServiceLinkStub.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace oat\tao\test\unit;
+
+use oat\generis\model\DependencyInjection\ServiceLink;
+
+class ServiceLinkStub extends ServiceLink
+{
+}

--- a/test/unit/import/service/AgnosticImportHandlerTest.php
+++ b/test/unit/import/service/AgnosticImportHandlerTest.php
@@ -24,6 +24,7 @@ namespace oat\tao\test\unit\import\service;
 
 use core_kernel_classes_Class;
 use Exception;
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\reporting\Report;
 use oat\tao\model\import\Processor\ImportFileErrorHandlerInterface;
@@ -42,6 +43,9 @@ class AgnosticImportHandlerTest extends TestCase
     /** @var UploadService|MockObject */
     private $uploadService;
 
+    /** @var ServiceLink|MockObject */
+    private $uploadServiceLink;
+
     /** @var ImportFileErrorHandlerInterface|MockObject */
     private $errorHandler;
 
@@ -53,7 +57,8 @@ class AgnosticImportHandlerTest extends TestCase
         $this->errorHandler = $this->createMock(ImportFileErrorHandlerInterface::class);
         $this->processor = $this->createMock(ImportFileProcessorInterface::class);
         $this->uploadService = $this->createMock(UploadService::class);
-        $this->subject = (new AgnosticImportHandler($this->uploadService))
+        $this->uploadServiceLink = $this->createMock(ServiceLink::class);
+        $this->subject = (new AgnosticImportHandler($this->uploadServiceLink))
             ->withErrorHandler($this->errorHandler)
             ->withFileProcessor($this->processor);
     }
@@ -77,6 +82,9 @@ class AgnosticImportHandlerTest extends TestCase
         $form = $this->createMock(tao_helpers_form_Form::class);
         $file = $this->createMock(File::class);
 
+        $this->uploadServiceLink
+            ->method('getService')
+            ->willReturn($this->uploadService);
         $this->uploadService
             ->expects($this->once())
             ->method('fetchUploadedFile')
@@ -104,6 +112,9 @@ class AgnosticImportHandlerTest extends TestCase
         $file = $this->createMock(File::class);
         $exception = new Exception('Does not matter');
 
+        $this->uploadServiceLink
+            ->method('getService')
+            ->willReturn($this->uploadService);
         $this->uploadService
             ->expects($this->once())
             ->method('fetchUploadedFile')

--- a/test/unit/import/service/AgnosticImportHandlerTest.php
+++ b/test/unit/import/service/AgnosticImportHandlerTest.php
@@ -24,14 +24,14 @@ namespace oat\tao\test\unit\import\service;
 
 use core_kernel_classes_Class;
 use Exception;
-use oat\generis\model\DependencyInjection\ServiceLink;
+use oat\generis\test\TestCase;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\reporting\Report;
 use oat\tao\model\import\Processor\ImportFileErrorHandlerInterface;
 use oat\tao\model\import\Processor\ImportFileProcessorInterface;
 use oat\tao\model\import\service\AgnosticImportHandler;
-use oat\generis\test\TestCase;
 use oat\tao\model\upload\UploadService;
+use oat\tao\test\unit\ServiceLinkStub;
 use PHPUnit\Framework\MockObject\MockObject;
 use tao_helpers_form_Form;
 
@@ -43,7 +43,7 @@ class AgnosticImportHandlerTest extends TestCase
     /** @var UploadService|MockObject */
     private $uploadService;
 
-    /** @var ServiceLink|MockObject */
+    /** @var ServiceLinkStub|MockObject */
     private $uploadServiceLink;
 
     /** @var ImportFileErrorHandlerInterface|MockObject */
@@ -57,7 +57,7 @@ class AgnosticImportHandlerTest extends TestCase
         $this->errorHandler = $this->createMock(ImportFileErrorHandlerInterface::class);
         $this->processor = $this->createMock(ImportFileProcessorInterface::class);
         $this->uploadService = $this->createMock(UploadService::class);
-        $this->uploadServiceLink = $this->createMock(ServiceLink::class);
+        $this->uploadServiceLink = $this->createMock(ServiceLinkStub::class);
         $this->subject = (new AgnosticImportHandler($this->uploadServiceLink))
             ->withErrorHandler($this->errorHandler)
             ->withFileProcessor($this->processor);

--- a/test/unit/import/service/AgnosticImportHandlerTest.php
+++ b/test/unit/import/service/AgnosticImportHandlerTest.php
@@ -24,6 +24,7 @@ namespace oat\tao\test\unit\import\service;
 
 use core_kernel_classes_Class;
 use Exception;
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\generis\test\TestCase;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\reporting\Report;
@@ -31,7 +32,6 @@ use oat\tao\model\import\Processor\ImportFileErrorHandlerInterface;
 use oat\tao\model\import\Processor\ImportFileProcessorInterface;
 use oat\tao\model\import\service\AgnosticImportHandler;
 use oat\tao\model\upload\UploadService;
-use oat\tao\test\unit\ServiceLinkStub;
 use PHPUnit\Framework\MockObject\MockObject;
 use tao_helpers_form_Form;
 
@@ -43,7 +43,7 @@ class AgnosticImportHandlerTest extends TestCase
     /** @var UploadService|MockObject */
     private $uploadService;
 
-    /** @var ServiceLinkStub|MockObject */
+    /** @var ServiceLink|MockObject */
     private $uploadServiceLink;
 
     /** @var ImportFileErrorHandlerInterface|MockObject */
@@ -57,7 +57,7 @@ class AgnosticImportHandlerTest extends TestCase
         $this->errorHandler = $this->createMock(ImportFileErrorHandlerInterface::class);
         $this->processor = $this->createMock(ImportFileProcessorInterface::class);
         $this->uploadService = $this->createMock(UploadService::class);
-        $this->uploadServiceLink = $this->createMock(ServiceLinkStub::class);
+        $this->uploadServiceLink = $this->createMock(ServiceLink::class);
         $this->subject = (new AgnosticImportHandler($this->uploadServiceLink))
             ->withErrorHandler($this->errorHandler)
             ->withFileProcessor($this->processor);

--- a/test/unit/import/service/AgnosticImportHandlerTest.php
+++ b/test/unit/import/service/AgnosticImportHandlerTest.php
@@ -31,7 +31,6 @@ use oat\oatbox\reporting\Report;
 use oat\tao\model\import\Processor\ImportFileErrorHandlerInterface;
 use oat\tao\model\import\Processor\ImportFileProcessorInterface;
 use oat\tao\model\import\service\AgnosticImportHandler;
-use oat\tao\model\upload\UploadService;
 use PHPUnit\Framework\MockObject\MockObject;
 use tao_helpers_form_Form;
 
@@ -39,9 +38,6 @@ class AgnosticImportHandlerTest extends TestCase
 {
     /** @var AgnosticImportHandler */
     private $subject;
-
-    /** @var UploadService|MockObject */
-    private $uploadService;
 
     /** @var ServiceLink|MockObject */
     private $uploadServiceLink;
@@ -56,7 +52,6 @@ class AgnosticImportHandlerTest extends TestCase
     {
         $this->errorHandler = $this->createMock(ImportFileErrorHandlerInterface::class);
         $this->processor = $this->createMock(ImportFileProcessorInterface::class);
-        $this->uploadService = $this->createMock(UploadService::class);
         $this->uploadServiceLink = $this->createMock(ServiceLink::class);
         $this->subject = (new AgnosticImportHandler($this->uploadServiceLink))
             ->withErrorHandler($this->errorHandler)
@@ -83,17 +78,8 @@ class AgnosticImportHandlerTest extends TestCase
         $file = $this->createMock(File::class);
 
         $this->uploadServiceLink
-            ->method('getService')
-            ->willReturn($this->uploadService);
-        $this->uploadService
-            ->expects($this->once())
-            ->method('fetchUploadedFile')
+            ->method('__call')
             ->willReturn($file);
-
-        $this->uploadService
-            ->expects($this->once())
-            ->method('remove')
-            ->with($file);
 
         $this->processor
             ->expects($this->once())
@@ -113,17 +99,8 @@ class AgnosticImportHandlerTest extends TestCase
         $exception = new Exception('Does not matter');
 
         $this->uploadServiceLink
-            ->method('getService')
-            ->willReturn($this->uploadService);
-        $this->uploadService
-            ->expects($this->once())
-            ->method('fetchUploadedFile')
+            ->method('__call')
             ->willReturn($file);
-
-        $this->uploadService
-            ->expects($this->once())
-            ->method('remove')
-            ->with($file);
 
         $this->processor
             ->expects($this->once())

--- a/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
+++ b/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
@@ -52,9 +52,6 @@ use tao_helpers_Mode;
 
 class ClientConfigStorageTest extends TestCase
 {
-    /** @var TokenService|MockObject */
-    private TokenService $tokenService;
-
     /** @var ServiceLink|MockObject */
     private ServiceLink $tokenServiceLink;
 
@@ -67,14 +64,8 @@ class ClientConfigStorageTest extends TestCase
     /** @var ServiceLink|MockObject */
     private ServiceLink $assetServiceLink;
 
-    /** @var AssetService|MockObject */
-    private AssetService $assetService;
-
     /** @var common_ext_ExtensionsManager|MockObject */
     private common_ext_ExtensionsManager $extensionsManager;
-
-    /** @var ClientConfigService|MockObject */
-    private ClientConfigService $clientConfigService;
 
     /** @var ServiceLink|MockObject */
     private ServiceLink $clientConfigServiceLink;
@@ -108,13 +99,10 @@ class ClientConfigStorageTest extends TestCase
     protected function setUp(): void
     {
         $this->tokenServiceLink = $this->createMock(ServiceLink::class);
-        $this->tokenService = $this->createMock(TokenService::class);
         $this->clientLibRegistry = $this->createMock(ClientLibRegistry::class);
         $this->featureFlagConfigSwitcher = $this->createMock(FeatureFlagConfigSwitcher::class);
         $this->assetServiceLink = $this->createMock(ServiceLink::class);
-        $this->assetService = $this->createMock(AssetService::class);
         $this->extensionsManager = $this->createMock(common_ext_ExtensionsManager::class);
-        $this->clientConfigService = $this->createMock(ClientConfigService::class);
         $this->clientConfigServiceLink = $this->createMock(ServiceLink::class);
         $this->userLanguageService = $this->createMock(UserLanguageService::class);
         $this->featureFlagRepository = $this->createMock(FeatureFlagRepositoryInterface::class);
@@ -184,11 +172,7 @@ class ClientConfigStorageTest extends TestCase
             ->willReturn($resolver);
 
         $this->assetServiceLink
-            ->method('getService')
-            ->willReturn($this->assetService);
-        $this->assetService
-            ->method('getJsBaseWww')
-            ->with('tao')
+            ->method('__call')
             ->willReturn('JsBaseWww');
 
         $session = $this->createMock(common_session_Session::class);
@@ -228,11 +212,9 @@ class ClientConfigStorageTest extends TestCase
             ]);
 
         $this->tokenServiceLink
-            ->method('getService')
-            ->willReturn($this->tokenService);
-        $this->tokenService
             ->expects($this->once())
-            ->method('getClientConfig')
+            ->method('__call')
+            ->with('getClientConfig')
             ->willReturn([
                 'clientConfigKey' => 'clientConfigValue',
             ]);
@@ -263,12 +245,10 @@ class ClientConfigStorageTest extends TestCase
             ->willReturn($dateFormatter);
 
         $this->assetServiceLink
-            ->method('getService')
-            ->willReturn($this->assetService);
-        $this->assetService
-            ->method('getJsBaseWww')
-            ->with('tao')
-            ->willReturn('jsBaseWww');
+            ->method('__call')
+            ->willReturn(
+                'jsBaseWww'
+            );
 
         $this->userLanguageService
             ->method('getAuthoringLanguage')
@@ -297,11 +277,9 @@ class ClientConfigStorageTest extends TestCase
             ]);
 
         $this->clientConfigServiceLink
-            ->method('getService')
-            ->willReturn($this->clientConfigService);
-        $this->clientConfigService
             ->expects($this->once())
-            ->method('getExtendedConfig')
+            ->method('__call')
+            ->with('getExtendedConfig')
             ->willReturn([
                 'extendedConfigKey' => ['extendedConfigValue'],
             ]);

--- a/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
+++ b/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
@@ -27,7 +27,6 @@ namespace oat\tao\test\unit\models\classes\clientConfig;
 use common_ext_Extension;
 use common_ext_ExtensionsManager;
 use common_session_Session;
-use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\UserLanguageService;
 use oat\tao\helpers\dateFormatter\DateFormatterFactory;
@@ -44,6 +43,7 @@ use oat\tao\model\menu\Perspective;
 use oat\tao\model\routing\Resolver;
 use oat\tao\model\routing\ResolverFactory;
 use oat\tao\model\security\xsrf\TokenService;
+use oat\tao\test\unit\ServiceLinkStub;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -55,8 +55,8 @@ class ClientConfigStorageTest extends TestCase
     /** @var TokenService|MockObject */
     private TokenService $tokenService;
 
-    /** @var ServiceLink|MockObject */
-    private ServiceLink $tokenServiceLink;
+    /** @var ServiceLinkStub|MockObject */
+    private ServiceLinkStub $tokenServiceLink;
 
     /** @var ClientLibRegistry|MockObject */
     private ClientLibRegistry $clientLibRegistry;
@@ -64,8 +64,8 @@ class ClientConfigStorageTest extends TestCase
     /** @var FeatureFlagConfigSwitcher|MockObject */
     private FeatureFlagConfigSwitcher $featureFlagConfigSwitcher;
 
-    /** @var ServiceLink|MockObject */
-    private ServiceLink $assetServiceLink;
+    /** @var ServiceLinkStub|MockObject */
+    private ServiceLinkStub $assetServiceLink;
 
     /** @var AssetService|MockObject */
     private AssetService $assetService;
@@ -77,8 +77,8 @@ class ClientConfigStorageTest extends TestCase
     private ClientConfigService $clientConfigService;
 
 
-    /** @var ServiceLink|MockObject */
-    private ServiceLink $clientConfigServiceLink;
+    /** @var ServiceLinkStub|MockObject */
+    private ServiceLinkStub $clientConfigServiceLink;
 
     /** @var UserLanguageService|MockObject */
     private UserLanguageService $userLanguageService;
@@ -108,15 +108,15 @@ class ClientConfigStorageTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->tokenServiceLink = $this->createMock(ServiceLink::class);
+        $this->tokenServiceLink = $this->createMock(ServiceLinkStub::class);
         $this->tokenService = $this->createMock(TokenService::class);
         $this->clientLibRegistry = $this->createMock(ClientLibRegistry::class);
         $this->featureFlagConfigSwitcher = $this->createMock(FeatureFlagConfigSwitcher::class);
-        $this->assetServiceLink = $this->createMock(ServiceLink::class);
+        $this->assetServiceLink = $this->createMock(ServiceLinkStub::class);
         $this->assetService = $this->createMock(AssetService::class);
         $this->extensionsManager = $this->createMock(common_ext_ExtensionsManager::class);
         $this->clientConfigService = $this->createMock(ClientConfigService::class);
-        $this->clientConfigServiceLink = $this->createMock(ServiceLink::class);
+        $this->clientConfigServiceLink = $this->createMock(ServiceLinkStub::class);
         $this->userLanguageService = $this->createMock(UserLanguageService::class);
         $this->featureFlagRepository = $this->createMock(FeatureFlagRepositoryInterface::class);
         $this->resolverFactory = $this->createMock(ResolverFactory::class);

--- a/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
+++ b/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
@@ -27,6 +27,7 @@ namespace oat\tao\test\unit\models\classes\clientConfig;
 use common_ext_Extension;
 use common_ext_ExtensionsManager;
 use common_session_Session;
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\UserLanguageService;
 use oat\tao\helpers\dateFormatter\DateFormatterFactory;
@@ -54,11 +55,17 @@ class ClientConfigStorageTest extends TestCase
     /** @var TokenService|MockObject */
     private TokenService $tokenService;
 
+    /** @var ServiceLink|MockObject */
+    private ServiceLink $tokenServiceLink;
+
     /** @var ClientLibRegistry|MockObject */
     private ClientLibRegistry $clientLibRegistry;
 
     /** @var FeatureFlagConfigSwitcher|MockObject */
     private FeatureFlagConfigSwitcher $featureFlagConfigSwitcher;
+
+    /** @var ServiceLink|MockObject */
+    private ServiceLink $assetServiceLink;
 
     /** @var AssetService|MockObject */
     private AssetService $assetService;
@@ -68,6 +75,10 @@ class ClientConfigStorageTest extends TestCase
 
     /** @var ClientConfigService|MockObject */
     private ClientConfigService $clientConfigService;
+
+
+    /** @var ServiceLink|MockObject */
+    private ServiceLink $clientConfigServiceLink;
 
     /** @var UserLanguageService|MockObject */
     private UserLanguageService $userLanguageService;
@@ -97,12 +108,15 @@ class ClientConfigStorageTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->tokenServiceLink = $this->createMock(ServiceLink::class);
         $this->tokenService = $this->createMock(TokenService::class);
         $this->clientLibRegistry = $this->createMock(ClientLibRegistry::class);
         $this->featureFlagConfigSwitcher = $this->createMock(FeatureFlagConfigSwitcher::class);
+        $this->assetServiceLink = $this->createMock(ServiceLink::class);
         $this->assetService = $this->createMock(AssetService::class);
         $this->extensionsManager = $this->createMock(common_ext_ExtensionsManager::class);
         $this->clientConfigService = $this->createMock(ClientConfigService::class);
+        $this->clientConfigServiceLink = $this->createMock(ServiceLink::class);
         $this->userLanguageService = $this->createMock(UserLanguageService::class);
         $this->featureFlagRepository = $this->createMock(FeatureFlagRepositoryInterface::class);
         $this->resolverFactory = $this->createMock(ResolverFactory::class);
@@ -113,12 +127,12 @@ class ClientConfigStorageTest extends TestCase
         $this->menuService = $this->createMock(MenuService::class);
 
         $this->sut = new ClientConfigStorage(
-            $this->tokenService,
+            $this->tokenServiceLink,
             $this->clientLibRegistry,
             $this->featureFlagConfigSwitcher,
-            $this->assetService,
+            $this->assetServiceLink,
             $this->extensionsManager,
-            $this->clientConfigService,
+            $this->clientConfigServiceLink,
             $this->userLanguageService,
             $this->featureFlagRepository,
             $this->resolverFactory,
@@ -170,6 +184,9 @@ class ClientConfigStorageTest extends TestCase
             ])
             ->willReturn($resolver);
 
+        $this->assetServiceLink
+            ->method('getService')
+            ->willReturn($this->assetService);
         $this->assetService
             ->method('getJsBaseWww')
             ->with('tao')
@@ -211,6 +228,9 @@ class ClientConfigStorageTest extends TestCase
                 ['shownExtension', $shownExtension],
             ]);
 
+        $this->tokenServiceLink
+            ->method('getService')
+            ->willReturn($this->tokenService);
         $this->tokenService
             ->expects($this->once())
             ->method('getClientConfig')
@@ -243,10 +263,9 @@ class ClientConfigStorageTest extends TestCase
             ->method('create')
             ->willReturn($dateFormatter);
 
-        $this->assetService
-            ->expects($this->once())
-            ->method('getCacheBuster')
-            ->willReturn('cacheBuster');
+        $this->assetServiceLink
+            ->method('getService')
+            ->willReturn($this->assetService);
         $this->assetService
             ->method('getJsBaseWww')
             ->with('tao')
@@ -278,6 +297,9 @@ class ClientConfigStorageTest extends TestCase
                 'FEATURE_FLAG' => false,
             ]);
 
+        $this->clientConfigServiceLink
+            ->method('getService')
+            ->willReturn($this->clientConfigService);
         $this->clientConfigService
             ->expects($this->once())
             ->method('getExtendedConfig')

--- a/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
+++ b/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
@@ -27,6 +27,7 @@ namespace oat\tao\test\unit\models\classes\clientConfig;
 use common_ext_Extension;
 use common_ext_ExtensionsManager;
 use common_session_Session;
+use oat\generis\model\DependencyInjection\ServiceLink;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\UserLanguageService;
 use oat\tao\helpers\dateFormatter\DateFormatterFactory;
@@ -43,7 +44,6 @@ use oat\tao\model\menu\Perspective;
 use oat\tao\model\routing\Resolver;
 use oat\tao\model\routing\ResolverFactory;
 use oat\tao\model\security\xsrf\TokenService;
-use oat\tao\test\unit\ServiceLinkStub;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -55,8 +55,8 @@ class ClientConfigStorageTest extends TestCase
     /** @var TokenService|MockObject */
     private TokenService $tokenService;
 
-    /** @var ServiceLinkStub|MockObject */
-    private ServiceLinkStub $tokenServiceLink;
+    /** @var ServiceLink|MockObject */
+    private ServiceLink $tokenServiceLink;
 
     /** @var ClientLibRegistry|MockObject */
     private ClientLibRegistry $clientLibRegistry;
@@ -64,8 +64,8 @@ class ClientConfigStorageTest extends TestCase
     /** @var FeatureFlagConfigSwitcher|MockObject */
     private FeatureFlagConfigSwitcher $featureFlagConfigSwitcher;
 
-    /** @var ServiceLinkStub|MockObject */
-    private ServiceLinkStub $assetServiceLink;
+    /** @var ServiceLink|MockObject */
+    private ServiceLink $assetServiceLink;
 
     /** @var AssetService|MockObject */
     private AssetService $assetService;
@@ -76,9 +76,8 @@ class ClientConfigStorageTest extends TestCase
     /** @var ClientConfigService|MockObject */
     private ClientConfigService $clientConfigService;
 
-
-    /** @var ServiceLinkStub|MockObject */
-    private ServiceLinkStub $clientConfigServiceLink;
+    /** @var ServiceLink|MockObject */
+    private ServiceLink $clientConfigServiceLink;
 
     /** @var UserLanguageService|MockObject */
     private UserLanguageService $userLanguageService;
@@ -108,15 +107,15 @@ class ClientConfigStorageTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->tokenServiceLink = $this->createMock(ServiceLinkStub::class);
+        $this->tokenServiceLink = $this->createMock(ServiceLink::class);
         $this->tokenService = $this->createMock(TokenService::class);
         $this->clientLibRegistry = $this->createMock(ClientLibRegistry::class);
         $this->featureFlagConfigSwitcher = $this->createMock(FeatureFlagConfigSwitcher::class);
-        $this->assetServiceLink = $this->createMock(ServiceLinkStub::class);
+        $this->assetServiceLink = $this->createMock(ServiceLink::class);
         $this->assetService = $this->createMock(AssetService::class);
         $this->extensionsManager = $this->createMock(common_ext_ExtensionsManager::class);
         $this->clientConfigService = $this->createMock(ClientConfigService::class);
-        $this->clientConfigServiceLink = $this->createMock(ServiceLinkStub::class);
+        $this->clientConfigServiceLink = $this->createMock(ServiceLink::class);
         $this->userLanguageService = $this->createMock(UserLanguageService::class);
         $this->featureFlagRepository = $this->createMock(FeatureFlagRepositoryInterface::class);
         $this->resolverFactory = $this->createMock(ResolverFactory::class);


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/REL-1326

## Goal
DI container services availability during install

## Changelog
- feat: DI container services availability during install
- feat: added the ability to configure the run DI container registered service->method as part extension install process. 

## How to test
Configure extension manifest install section with parameter  ```'containerRebuild' => true,```
Debug one of install->php classes to check the availability of some DI services registered in the provider from ```containerServiceProviders```
Run setup to debug
```docker exec -it studio-phpfpm php tao/scripts/taoSetup.php /var/docker-stack-cli/setup.json -vvv```

To check the ability to run DI container registered service->method configured in the manifest.php file you should add some service to section  [install][php] in this format:
```
            [
                'service' => SomeServiceClass::class,
                'method' => 'methodName',
                'arguments' => ['argument1', ...]
            ]       
```
```containerRebuild``` must be set to true for this extension

Depend on https://github.com/oat-sa/generis/pull/1086