### PR TITLE
AUT-3552 fix: do not duplicate read only labels (model 2)

### DIFF
--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -454,8 +454,8 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule
 
         if ($myForm->isSubmited() && $myForm->isValid()) {
             if ($hasWriteAccess) {
-                $labelProp = $class->getProperty(OntologyRdfs::RDFS_LABEL);
-                $labelProp->isWritable() && $class->setLabel(
+                $labelFormElement = $myForm->getElement(tao_helpers_Uri::encode(OntologyRdfs::RDFS_LABEL));
+                $labelFormElement && !$labelFormElement->isDisabled() && $class->setLabel(
                     $myForm->getValue(tao_helpers_Uri::encode(OntologyRdfs::RDFS_LABEL))
                 );
                 $this->setData('message', __('%s Class saved', $class->getLabel()));

--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -454,7 +454,8 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule
 
         if ($myForm->isSubmited() && $myForm->isValid()) {
             if ($hasWriteAccess) {
-                $class->setLabel($myForm->getValue(tao_helpers_Uri::encode(OntologyRdfs::RDFS_LABEL)));
+                $labelProp = $class->getProperty(OntologyRdfs::RDFS_LABEL);
+                $labelProp->isWritable() && $class->setLabel($myForm->getValue(tao_helpers_Uri::encode(OntologyRdfs::RDFS_LABEL)));
                 $this->setData('message', __('%s Class saved', $class->getLabel()));
             } else {
                 $this->setData('errorMessage', __('You do not have the required rights to edit this resource.'));

--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -455,7 +455,9 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule
         if ($myForm->isSubmited() && $myForm->isValid()) {
             if ($hasWriteAccess) {
                 $labelProp = $class->getProperty(OntologyRdfs::RDFS_LABEL);
-                $labelProp->isWritable() && $class->setLabel($myForm->getValue(tao_helpers_Uri::encode(OntologyRdfs::RDFS_LABEL)));
+                $labelProp->isWritable() && $class->setLabel(
+                    $myForm->getValue(tao_helpers_Uri::encode(OntologyRdfs::RDFS_LABEL))
+                );
                 $this->setData('message', __('%s Class saved', $class->getLabel()));
             } else {
                 $this->setData('errorMessage', __('You do not have the required rights to edit this resource.'));

--- a/actions/form/class.Clazz.php
+++ b/actions/form/class.Clazz.php
@@ -194,7 +194,7 @@ class tao_actions_form_Clazz extends tao_helpers_form_FormContainer
 
                 //set label validator, read only
                 if ($property->getUri() == OntologyRdfs::RDFS_LABEL) {
-                    $readonly = tao_helpers_form_FormFactory::getElement($element->getName(), 'Readonly');
+                    $readonly = tao_helpers_form_FormFactory::getElement('', 'Readonly');
                     $readonly->setDescription($element->getDescription());
                     $readonly->setValue($element->getRawValue());
                     $element = $readonly;

--- a/actions/form/class.EditClassLabel.php
+++ b/actions/form/class.EditClassLabel.php
@@ -114,6 +114,7 @@ class tao_actions_form_EditClassLabel extends \tao_helpers_form_FormContainer
             $namespace = substr($clazz->getUri(), 0, strpos($clazz->getUri(), '#'));
             if (!$this->getNamespaceHelper()->isNamespaceSupported($namespace)) {
                 $readonly = \tao_helpers_form_FormFactory::getElement($element->getName(), 'Readonly');
+                $readonly->disable();
                 $readonly->setDescription($element->getDescription());
                 $readonly->setValue($element->getRawValue());
                 $element = $readonly;

--- a/actions/form/class.EditClassLabel.php
+++ b/actions/form/class.EditClassLabel.php
@@ -82,10 +82,10 @@ class tao_actions_form_EditClassLabel extends \tao_helpers_form_FormContainer
         }
         unset($this->options['name']);
 
-        $this->form = \tao_helpers_form_FormFactory::getForm($name, $this->options);
+        $this->form = tao_helpers_form_FormFactory::getForm($name, $this->options);
 
 
-        $this->form->setActions(\tao_helpers_form_FormFactory::getCommonActions(), 'bottom');
+        $this->form->setActions(tao_helpers_form_FormFactory::getCommonActions(), 'bottom');
     }
 
     /**
@@ -109,11 +109,11 @@ class tao_actions_form_EditClassLabel extends \tao_helpers_form_FormContainer
             }
             //set label validator
             $element->addValidators([
-                \tao_helpers_form_FormFactory::getValidator('NotEmpty'),
+                tao_helpers_form_FormFactory::getValidator('NotEmpty'),
             ]);
             $namespace = substr($clazz->getUri(), 0, strpos($clazz->getUri(), '#'));
             if (!$this->getNamespaceHelper()->isNamespaceSupported($namespace)) {
-                $readonly = \tao_helpers_form_FormFactory::getElement('', 'Readonly');
+                $readonly = tao_helpers_form_FormFactory::getElement('', 'Readonly');
                 $readonly->disable();
                 $readonly->setDescription($element->getDescription());
                 $readonly->setValue($element->getRawValue());
@@ -124,7 +124,7 @@ class tao_actions_form_EditClassLabel extends \tao_helpers_form_FormContainer
         }
 
         //add an hidden elt for the class uri
-        $classUriElt = \tao_helpers_form_FormFactory::getElement('classUri', 'Hidden');
+        $classUriElt = tao_helpers_form_FormFactory::getElement('classUri', 'Hidden');
         $classUriElt->setValue(\tao_helpers_Uri::encode($clazz->getUri()));
         $classUriElt->addClass('global');
         $this->form->addElement($classUriElt);

--- a/actions/form/class.EditClassLabel.php
+++ b/actions/form/class.EditClassLabel.php
@@ -113,7 +113,7 @@ class tao_actions_form_EditClassLabel extends \tao_helpers_form_FormContainer
             ]);
             $namespace = substr($clazz->getUri(), 0, strpos($clazz->getUri(), '#'));
             if (!$this->getNamespaceHelper()->isNamespaceSupported($namespace)) {
-                $readonly = \tao_helpers_form_FormFactory::getElement($element->getName(), 'Readonly');
+                $readonly = \tao_helpers_form_FormFactory::getElement('', 'Readonly');
                 $readonly->disable();
                 $readonly->setDescription($element->getDescription());
                 $readonly->setValue($element->getRawValue());

--- a/migrations/Version202403072011000000_tao.php
+++ b/migrations/Version202403072011000000_tao.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\generis\model\OntologyAwareTrait;
+use oat\generis\model\OntologyRdfs;
+use oat\tao\model\TaoOntology;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202403072011000000_tao extends AbstractMigration
+{
+    use OntologyAwareTrait;
+
+    public function getDescription(): string
+    {
+        return sprintf('Fix duplicated label for %s (Test-taker)', TaoOntology::CLASS_URI_SUBJECT);
+    }
+
+    public function up(Schema $schema): void
+    {
+        $testTakerClass = $this->getClass(TaoOntology::CLASS_URI_SUBJECT);
+        $labelProperty = $this->getProperty(OntologyRdfs::RDFS_LABEL);
+        $testTakerClass->removePropertyValue(
+            $labelProperty,
+            $testTakerClass->getOnePropertyValue($labelProperty)
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
+++ b/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
@@ -24,6 +24,7 @@
  *               2022 (update and modification) Open Assessment Technologies SA;
  */
 
+use oat\generis\model\data\Ontology;
 use oat\generis\model\OntologyRdf;
 use oat\tao\model\dataBinding\AbstractDataBinder;
 use oat\tao\model\dataBinding\GenerisInstanceDataBindingException;
@@ -126,12 +127,12 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
                     $types = is_array($propertyValue) ? $propertyValue : [$propertyValue];
 
                     foreach ($types as $type) {
-                        $instance->setType(new core_kernel_classes_Class($type));
+                        $instance->setType($this->getOntology()->getClass($type));
                     }
                     continue;
                 }
 
-                $prop = new core_kernel_classes_Property($propertyUri);
+                $prop = $this->getOntology()->getProperty($propertyUri);
 
                 if ($this->isBlockedForModification($prop)) {
                     continue;
@@ -181,7 +182,6 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
             return $instance;
         } catch (common_Exception $e) {
             $msg = "An error occured while binding property values to instance '': " . $e->getMessage();
-            $instanceUri = $instance->getUri();
             throw new tao_models_classes_dataBinding_GenerisInstanceDataBindingException($msg);
         }
     }
@@ -216,6 +216,11 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
     private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
     {
         return $this->getServiceManager()->get(FeatureFlagChecker::class);
+    }
+
+    private function getOntology(): Ontology
+    {
+        return $this->getServiceManager()->get(Ontology::SERVICE_ID);
     }
 
     private function getServiceManager(): ServiceManager

--- a/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
+++ b/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
@@ -196,7 +196,7 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
             return $property->isStatistical();
         }
 
-        return $property->isWritable();
+        return !$property->isWritable();
     }
 
     private function isEmptyValue(string $value): bool

--- a/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
+++ b/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
@@ -196,7 +196,7 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
             return $property->isStatistical();
         }
 
-        return !$property->isWritable();
+        return false;
     }
 
     private function isEmptyValue(string $value): bool

--- a/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
+++ b/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
@@ -196,7 +196,7 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
             return $property->isStatistical();
         }
 
-        return false;
+        return $property->isWritable();
     }
 
     private function isEmptyValue(string $value): bool

--- a/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
+++ b/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
@@ -71,9 +71,6 @@ class GenerisInstanceDataBinderTest extends TestCase
     /** @var Ontology|MockObject */
     private $ontology;
 
-    /** @var bool */
-    private $isWritable = true;
-
     public function setUp(): void
     {
         $this->eventManagerMock = $this->createMock(EventManager::class);
@@ -103,19 +100,11 @@ class GenerisInstanceDataBinderTest extends TestCase
         $this->property1
             ->method('getUri')
             ->willReturn(self::URI_PROPERTY_1);
-        $this->property1
-            ->method('isWritable')
-            ->will($this->returnCallback(function () {
-                return $this->isWritable;
-            }));
 
         $this->property2 = $this->createMock(core_kernel_classes_Property::class);
         $this->property2
             ->method('getUri')
             ->willReturn(self::URI_PROPERTY_2);
-        $this->property2
-            ->method('isWritable')
-            ->willReturn(true);
 
         $this->target
             ->method('getUri')
@@ -680,33 +669,6 @@ class GenerisInstanceDataBinderTest extends TestCase
 
         $resource = $this->sut->bind([
             self::URI_PROPERTY_2 => 'Value 2',
-        ]);
-
-        $this->assertSame($this->target, $resource);
-    }
-
-    public function testWillNotSaveNotWritableProperties(): void
-    {
-        $this->isWritable = false;
-
-        $this->eventManagerMock
-            ->expects($this->never())
-            ->method('trigger');
-
-        $this->target
-            ->expects($this->never())
-            ->method('getPropertyValuesCollection');
-
-        $this->target
-            ->expects($this->never())
-            ->method('setPropertyValue');
-
-        $this->target
-            ->expects($this->never())
-            ->method('removePropertyValues');
-
-        $resource = $this->sut->bind([
-            self::URI_PROPERTY_1 => 'Value 1',
         ]);
 
         $this->assertSame($this->target, $resource);

--- a/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
+++ b/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
@@ -20,6 +20,7 @@
 
 declare(strict_types=1);
 
+use oat\generis\model\data\Ontology;
 use oat\generis\test\MockObject;
 use oat\generis\test\TestCase;
 use oat\oatbox\event\EventManager;
@@ -66,6 +67,9 @@ class GenerisInstanceDataBinderTest extends TestCase
 
     /** @var FeatureFlagCheckerInterface|MockObject */
     private $featureFlagChecker;
+
+    /** @var Ontology|MockObject */
+    private $ontology;
 
     public function setUp(): void
     {
@@ -131,11 +135,26 @@ class GenerisInstanceDataBinderTest extends TestCase
             ->method('isEnabled')
             ->willReturn(false);
 
+        $this->ontology = $this->createMock(Ontology::class);
+        $this->ontology
+            ->method('getClass')
+            ->willReturnMap([
+                [self::URI_TYPE_1, $this->classType1],
+                [self::URI_TYPE_2, $this->classType2],
+            ]);
+        $this->ontology
+            ->method('getProperty')
+            ->willReturnMap([
+                [self::URI_PROPERTY_1, $this->property1],
+                [self::URI_PROPERTY_2, $this->property2],
+            ]);
+
         $this->sut->withEventManager($this->eventManagerMock);
         $this->sut->withServiceManager(
             $this->getServiceLocatorMock(
                 [
-                    FeatureFlagChecker::class => $this->featureFlagChecker
+                    FeatureFlagChecker::class => $this->featureFlagChecker,
+                    Ontology::SERVICE_ID => $this->ontology
                 ]
             )
         );


### PR DESCRIPTION
This PR aims to avoid saving/duplicating system properties from UI

How to test:
- Install recent TAO release with test-centers extension
- Select Test-taker root class
- Submit edit from or submit schema (properties) form
- Create test-center
- See duplicates as described [in the ticket](https://oat-sa.atlassian.net/browse/AUT-3552)
- Switch tao-core to this PRs branch and run taoUpdate
- Ensure that the duplicate has gone
- Submit forms related Test-taker root class as before
- Check that the duplicates do not appear anymore
- Check that other properties (which form inputs are not disabled) still editable from UI