### PR TITLE
Feature/BSA-391/Allow to disable figure widgets

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -13,7 +13,7 @@
                 "@oat-sa/tao-core-libs": "^0.5.3",
                 "@oat-sa/tao-core-sdk": "^2.0.1",
                 "@oat-sa/tao-core-shared-libs": "^1.6.1",
-                "@oat-sa/tao-core-ui": "https://github.com/oat-sa/tao-core-ui-fe#feature/BSA-391/2.3.0/allow-to-disable-figure-widgets",
+                "@oat-sa/tao-core-ui": "^2.3.0",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
                 "gamp": "0.2.1",
@@ -79,9 +79,9 @@
             "integrity": "sha512-KnW5RnCOjewkimfDgh/+w9J77bc3gWH5YR1fIHon6j86ywFL+Fevcn5ghdZZrWTzwEMZfEju39VhI7LjXUWKnA=="
         },
         "node_modules/@oat-sa/tao-core-ui": {
-            "version": "2.2.0",
-            "resolved": "git+ssh://git@github.com/oat-sa/tao-core-ui-fe.git#632b217542023ec946cf71ea6b63227b40a6266d",
-            "license": "GPL-2.0"
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-2.3.0.tgz",
+            "integrity": "sha512-0Lpt+B1MLN3smqeQ98bnd2VB+ks9UO3cHG4NuiM7OqI7vu8a760zoPjvw6QzZGFfogBUjb++g0v3nm/t7u1YQg=="
         },
         "node_modules/amdefine": {
             "version": "1.0.1",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,291 +1,206 @@
 {
     "name": "@oat-sa/tao",
     "version": "0.10.0",
-    "lockfileVersion": 3,
+    "lockfileVersion": 1,
     "requires": true,
-    "packages": {
-        "": {
-            "name": "@oat-sa/tao",
-            "version": "0.10.0",
-            "license": "GPL-2.0",
-            "dependencies": {
-                "@babel/polyfill": "^7.4.4",
-                "@oat-sa/tao-core-libs": "^0.5.3",
-                "@oat-sa/tao-core-sdk": "^2.0.1",
-                "@oat-sa/tao-core-shared-libs": "^1.6.1",
-                "@oat-sa/tao-core-ui": "^2.3.0",
-                "codemirror": "^5.54.0",
-                "dompurify": "^2.4.0",
-                "gamp": "0.2.1",
-                "handlebars": "1.3.0",
-                "interactjs": "1.3.4",
-                "jquery": "1.9.1",
-                "lodash": "2.4.1",
-                "moment": "^2.29.4",
-                "moment-timezone": "^0.5.43",
-                "popper.js": "1.16.1",
-                "raphael": "2.3.0",
-                "select2": "3.5.1",
-                "tooltip.js": "1.3.3",
-                "url-polyfill": "1.1.12"
-            },
-            "devDependencies": {
-                "fs": "0.0.1-security"
-            }
-        },
-        "node_modules/@babel/polyfill": {
+    "dependencies": {
+        "@babel/polyfill": {
             "version": "7.12.1",
             "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
             "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-            "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-            "dependencies": {
+            "requires": {
                 "core-js": "^2.6.5",
                 "regenerator-runtime": "^0.13.4"
             }
         },
-        "node_modules/@oat-sa/tao-core-libs": {
+        "@oat-sa/tao-core-libs": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.5.3.tgz",
-            "integrity": "sha512-0zRfr1xOrLvbPG6Mqra07qfoG5A46hcz4/2sFmz+b+hNl6YfCIgElSUkniXyQo4dcC651kS61VfGPedkuue3cQ==",
-            "peerDependencies": {
-                "async": "0.2.10",
-                "dompurify": "^2.4.0",
-                "gamp": "0.2.1",
-                "handlebars": "1.3.0",
-                "interactjs": "1.3.4",
-                "jquery": ">= 1.9.1 < 3.0.0",
-                "lodash": "2.4.1",
-                "moment": "^2.29.4",
-                "moment-timezone": "^0.5.43",
-                "popper.js": "1.16.1",
-                "raphael": "2.3.0",
-                "select2": "3.5.1",
-                "tooltip.js": "1.3.3"
-            }
+            "integrity": "sha512-0zRfr1xOrLvbPG6Mqra07qfoG5A46hcz4/2sFmz+b+hNl6YfCIgElSUkniXyQo4dcC651kS61VfGPedkuue3cQ=="
         },
-        "node_modules/@oat-sa/tao-core-sdk": {
+        "@oat-sa/tao-core-sdk": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-2.0.2.tgz",
             "integrity": "sha512-f7dEDHfJ3NpThKHJYjBI4nvR/63+Npcx/UYt9IK/ShQcuKAsDU6ugexxyMnc/97eS4UOTVFr6bvaP/CXWCF6hQ==",
-            "dependencies": {
+            "requires": {
                 "fastestsmallesttextencoderdecoder": "1.0.14",
                 "idb-wrapper": "1.7.2",
                 "webcrypto-shim": "0.1.7"
             }
         },
-        "node_modules/@oat-sa/tao-core-shared-libs": {
+        "@oat-sa/tao-core-shared-libs": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.6.1.tgz",
             "integrity": "sha512-KnW5RnCOjewkimfDgh/+w9J77bc3gWH5YR1fIHon6j86ywFL+Fevcn5ghdZZrWTzwEMZfEju39VhI7LjXUWKnA=="
         },
-        "node_modules/@oat-sa/tao-core-ui": {
+        "@oat-sa/tao-core-ui": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-2.3.0.tgz",
             "integrity": "sha512-0Lpt+B1MLN3smqeQ98bnd2VB+ks9UO3cHG4NuiM7OqI7vu8a760zoPjvw6QzZGFfogBUjb++g0v3nm/t7u1YQg=="
         },
-        "node_modules/amdefine": {
+        "amdefine": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
             "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-            "optional": true,
-            "engines": {
-                "node": ">=0.4.2"
-            }
+            "optional": true
         },
-        "node_modules/async": {
+        "async": {
             "version": "0.2.10",
             "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+            "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+            "optional": true
         },
-        "node_modules/codemirror": {
+        "codemirror": {
             "version": "5.65.16",
             "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
             "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
         },
-        "node_modules/core-js": {
+        "core-js": {
             "version": "2.6.12",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-            "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-            "hasInstallScript": true
+            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
-        "node_modules/dompurify": {
+        "dompurify": {
             "version": "2.4.7",
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
             "integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ=="
         },
-        "node_modules/eve-raphael": {
+        "eve-raphael": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
             "integrity": "sha512-jrxnPsCGqng1UZuEp9DecX/AuSyAszATSjf4oEcRxvfxa1Oux4KkIPKBAAWWnpdwfARtr+Q0o9aPYWjsROD7ug=="
         },
-        "node_modules/fastestsmallesttextencoderdecoder": {
+        "fastestsmallesttextencoderdecoder": {
             "version": "1.0.14",
             "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
             "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ=="
         },
-        "node_modules/fs": {
+        "fs": {
             "version": "0.0.1-security",
             "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
             "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
             "dev": true
         },
-        "node_modules/gamp": {
+        "gamp": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/gamp/-/gamp-0.2.1.tgz",
             "integrity": "sha512-dZy17z9sc1k8mU/esu5Rb3/0ZMEJldkRnikb+c8KtNLslGzJqBX7TJfaAlUaoCT9cw6h+SCUTO3tvuRBVCgbkg=="
         },
-        "node_modules/handlebars": {
+        "handlebars": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
             "integrity": "sha512-l7sLUTqXCkc1Ypoy8mSOWZFEZJK3VYQYnLfIVTRJeSHdgzt6hXkQ0uPGugydPa99KyyBdsi0J3WvYfm/HX5naQ==",
-            "dependencies": {
-                "optimist": "~0.3"
-            },
-            "bin": {
-                "handlebars": "bin/handlebars"
-            },
-            "engines": {
-                "node": ">=0.4.7"
-            },
-            "optionalDependencies": {
+            "requires": {
+                "optimist": "~0.3",
                 "uglify-js": "~2.3"
             }
         },
-        "node_modules/idb-wrapper": {
+        "idb-wrapper": {
             "version": "1.7.2",
             "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
             "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
         },
-        "node_modules/interactjs": {
+        "interactjs": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.3.4.tgz",
             "integrity": "sha512-AQ2CdPEyHqiEEQ1FFgMBj79UEsU1+rUwSXuhOkflvB65p4iECft28SN/PvhD/Y9OtNge8aH1qTibjAi+RXQMqQ=="
         },
-        "node_modules/jquery": {
+        "jquery": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
             "integrity": "sha512-gK7jP5cOEUzjyL0dy7MEMfeSFlmt1yNSdZK98CL8W6o0DiNVW5O9hLcD2bdl48mL8q7bEJgd7d9AhhDaN+iDSQ=="
         },
-        "node_modules/lodash": {
+        "lodash": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-            "integrity": "sha512-qa6QqjA9jJB4AYw+NpD2GI4dzHL6Mv0hL+By6iIul4Ce0C1refrjZJmcGvWdnLUwl4LIPtvzje3UQfGH+nCEsQ==",
-            "engines": [
-                "node",
-                "rhino"
-            ]
+            "integrity": "sha512-qa6QqjA9jJB4AYw+NpD2GI4dzHL6Mv0hL+By6iIul4Ce0C1refrjZJmcGvWdnLUwl4LIPtvzje3UQfGH+nCEsQ=="
         },
-        "node_modules/moment": {
+        "moment": {
             "version": "2.29.4",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-            "engines": {
-                "node": "*"
-            }
+            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
         },
-        "node_modules/moment-timezone": {
+        "moment-timezone": {
             "version": "0.5.43",
             "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
             "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
-            "dependencies": {
+            "requires": {
                 "moment": "^2.29.4"
-            },
-            "engines": {
-                "node": "*"
             }
         },
-        "node_modules/optimist": {
+        "optimist": {
             "version": "0.3.7",
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
             "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-            "dependencies": {
+            "requires": {
                 "wordwrap": "~0.0.2"
             }
         },
-        "node_modules/popper.js": {
+        "popper.js": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-            "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/popperjs"
-            }
+            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
         },
-        "node_modules/raphael": {
+        "raphael": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
             "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
-            "dependencies": {
+            "requires": {
                 "eve-raphael": "0.5.0"
             }
         },
-        "node_modules/regenerator-runtime": {
+        "regenerator-runtime": {
             "version": "0.13.11",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
             "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
         },
-        "node_modules/select2": {
+        "select2": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/select2/-/select2-3.5.1.tgz",
             "integrity": "sha512-IFX3UFPpPyK1I1Kuw1R1x+upMyNAZbMlkFhiTnRCRR7ii0KU1brmJMLa3GZcrMWCHiQlm0eKqb6i4XO4pqOrGQ=="
         },
-        "node_modules/source-map": {
+        "source-map": {
             "version": "0.1.43",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
             "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
             "optional": true,
-            "dependencies": {
+            "requires": {
                 "amdefine": ">=0.0.4"
-            },
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
-        "node_modules/tooltip.js": {
+        "tooltip.js": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.3.3.tgz",
             "integrity": "sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==",
-            "deprecated": "Tooltip.js is not supported anymore, please migrate to tippy.js",
-            "dependencies": {
+            "requires": {
                 "popper.js": "^1.0.2"
             }
         },
-        "node_modules/uglify-js": {
+        "uglify-js": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
             "integrity": "sha512-T2LWWydxf5+Btpb0S/Gg/yKFmYjnX9jtQ4mdN9YRq73BhN21EhU0Dvw3wYDLqd3TooGUJlCKf3Gfyjjy/RTcWA==",
             "optional": true,
-            "dependencies": {
+            "requires": {
                 "async": "~0.2.6",
                 "optimist": "~0.3.5",
                 "source-map": "~0.1.7"
-            },
-            "bin": {
-                "uglifyjs": "bin/uglifyjs"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
-        "node_modules/url-polyfill": {
+        "url-polyfill": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.12.tgz",
             "integrity": "sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A=="
         },
-        "node_modules/webcrypto-shim": {
+        "webcrypto-shim": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
             "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
         },
-        "node_modules/wordwrap": {
+        "wordwrap": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-            "engines": {
-                "node": ">=0.4.0"
-            }
+            "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
         }
     }
 }

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,206 +1,291 @@
 {
-  "name": "@oat-sa/tao",
-  "version": "0.10.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@babel/polyfill": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "@oat-sa/tao-core-libs": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.5.3.tgz",
-      "integrity": "sha512-0zRfr1xOrLvbPG6Mqra07qfoG5A46hcz4/2sFmz+b+hNl6YfCIgElSUkniXyQo4dcC651kS61VfGPedkuue3cQ==",
-      "requires": {}
-    },
-    "@oat-sa/tao-core-sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-2.0.1.tgz",
-      "integrity": "sha512-1kiqbHOk5+uVqVBRKiiJgfLJWQc0Iqmw4d0vrtsgQk/foiiEGy8tW0lHRRS0cO1nnmBftov7eINuPgEsVYwiJw==",
-      "requires": {
-        "fastestsmallesttextencoderdecoder": "1.0.14",
-        "idb-wrapper": "1.7.2",
-        "webcrypto-shim": "0.1.7"
-      }
-    },
-    "@oat-sa/tao-core-shared-libs": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.6.1.tgz",
-      "integrity": "sha512-KnW5RnCOjewkimfDgh/+w9J77bc3gWH5YR1fIHon6j86ywFL+Fevcn5ghdZZrWTzwEMZfEju39VhI7LjXUWKnA=="
-    },
-    "@oat-sa/tao-core-ui": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-2.2.0.tgz",
-      "integrity": "sha512-guRQZTv0OsT+mL5LxGMAlaQTsEW4yqfGnH2IY0zbLU7V2JhA+3mnzlc/MF0h/QaDdjUBl8NlQCCINV+TNt8Dww=="
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "optional": true
-    },
-    "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
-    },
-    "codemirror": {
-      "version": "5.65.12",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.12.tgz",
-      "integrity": "sha512-z2jlHBocElRnPYysN2HAuhXbO3DNB0bcSKmNz3hcWR2Js2Dkhc1bEOxG93Z3DeUrnm+qx56XOY5wQmbP5KY0sw=="
-    },
-    "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-    },
-    "dompurify": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
-      "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
-    },
-    "eve-raphael": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
-      "integrity": "sha512-jrxnPsCGqng1UZuEp9DecX/AuSyAszATSjf4oEcRxvfxa1Oux4KkIPKBAAWWnpdwfARtr+Q0o9aPYWjsROD7ug=="
-    },
-    "fastestsmallesttextencoderdecoder": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
-      "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ=="
-    },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
-      "dev": true
-    },
-    "gamp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/gamp/-/gamp-0.2.1.tgz",
-      "integrity": "sha512-dZy17z9sc1k8mU/esu5Rb3/0ZMEJldkRnikb+c8KtNLslGzJqBX7TJfaAlUaoCT9cw6h+SCUTO3tvuRBVCgbkg=="
-    },
-    "handlebars": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
-      "integrity": "sha512-l7sLUTqXCkc1Ypoy8mSOWZFEZJK3VYQYnLfIVTRJeSHdgzt6hXkQ0uPGugydPa99KyyBdsi0J3WvYfm/HX5naQ==",
-      "requires": {
-        "optimist": "~0.3",
-        "uglify-js": "~2.3"
-      }
-    },
-    "idb-wrapper": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
-      "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
-    },
-    "interactjs": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.3.4.tgz",
-      "integrity": "sha512-AQ2CdPEyHqiEEQ1FFgMBj79UEsU1+rUwSXuhOkflvB65p4iECft28SN/PvhD/Y9OtNge8aH1qTibjAi+RXQMqQ=="
-    },
-    "jquery": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
-      "integrity": "sha512-gK7jP5cOEUzjyL0dy7MEMfeSFlmt1yNSdZK98CL8W6o0DiNVW5O9hLcD2bdl48mL8q7bEJgd7d9AhhDaN+iDSQ=="
-    },
-    "lodash": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-      "integrity": "sha512-qa6QqjA9jJB4AYw+NpD2GI4dzHL6Mv0hL+By6iIul4Ce0C1refrjZJmcGvWdnLUwl4LIPtvzje3UQfGH+nCEsQ=="
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
-    },
-    "moment-timezone": {
-      "version": "0.5.43",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
-      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
-      "requires": {
-        "moment": "^2.29.4"
-      }
-    },
-    "optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-      "requires": {
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
-    "raphael": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
-      "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
-      "requires": {
-        "eve-raphael": "0.5.0"
-      }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-    },
-    "select2": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/select2/-/select2-3.5.1.tgz",
-      "integrity": "sha512-IFX3UFPpPyK1I1Kuw1R1x+upMyNAZbMlkFhiTnRCRR7ii0KU1brmJMLa3GZcrMWCHiQlm0eKqb6i4XO4pqOrGQ=="
-    },
-    "source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
-      "optional": true,
-      "requires": {
-        "amdefine": ">=0.0.4"
-      }
-    },
-    "tooltip.js": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.3.3.tgz",
-      "integrity": "sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==",
-      "requires": {
-        "popper.js": "^1.0.2"
-      }
-    },
-    "uglify-js": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-      "integrity": "sha512-T2LWWydxf5+Btpb0S/Gg/yKFmYjnX9jtQ4mdN9YRq73BhN21EhU0Dvw3wYDLqd3TooGUJlCKf3Gfyjjy/RTcWA==",
-      "optional": true,
-      "requires": {
-        "async": "~0.2.6",
-        "optimist": "~0.3.5",
-        "source-map": "~0.1.7"
-      }
-    },
-    "url-polyfill": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.12.tgz",
-      "integrity": "sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A=="
-    },
-    "webcrypto-shim": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
-      "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw=="
+    "name": "@oat-sa/tao",
+    "version": "0.10.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@oat-sa/tao",
+            "version": "0.10.0",
+            "license": "GPL-2.0",
+            "dependencies": {
+                "@babel/polyfill": "^7.4.4",
+                "@oat-sa/tao-core-libs": "^0.5.3",
+                "@oat-sa/tao-core-sdk": "^2.0.1",
+                "@oat-sa/tao-core-shared-libs": "^1.6.1",
+                "@oat-sa/tao-core-ui": "https://github.com/oat-sa/tao-core-ui-fe#feature/BSA-391/2.3.0/allow-to-disable-figure-widgets",
+                "codemirror": "^5.54.0",
+                "dompurify": "^2.4.0",
+                "gamp": "0.2.1",
+                "handlebars": "1.3.0",
+                "interactjs": "1.3.4",
+                "jquery": "1.9.1",
+                "lodash": "2.4.1",
+                "moment": "^2.29.4",
+                "moment-timezone": "^0.5.43",
+                "popper.js": "1.16.1",
+                "raphael": "2.3.0",
+                "select2": "3.5.1",
+                "tooltip.js": "1.3.3",
+                "url-polyfill": "1.1.12"
+            },
+            "devDependencies": {
+                "fs": "0.0.1-security"
+            }
+        },
+        "node_modules/@babel/polyfill": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
+            "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
+            "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
+            "dependencies": {
+                "core-js": "^2.6.5",
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "node_modules/@oat-sa/tao-core-libs": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-libs/-/tao-core-libs-0.5.3.tgz",
+            "integrity": "sha512-0zRfr1xOrLvbPG6Mqra07qfoG5A46hcz4/2sFmz+b+hNl6YfCIgElSUkniXyQo4dcC651kS61VfGPedkuue3cQ==",
+            "peerDependencies": {
+                "async": "0.2.10",
+                "dompurify": "^2.4.0",
+                "gamp": "0.2.1",
+                "handlebars": "1.3.0",
+                "interactjs": "1.3.4",
+                "jquery": ">= 1.9.1 < 3.0.0",
+                "lodash": "2.4.1",
+                "moment": "^2.29.4",
+                "moment-timezone": "^0.5.43",
+                "popper.js": "1.16.1",
+                "raphael": "2.3.0",
+                "select2": "3.5.1",
+                "tooltip.js": "1.3.3"
+            }
+        },
+        "node_modules/@oat-sa/tao-core-sdk": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-2.0.2.tgz",
+            "integrity": "sha512-f7dEDHfJ3NpThKHJYjBI4nvR/63+Npcx/UYt9IK/ShQcuKAsDU6ugexxyMnc/97eS4UOTVFr6bvaP/CXWCF6hQ==",
+            "dependencies": {
+                "fastestsmallesttextencoderdecoder": "1.0.14",
+                "idb-wrapper": "1.7.2",
+                "webcrypto-shim": "0.1.7"
+            }
+        },
+        "node_modules/@oat-sa/tao-core-shared-libs": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.6.1.tgz",
+            "integrity": "sha512-KnW5RnCOjewkimfDgh/+w9J77bc3gWH5YR1fIHon6j86ywFL+Fevcn5ghdZZrWTzwEMZfEju39VhI7LjXUWKnA=="
+        },
+        "node_modules/@oat-sa/tao-core-ui": {
+            "version": "2.2.0",
+            "resolved": "git+ssh://git@github.com/oat-sa/tao-core-ui-fe.git#632b217542023ec946cf71ea6b63227b40a6266d",
+            "license": "GPL-2.0"
+        },
+        "node_modules/amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+            "optional": true,
+            "engines": {
+                "node": ">=0.4.2"
+            }
+        },
+        "node_modules/async": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+            "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+        },
+        "node_modules/codemirror": {
+            "version": "5.65.16",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+            "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
+        },
+        "node_modules/core-js": {
+            "version": "2.6.12",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+            "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+            "hasInstallScript": true
+        },
+        "node_modules/dompurify": {
+            "version": "2.4.7",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
+            "integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ=="
+        },
+        "node_modules/eve-raphael": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+            "integrity": "sha512-jrxnPsCGqng1UZuEp9DecX/AuSyAszATSjf4oEcRxvfxa1Oux4KkIPKBAAWWnpdwfARtr+Q0o9aPYWjsROD7ug=="
+        },
+        "node_modules/fastestsmallesttextencoderdecoder": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
+            "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ=="
+        },
+        "node_modules/fs": {
+            "version": "0.0.1-security",
+            "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+            "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
+            "dev": true
+        },
+        "node_modules/gamp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/gamp/-/gamp-0.2.1.tgz",
+            "integrity": "sha512-dZy17z9sc1k8mU/esu5Rb3/0ZMEJldkRnikb+c8KtNLslGzJqBX7TJfaAlUaoCT9cw6h+SCUTO3tvuRBVCgbkg=="
+        },
+        "node_modules/handlebars": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+            "integrity": "sha512-l7sLUTqXCkc1Ypoy8mSOWZFEZJK3VYQYnLfIVTRJeSHdgzt6hXkQ0uPGugydPa99KyyBdsi0J3WvYfm/HX5naQ==",
+            "dependencies": {
+                "optimist": "~0.3"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "~2.3"
+            }
+        },
+        "node_modules/idb-wrapper": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
+            "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
+        },
+        "node_modules/interactjs": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.3.4.tgz",
+            "integrity": "sha512-AQ2CdPEyHqiEEQ1FFgMBj79UEsU1+rUwSXuhOkflvB65p4iECft28SN/PvhD/Y9OtNge8aH1qTibjAi+RXQMqQ=="
+        },
+        "node_modules/jquery": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
+            "integrity": "sha512-gK7jP5cOEUzjyL0dy7MEMfeSFlmt1yNSdZK98CL8W6o0DiNVW5O9hLcD2bdl48mL8q7bEJgd7d9AhhDaN+iDSQ=="
+        },
+        "node_modules/lodash": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+            "integrity": "sha512-qa6QqjA9jJB4AYw+NpD2GI4dzHL6Mv0hL+By6iIul4Ce0C1refrjZJmcGvWdnLUwl4LIPtvzje3UQfGH+nCEsQ==",
+            "engines": [
+                "node",
+                "rhino"
+            ]
+        },
+        "node_modules/moment": {
+            "version": "2.29.4",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/moment-timezone": {
+            "version": "0.5.43",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+            "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+            "dependencies": {
+                "moment": "^2.29.4"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/optimist": {
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+            "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
+            "dependencies": {
+                "wordwrap": "~0.0.2"
+            }
+        },
+        "node_modules/popper.js": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+            "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/raphael": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
+            "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
+            "dependencies": {
+                "eve-raphael": "0.5.0"
+            }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+        },
+        "node_modules/select2": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/select2/-/select2-3.5.1.tgz",
+            "integrity": "sha512-IFX3UFPpPyK1I1Kuw1R1x+upMyNAZbMlkFhiTnRCRR7ii0KU1brmJMLa3GZcrMWCHiQlm0eKqb6i4XO4pqOrGQ=="
+        },
+        "node_modules/source-map": {
+            "version": "0.1.43",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+            "integrity": "sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==",
+            "optional": true,
+            "dependencies": {
+                "amdefine": ">=0.0.4"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/tooltip.js": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tooltip.js/-/tooltip.js-1.3.3.tgz",
+            "integrity": "sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==",
+            "deprecated": "Tooltip.js is not supported anymore, please migrate to tippy.js",
+            "dependencies": {
+                "popper.js": "^1.0.2"
+            }
+        },
+        "node_modules/uglify-js": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+            "integrity": "sha512-T2LWWydxf5+Btpb0S/Gg/yKFmYjnX9jtQ4mdN9YRq73BhN21EhU0Dvw3wYDLqd3TooGUJlCKf3Gfyjjy/RTcWA==",
+            "optional": true,
+            "dependencies": {
+                "async": "~0.2.6",
+                "optimist": "~0.3.5",
+                "source-map": "~0.1.7"
+            },
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/url-polyfill": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.12.tgz",
+            "integrity": "sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A=="
+        },
+        "node_modules/webcrypto-shim": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
+            "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
+        },
+        "node_modules/wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        }
     }
-  }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,35 +1,35 @@
 {
-  "name": "@oat-sa/tao",
-  "version": "0.10.0",
-  "license": "GPL-2.0",
-  "description": "tao core dependencies",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/oat-sa/tao-core.git"
-  },
-  "scripts": {},
-  "dependencies": {
-    "@babel/polyfill": "^7.4.4",
-    "@oat-sa/tao-core-libs": "^0.5.3",
-    "@oat-sa/tao-core-sdk": "^2.0.1",
-    "@oat-sa/tao-core-shared-libs": "^1.6.1",
-    "@oat-sa/tao-core-ui": "^2.2.0",
-    "codemirror": "^5.54.0",
-    "dompurify": "^2.4.0",
-    "gamp": "0.2.1",
-    "handlebars": "1.3.0",
-    "interactjs": "1.3.4",
-    "jquery": "1.9.1",
-    "lodash": "2.4.1",
-    "moment": "^2.29.4",
-    "moment-timezone": "^0.5.43",
-    "popper.js": "1.16.1",
-    "raphael": "2.3.0",
-    "select2": "3.5.1",
-    "tooltip.js": "1.3.3",
-    "url-polyfill": "1.1.12"
-  },
-  "devDependencies": {
-    "fs": "0.0.1-security"
-  }
+    "name": "@oat-sa/tao",
+    "version": "0.10.0",
+    "license": "GPL-2.0",
+    "description": "tao core dependencies",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/oat-sa/tao-core.git"
+    },
+    "scripts": {},
+    "dependencies": {
+        "@babel/polyfill": "^7.4.4",
+        "@oat-sa/tao-core-libs": "^0.5.3",
+        "@oat-sa/tao-core-sdk": "^2.0.1",
+        "@oat-sa/tao-core-shared-libs": "^1.6.1",
+        "@oat-sa/tao-core-ui": "https://github.com/oat-sa/tao-core-ui-fe#feature/BSA-391/2.3.0/allow-to-disable-figure-widgets",
+        "codemirror": "^5.54.0",
+        "dompurify": "^2.4.0",
+        "gamp": "0.2.1",
+        "handlebars": "1.3.0",
+        "interactjs": "1.3.4",
+        "jquery": "1.9.1",
+        "lodash": "2.4.1",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.43",
+        "popper.js": "1.16.1",
+        "raphael": "2.3.0",
+        "select2": "3.5.1",
+        "tooltip.js": "1.3.3",
+        "url-polyfill": "1.1.12"
+    },
+    "devDependencies": {
+        "fs": "0.0.1-security"
+    }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^0.5.3",
         "@oat-sa/tao-core-sdk": "^2.0.1",
         "@oat-sa/tao-core-shared-libs": "^1.6.1",
-        "@oat-sa/tao-core-ui": "https://github.com/oat-sa/tao-core-ui-fe#feature/BSA-391/2.3.0/allow-to-disable-figure-widgets",
+        "@oat-sa/tao-core-ui": "^2.3.0",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",
         "gamp": "0.2.1",


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/BSA-391

Requires: 
 - [x] https://github.com/oat-sa/tao-core-ui-fe/pull/580

### Summary

Manage a feature flag for disabling the figure widget.

### Details

Some customers rely on the block positioning of the figures for aligning images in columns. The figure widget sets them to inline positioning, hence the need to have a feature flag for disabling it. The other possibility is to roll back the feature, but this is less handy.

The feature can be disabled thanks to the feature flag `FEATURE_FLAG_DISABLE_FIGURE_WIDGET`.
The feature is enabled by default

### How to test

- have all dependencies (other PR) installed
- edit an item and place images on the canvas. Check the attached ticket for a sample item.
- turn the feature flag on and off, and see the differences

### Tidbit

To set and manage the feature flag, take a look at this [documentation](https://github.com/oat-sa/tao-core/blob/master/models/classes/featureFlag/README.md).

```
php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_DISABLE_FIGURE_WIDGET -v true
```