### PR TITLE
fix: internal server error is appearing when removing deliveries

### DIFF
--- a/migrations/Version202312081310042234_tao.php
+++ b/migrations/Version202312081310042234_tao.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023(original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\generis\model\data\event\ClassPropertyDeletedEvent;
+use oat\generis\model\data\event\ResourceDeleted;
+use oat\oatbox\event\EventManager;
+use oat\tao\model\listener\ClassPropertyRemovedListener;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+final class Version202312081310042234_tao extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register property cache warmup and modify listeners.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->detach(
+            ResourceDeleted::class,
+            [ClassPropertyRemovedListener::SERVICE_ID, 'handleDeletedEvent']
+        );
+        $eventManager->attach(
+            ClassPropertyDeletedEvent::class,
+            [ClassPropertyRemovedListener::SERVICE_ID, 'handleDeletedEvent']
+        );
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/models/classes/listener/ClassPropertyRemovedListener.php
+++ b/models/classes/listener/ClassPropertyRemovedListener.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace oat\tao\model\listener;
 
+use oat\generis\model\data\event\ClassPropertyDeletedEvent;
 use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\AdvancedSearch\AdvancedSearchChecker;
 use oat\tao\model\event\ClassPropertyRemovedEvent;
@@ -53,10 +54,10 @@ class ClassPropertyRemovedListener extends ConfigurableService
         );
     }
 
-    public function handleDeletedEvent(ResourceDeleted $event): void
+    public function handleDeletedEvent(ClassPropertyDeletedEvent $event): void
     {
-        if ($event->getResource()->isProperty()) {
-            $classProperty = new \core_kernel_classes_Property($event->getResource());
+        foreach ($event->getProperties() as $uri) {
+            $classProperty = new \core_kernel_classes_Property($uri);
             $classProperty->clearCachedValues();
         }
     }


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/REL-1376

## Goal
Fix the issue when we try to delete the delivery

## Changelog
- fix: fix on property remove cache clear

## How to test
- As admin go to the Deliveries tab
- Select any delivery in the tree
- Click  Delete and confirm