### PR TITLE
ADF-1537: internal server error appearing when delivery is deleted

### DIFF
--- a/migrations/Version202402086838312237_tao.php
+++ b/migrations/Version202402086838312237_tao.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\generis\model\data\event\ResourceDeleted;
+use oat\tao\model\listener\ClassPropertyRemovedListener;
+use oat\oatbox\event\EventManager;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202402086838312237_tao extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rolled back the listener for ResourceDeleted';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->detach(
+            ResourceDeleted::class,
+            [ClassPropertyRemovedListener::SERVICE_ID, 'handleDeletedEvent']
+        );
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+
+    public function down(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->attach(
+            ResourceDeleted::class,
+            [ClassPropertyRemovedListener::SERVICE_ID, 'handleDeletedEvent']
+        );
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+}

--- a/scripts/install/RegisterEvents.php
+++ b/scripts/install/RegisterEvents.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace oat\tao\scripts\install;
 
 use oat\generis\model\data\event\CacheWarmupEvent;
-use oat\generis\model\data\event\ResourceDeleted;
 use oat\generis\model\data\event\ResourceUpdated;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\event\EventManager;
@@ -34,7 +33,6 @@ use oat\tao\model\featureFlag\Listener\FeatureFlagCacheWarmupListener;
 use oat\tao\model\Language\Listener\LanguageCacheWarmupListener;
 use oat\tao\model\listener\ClassPropertiesChangedListener;
 use oat\tao\model\listener\ClassPropertyCacheWarmupListener;
-use oat\tao\model\listener\ClassPropertyRemovedListener;
 use oat\tao\model\menu\Listener\MenuCacheWarmupListener;
 use oat\tao\model\migrations\MigrationsService;
 use oat\tao\model\routing\Listener\AnnotationCacheWarmupListener;
@@ -74,10 +72,6 @@ class RegisterEvents extends InstallAction
         $eventManager->attach(
             CacheWarmupEvent::class,
             [ClassPropertyCacheWarmupListener::class, 'handleEvent']
-        );
-        $eventManager->attach(
-            ResourceDeleted::class,
-            [ClassPropertyRemovedListener::SERVICE_ID, 'handleDeletedEvent']
         );
         $eventManager->attach(
             ResourceUpdated::class,


### PR DESCRIPTION
Related to - [https://oat-sa.atlassian.net/browse/ADF-1537](https://oat-sa.atlassian.net/browse/ADF-1537)

## Goal
Fix the issue when we try to delete the delivery

## Changelog
- fix: remove Property Deleted listener, because property cache clearing on the separated property delete

## How to test
- As admin go to the Deliveries tab
- Select any delivery in the tree
- Click  Delete and confirm

## How it looked before

https://github.com/oat-sa/tao-core/assets/10648378/06ed912d-13f6-4032-b474-7e10b93ea269

## How it looks now

https://github.com/oat-sa/tao-core/assets/10648378/180922b8-f081-4c2c-8971-fe2a050c1a4f




