### PR TITLE
Add format microtime() to DateTimeInterface::RFC3339_EXTENDED function (#3928)

### DIFF
--- a/helpers/class.Date.php
+++ b/helpers/class.Date.php
@@ -283,4 +283,29 @@ class tao_helpers_Date
         }
         return $timeKeys;
     }
+
+    /**
+     * Converts from microseconds seconds format of microtime() function to RFC3339_EXTENDED
+     * @param string|null $microtime
+     * @return string|null
+     * @example 0.47950700 1700135696 to 1700135696.47950700
+     */
+    public static function formatMicrotime(?string $microtime): ?string
+    {
+        if ($microtime === null) {
+            return null;
+        }
+
+        // Split the string into microseconds and seconds
+        list($microseconds, $seconds) = explode(' ', $microtime);
+
+        // Show only the numbers after the dot without the integral part
+        list(, $decimalPart) = explode('.', sprintf('%0.6f', $microseconds));
+        //To preserve time zone we are not using createFromFormat()
+        $date = new DateTime();
+        $date->setTimestamp((int)$seconds);
+        $date->modify('+ ' . $decimalPart . ' microseconds');
+
+        return $date->format(DateTimeInterface::RFC3339_EXTENDED);
+    }
 }

--- a/test/unit/helpers/DateTest.php
+++ b/test/unit/helpers/DateTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\helpers;
+
+use oat\generis\test\TestCase;
+use tao_helpers_Date as DateHelper;
+
+class DateTest extends TestCase
+{
+    /**
+     * @dataProvider microtimeProvider
+     */
+    public function testMicrotimeFormat(?string $microtime, ?string $expected)
+    {
+        $result = DateHelper::formatMicrotime($microtime);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function microtimeProvider()
+    {
+        return [
+            ['microtime' => '0.51487900 1701076034', 'expected' => '2023-11-27T09:07:14.514+00:00'],
+            ['microtime' => '0.81487900 1701078054', 'expected' => '2023-11-27T09:40:54.814+00:00'],
+            ['microtime' => '0.71487900 1701073054', 'expected' => '2023-11-27T08:17:34.714+00:00'],
+            ['microtime' => '0.0 1701073054', 'expected' => '2023-11-27T08:17:34.000+00:00'],
+            ['microtime' => '0 1701073054', 'expected' => '2023-11-27T08:17:34.000+00:00'],
+            ['microtime' => null, 'expected' => null]
+        ];
+    }
+}


### PR DESCRIPTION
BACKPORT of https://github.com/oat-sa/tao-core/pull/3932

* fix: refactor and move format function to Date helper, pass deliveryExecution->getFinishTime() on delivery finish

* feat: add unit test

* feat: add unit test

* fix: codestyle

* fix: add new data

(cherry picked from commit 3c01dcf943eb64dc7cf36cc4ef5b3d45728349a3)