### PR TITLE
feat: add `cy-GB`, `en-CA` and `es-CO` _data_ locales

### DIFF
--- a/locales/cy-GB/lang.rdf
+++ b/locales/cy-GB/lang.rdf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xml:base="http://www.tao.lu/Ontologies/TAO.rdf#"
+	xmlns:tao="http://www.tao.lu/Ontologies/TAO.rdf#"
+>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAO.rdf#Langcy-GB">
+    <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#Languages"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Welsh (United Kingdom)]]></rdfs:label>
+    <rdf:value><![CDATA[cy-GB]]></rdf:value>
+    <tao:LanguageUsages rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#LanguageUsageData"/>
+    <tao:LanguageOrientation rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#OrientationLeftToRight"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/locales/en-CA/lang.rdf
+++ b/locales/en-CA/lang.rdf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xml:base="http://www.tao.lu/Ontologies/TAO.rdf#"
+	xmlns:tao="http://www.tao.lu/Ontologies/TAO.rdf#"
+>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAO.rdf#Langen-CA">
+    <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#Languages"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[English (Canada)]]></rdfs:label>
+    <rdf:value><![CDATA[en-CA]]></rdf:value>
+    <tao:LanguageUsages rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#LanguageUsageData"/>
+    <tao:LanguageOrientation rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#OrientationLeftToRight"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/locales/es-CO/lang.rdf
+++ b/locales/es-CO/lang.rdf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xml:base="http://www.tao.lu/Ontologies/TAO.rdf#"
+	xmlns:tao="http://www.tao.lu/Ontologies/TAO.rdf#"
+>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAO.rdf#Langes-CO">
+    <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#Languages"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Spanish (Colombia)]]></rdfs:label>
+    <rdf:value><![CDATA[es-CO]]></rdf:value>
+    <tao:LanguageUsages rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#LanguageUsageData"/>
+    <tao:LanguageOrientation rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#OrientationLeftToRight"/>
+  </rdf:Description>
+</rdf:RDF>

--- a/migrations/Version202402061413282234_tao.php
+++ b/migrations/Version202402061413282234_tao.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\SyncModels;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202402061413282234_tao extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update Ontology models';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->runAction(new SyncModels());
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException(
+            'A manual ontology definition update and synchronization of the RDF models is required in order to revert this migration.'
+        );
+    }
+}


### PR DESCRIPTION
# [OAP-10](https://oat-sa.atlassian.net/browse/OAP-10)

This PR adds values for _data_ (items, tests) localization.
For the moment, the locales will be applied to the actual environment manually via https://oat-sa.atlassian.net/browse/OSD-4736. This migration will then simply have no effect on the data on that particular environment.

## How to test

1. `php tao/scripts/taoUpdate.php`
2. Author an Item via TAO 3.x
3. Observe the `Languages` drop down options in the right-hand side panel

[OAP-10]: https://oat-sa.atlassian.net/browse/OAP-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ