### PR TITLE
Fix/rel 1418/fix phpdoc blocking cache warmup

### DIFF
--- a/actions/class.File.php
+++ b/actions/class.File.php
@@ -80,7 +80,7 @@ class tao_actions_File extends tao_actions_CommonModule
 
     /**
      * Download a resource file content
-     * @param {String} uri Uri of the resource file
+     * @param String uri Uri of the resource file
      */
     public function downloadFile()
     {

--- a/actions/class.File.php
+++ b/actions/class.File.php
@@ -80,7 +80,7 @@ class tao_actions_File extends tao_actions_CommonModule
 
     /**
      * Download a resource file content
-     * @param String uri Uri of the resource file
+     * @param String id Uri of the resource file
      */
     public function downloadFile()
     {

--- a/actions/class.File.php
+++ b/actions/class.File.php
@@ -80,7 +80,7 @@ class tao_actions_File extends tao_actions_CommonModule
 
     /**
      * Download a resource file content
-     * @param String id Uri of the resource file
+     * @param string id Uri of the resource file
      */
     public function downloadFile()
     {


### PR DESCRIPTION
Fixing a phpdoc block that prevents cache warmup.
 
Related to : https://oat-sa.atlassian.net/browse/REL-985
 
Without the fix, phpdoc parser throws an error like:
```
Unexpected token "{", expected type at offset 0 on line 1
```
 
#### Steps to reproduce  (for bugs)
 - Run `php index.php 'oat\generis\scripts\tools\ApplicationCacheWarmup'`
 - Observer an error message `Cache warmup failed: Unexpected token "{", expected type at offset 0 on line 1`
  
#### How to test
 
To test, run the cache warmup command and get the `TAO cache warmed up!` report.
