### PR TITLE
fix google tag rendering

### DIFF
--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -593,8 +593,8 @@ class Layout
      */
     public static function getAnalyticsCode(): void
     {
-        $gaTag = getenv('GA_TAG');
-        $environment = getenv('NODE_ENV') === 'production' ? 'Production' : 'Internal';
+        $gaTag = $_ENV['GA_TAG'];
+        $environment = $_ENV['NODE_ENV'] === 'production' ? 'Production' : 'Internal';
 
         if ($gaTag && method_exists(self::$templateClass, 'inc')) {
             call_user_func(

--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -593,8 +593,8 @@ class Layout
      */
     public static function printAnalyticsCode(): void
     {
-        $gaTag = $_ENV['GA_TAG'];
-        $environment = $_ENV['NODE_ENV'] === 'production' ? 'Production' : 'Internal';
+        $gaTag = $_ENV['GA_TAG'] ?? '';
+        $environment = isset($_ENV['NODE_ENV']) && $_ENV['NODE_ENV'] === 'production' ? 'Production' : 'Internal';
 
         if ($gaTag && method_exists(self::$templateClass, 'inc')) {
             call_user_func(

--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -591,7 +591,7 @@ class Layout
     /**
      * Returns the necessary analytics code.
      */
-    public static function getAnalyticsCode(): void
+    public static function printAnalyticsCode(): void
     {
         $gaTag = $_ENV['GA_TAG'];
         $environment = $_ENV['NODE_ENV'] === 'production' ? 'Production' : 'Internal';

--- a/test/unit/helpers/LayoutTest.php
+++ b/test/unit/helpers/LayoutTest.php
@@ -20,11 +20,11 @@ class LayoutTest extends TestCase
         TemplateMock::resetCalls();
     }
 
-    public function testGetAnalyticsCodeWithGaTag(): void
+    public function testPrintAnalyticsCodeWithGaTag(): void
     {
         $this->setEnv('GA_TAG', 'dummy-ga-tag');
 
-        Layout::getAnalyticsCode();
+        Layout::printAnalyticsCode();
 
         self::assertSame(
             [
@@ -43,11 +43,11 @@ class LayoutTest extends TestCase
         );
     }
 
-    public function testGetAnalyticsCodeWithoutGaTag(): void
+    public function testPrintAnalyticsCodeWithoutGaTag(): void
     {
         $this->setEnv('GA_TAG', '');
 
-        Layout::getAnalyticsCode();
+        Layout::printAnalyticsCode();
 
         self::assertSame(
             [],

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -54,6 +54,6 @@ $hasVersionWarning = empty($_COOKIE['versionWarning'])
 <?=Layout::renderThemeTemplate(Theme::CONTEXT_BACKOFFICE, 'footer')?>
 
 <div class="loading-bar"></div>
-<? Layout::getAnalyticsCode(); ?>
+<?= Layout::getAnalyticsCode(); ?>
 </body>
 </html>

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -54,6 +54,6 @@ $hasVersionWarning = empty($_COOKIE['versionWarning'])
 <?=Layout::renderThemeTemplate(Theme::CONTEXT_BACKOFFICE, 'footer')?>
 
 <div class="loading-bar"></div>
-<?= Layout::getAnalyticsCode(); ?>
+<?php Layout::printAnalyticsCode(); ?>
 </body>
 </html>


### PR DESCRIPTION
# [TR-6036](https://oat-sa.atlassian.net/browse/TR-6036)

## Summary
This PR aim to address issue with rendering of GA tag in some environments

## Development impact
- fixed usage of deprecated sort tag `<? ?>` (which at least on `uat.eu.premium.lab.taocloud.org` converted into html comment)
- used `$_ENV` instead of `getenv` (usage of which [discouraged](https://github.com/vlucas/phpdotenv?tab=readme-ov-file#putenv-and-getenv) by dotenv lib documentation )

[TR-6036]: https://oat-sa.atlassian.net/browse/TR-6036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ