### PR TITLE
backport: MS-2756 backport to v54.6.2

### DIFF
--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -34,7 +34,7 @@ use oat\tao\model\layout\AmdLoader;
 
 class Layout
 {
-    private static string $templateClass = Template::class;
+    protected static string $templateClass = Template::class;
 
     public static function setTemplate(string $templateClass): void
     {

--- a/helpers/UserPilotTemplateHelper.php
+++ b/helpers/UserPilotTemplateHelper.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\helpers;
+
+use common_exception_Error;
+use oat\tao\model\session\Dto\UserPilotDto;
+
+class UserPilotTemplateHelper extends Layout
+{
+    public const USER_PILOT_TEMPLATE = 'blocks/userpilot.tpl';
+
+    /**
+     * @throws common_exception_Error
+     */
+    public static function userPilotCode(UserPilotDto $dto): void
+    {
+        $userPilotToken = getenv('USER_PILOT_TOKEN');
+        if (!$userPilotToken || !method_exists(self::$templateClass, 'inc')) {
+            return;
+        }
+
+        if (!$dto->getUserId()) {
+            return;
+        }
+
+        call_user_func(
+            [self::$templateClass, 'inc'],
+            self::USER_PILOT_TEMPLATE,
+            'tao',
+            [
+                'userpilot_data' => [
+                    'token' => $userPilotToken,
+                    'user' => [
+                        'id' => $dto->getUserId(),
+                        'name' => $dto->getUserName(),
+                        'login' => $dto->getUserLogin(),
+                        'email' => $dto->getUserEmail(),
+                        'roles' => join(',', $dto->getUserRoles()),
+                        'interface_language' => $dto->getInterfaceLanguage(),
+                    ],
+                    'tenant' => [
+                        'id' => $dto->getTenantId(),
+                    ]
+                ],
+            ]
+        );
+    }
+}

--- a/models/classes/session/Context/TenantDataSessionContext.php
+++ b/models/classes/session/Context/TenantDataSessionContext.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+namespace oat\tao\model\session\Context;
+
+use oat\oatbox\session\SessionContext;
+
+class TenantDataSessionContext implements SessionContext
+{
+    private ?string $tenantId;
+
+    public function __construct(string $tenantId = null)
+    {
+        $this->tenantId = $tenantId;
+    }
+
+    public function getTenantId(): ?string
+    {
+        return $this->tenantId;
+    }
+}

--- a/models/classes/session/Context/UserDataSessionContext.php
+++ b/models/classes/session/Context/UserDataSessionContext.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2013-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+namespace oat\tao\model\session\Context;
+
+use oat\oatbox\session\SessionContext;
+
+class UserDataSessionContext implements SessionContext
+{
+    private ?string $userId;
+    private ?string $userLogin;
+    private ?string $userName;
+    private ?string $userEmail;
+    private ?string $locale;
+
+    public function __construct(
+        string $userId = null,
+        string $userLogin = null,
+        string $userName = null,
+        string $userEmail = null,
+        string $locale = null
+    ) {
+        $this->userId = $userId;
+        $this->userLogin = $userLogin;
+        $this->userName = $userName;
+        $this->userEmail = $userEmail;
+        $this->locale = $locale;
+    }
+
+    public function getUserId(): ?string
+    {
+        return $this->userId;
+    }
+
+    public function getUserLogin(): ?string
+    {
+        return $this->userLogin;
+    }
+
+    public function getUserName(): ?string
+    {
+        return $this->userName;
+    }
+
+    public function getUserEmail(): ?string
+    {
+        return $this->userEmail;
+    }
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
+    }
+}

--- a/models/classes/session/Dto/UserPilotDto.php
+++ b/models/classes/session/Dto/UserPilotDto.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\model\session\Dto;
+
+use common_session_Session;
+use oat\tao\model\session\Context\TenantDataSessionContext;
+use oat\tao\model\session\Context\UserDataSessionContext;
+
+class UserPilotDto
+{
+    public const NOT_AVAILABLE = 'N/A';
+    public const DEFAULT_LOCALE = 'en-US';
+    private ?string $userId = null;
+    private ?string $userName = null;
+    private ?string $userLogin = null;
+    private ?string $userEmail = null;
+    private ?string $interfaceLanguage = null;
+    private array $userRoles = [];
+    private ?string $tenantId = null;
+
+    public function __construct($session = null)
+    {
+        if ($session instanceof common_session_Session) {
+            $contexts = $session->getContexts() ?? [];
+            foreach ($contexts as $context) {
+                if ($context instanceof UserDataSessionContext) {
+                    $this->userId = $context->getUserId();
+                    $this->userLogin = $context->getUserLogin() ?? self::NOT_AVAILABLE;
+                    $this->userName = $context->getUserName() ?? self::NOT_AVAILABLE;
+                    $this->userEmail = $context->getUserEmail() ?? self::NOT_AVAILABLE;
+                    $this->interfaceLanguage = $context->getLocale() ?? self::DEFAULT_LOCALE;
+                } elseif ($context instanceof TenantDataSessionContext) {
+                    $this->tenantId = $context->getTenantId();
+                }
+            }
+
+            if (null !== $this->userId && null !== $this->tenantId) {
+                $this->userId = $this->tenantId . '|' . $this->userId;
+            }
+
+            $this->userRoles = $session->getUserRoles() ?? [];
+        }
+    }
+
+    public function getUserId(): ?string
+    {
+        return $this->userId;
+    }
+
+    public function getUserLogin(): ?string
+    {
+        return $this->userLogin;
+    }
+
+    public function getUserName(): ?string
+    {
+        return $this->userName;
+    }
+
+    public function getUserEmail(): ?string
+    {
+        return $this->userEmail;
+    }
+
+    public function getInterfaceLanguage(): ?string
+    {
+        return $this->interfaceLanguage;
+    }
+
+    public function getUserRoles(): array
+    {
+        return $this->userRoles;
+    }
+
+    public function getTenantId(): ?string
+    {
+        return $this->tenantId;
+    }
+}

--- a/test/unit/helpers/LayoutTest.php
+++ b/test/unit/helpers/LayoutTest.php
@@ -3,7 +3,6 @@
 namespace oat\tao\test\unit\helpers;
 
 use oat\tao\helpers\Layout;
-use oat\tao\helpers\Template;
 use PHPUnit\Framework\TestCase;
 
 class LayoutTest extends TestCase
@@ -55,7 +54,7 @@ class LayoutTest extends TestCase
         );
     }
 
-    private function setEnv($key, $value)
+    protected function setEnv($key, $value): void
     {
         putenv("$key=$value");
         $_ENV[$key] = $value;

--- a/test/unit/helpers/UserPilotTemplateHelperTest.php
+++ b/test/unit/helpers/UserPilotTemplateHelperTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\tao\test\unit\helpers;
+
+use common_exception_Error;
+use common_session_AnonymousSession;
+use common_session_Session;
+use oat\oatbox\user\User;
+use oat\tao\helpers\UserPilotTemplateHelper;
+use oat\tao\model\session\Context\TenantDataSessionContext;
+use oat\tao\model\session\Context\UserDataSessionContext;
+use oat\tao\model\session\Dto\UserPilotDto;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class UserPilotTemplateHelperTest extends LayoutTest
+{
+    private ?MockObject $sessionMock = null;
+
+    /**
+     * @throws common_exception_Error
+     *
+     * @dataProvider provideUserPilotData
+     */
+    public function testUserPilotCode(
+        string $userPilotToken,
+        array $expectedCalls,
+        string $sessionMockClass = null,
+        string $userIdentifier = null,
+        string $login = null,
+        string $userName = null,
+        string $email = null,
+        string $locale = null,
+        array $userRole = null
+    ): void {
+        $this->setEnv('USER_PILOT_TOKEN', $userPilotToken);
+
+        if (null !== $sessionMockClass) {
+            $sessionUser = $this->createMock(User::class);
+            $user = $this->createMock(UserDataSessionContext::class);
+            $user
+                ->expects(self::once())
+                ->method('getUserId')
+                ->willReturn($userIdentifier);
+            $user
+                ->expects(self::once())
+                ->method('getUserLogin')
+                ->willReturn($login);
+            $user
+                ->expects(self::once())
+                ->method('getUserName')
+                ->willReturn($userName);
+            $user
+                ->expects(self::once())
+                ->method('getUserEmail')
+                ->willReturn($email);
+            $user
+                ->expects(self::once())
+                ->method('getLocale')
+                ->willReturn($locale);
+
+            $tenant = $this->createMock(TenantDataSessionContext::class);
+            $tenant
+                ->expects(self::once())
+                ->method('getTenantId')
+                ->willReturn('portal-authoring-client-id-local-dev-acc.nextgen-stack-local');
+
+            $this->sessionMock = $this->createMock($sessionMockClass);
+            $this->sessionMock->expects(self::once())->method('getUserRoles')->willReturn($userRole);
+            $this->sessionMock->expects(self::once())->method('getContexts')->willReturn([$user, $tenant]);
+        }
+        UserPilotTemplateHelper::userPilotCode(new UserPilotDto($this->sessionMock));
+
+        self::assertSame($expectedCalls, TemplateMock::getCalls());
+    }
+
+    public function provideUserPilotData(): array
+    {
+        return [
+            'No session' => [
+                '',
+                []
+            ],
+            'Anonymous session' => [
+                'dummy-user-pilot-token',
+                [],
+                common_session_AnonymousSession::class,
+                null,
+                'guest',
+                'guest',
+                null,
+                null,
+                ['https://www.tao.lu/Ontologies/generis.rdf#AnonymousRole']
+            ],
+            'Superuser session' => [
+                'dummy-user-pilot-token',
+                [
+                    [
+                        'oat\tao\test\unit\helpers\TemplateMock::inc' => [
+                            UserPilotTemplateHelper::USER_PILOT_TEMPLATE,
+                            'tao',
+                            [
+                                'userpilot_data' => [
+                                    'token' => 'dummy-user-pilot-token',
+                                    'user' => [
+                                        'id' => 'portal-authoring-client-id-local-dev-acc.nextgen-stack-local|admin',
+                                        'name' => 'Admin',
+                                        'login' => 'admin',
+                                        'email' => 'admin@taotesting.com',
+                                        'roles' =>
+                                            'https://www.tao.lu/Ontologies/TAO.rdf#GlobalManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#remoteProctoringManager,'
+                                            . 'https://www.tao.lu/Ontologies/TAO.rdf#BackOfficeRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAO.rdf#BaseUserRole,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#AnonymousRole,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#GenerisRole,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf'
+                                            . '#taoScoringServiceConnectManager,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#taoDeliverConnectManager,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#taoTaskQueueManager,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#taoTestPreviewUILoaderManager,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#ltiTestReviewManager,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#taoCeManager,'
+                                            . 'https://www.tao.lu/Ontologies/TAOProctor.rdf#TestCenterManager,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#taoEventLogManager,'
+                                            . 'https://www.tao.lu/Ontologies/taoFuncACL.rdf#FuncAclManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAOLTI.rdf#LtiDeliveryProviderManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/taoLti.rdf#LtiOutcomeUiManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAOResult.rdf#ResultsManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#taoLtiConsumerManager,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#taoDeliveryRdfManager,'
+                                            . 'https://www.tao.lu/Ontologies/TAOMedia.rdf#MediaManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiTestPreviewerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAOItem.rdf#QTIManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#qtiItemPciManager,'
+                                            . 'https://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAOItem.rdf#ItemsManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAOGroup.rdf#GroupsManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/generis.rdf#taoBackOfficeManager,'
+                                            . 'https://www.tao.lu/Ontologies/TAOResultServer.rdf#ResultServerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAOLTI.rdf#LtiManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAO.rdf#TaoManagerRole,'
+                                            . 'https://www.tao.lu/Ontologies/TAO.rdf#SysAdminRole',
+                                        'interface_language' => 'fr-FR'
+                                    ],
+                                    'tenant' => [
+                                        'id' => 'portal-authoring-client-id-local-dev-acc.nextgen-stack-local',
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                common_session_Session::class,
+                'admin',
+                'admin',
+                'Admin',
+                'admin@taotesting.com',
+                'fr-FR',
+                [
+                    'https://www.tao.lu/Ontologies/TAO.rdf#GlobalManagerRole',
+                    'https://www.tao.lu/Ontologies/generis.rdf#remoteProctoringManager',
+                    'https://www.tao.lu/Ontologies/TAO.rdf#BackOfficeRole',
+                    'https://www.tao.lu/Ontologies/TAO.rdf#BaseUserRole',
+                    'https://www.tao.lu/Ontologies/generis.rdf#AnonymousRole',
+                    'https://www.tao.lu/Ontologies/generis.rdf#GenerisRole',
+                    'https://www.tao.lu/Ontologies/generis.rdf#taoScoringServiceConnectManager',
+                    'https://www.tao.lu/Ontologies/generis.rdf#taoDeliverConnectManager',
+                    'https://www.tao.lu/Ontologies/generis.rdf#taoTaskQueueManager',
+                    'https://www.tao.lu/Ontologies/generis.rdf#taoTestPreviewUILoaderManager',
+                    'https://www.tao.lu/Ontologies/generis.rdf#ltiTestReviewManager',
+                    'https://www.tao.lu/Ontologies/generis.rdf#taoCeManager',
+                    'https://www.tao.lu/Ontologies/TAOProctor.rdf#TestCenterManager',
+                    'https://www.tao.lu/Ontologies/generis.rdf#taoEventLogManager',
+                    'https://www.tao.lu/Ontologies/taoFuncACL.rdf#FuncAclManagerRole',
+                    'https://www.tao.lu/Ontologies/TAOLTI.rdf#LtiDeliveryProviderManagerRole',
+                    'https://www.tao.lu/Ontologies/taoLti.rdf#LtiOutcomeUiManagerRole',
+                    'https://www.tao.lu/Ontologies/TAOResult.rdf#ResultsManagerRole',
+                    'https://www.tao.lu/Ontologies/generis.rdf#taoLtiConsumerManager',
+                    'https://www.tao.lu/Ontologies/generis.rdf#taoDeliveryRdfManager',
+                    'https://www.tao.lu/Ontologies/TAOMedia.rdf#MediaManagerRole',
+                    'https://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiTestPreviewerRole',
+                    'https://www.tao.lu/Ontologies/TAOTest.rdf#TaoQtiManagerRole',
+                    'https://www.tao.lu/Ontologies/TAOItem.rdf#QTIManagerRole',
+                    'https://www.tao.lu/Ontologies/generis.rdf#qtiItemPciManager',
+                    'https://www.tao.lu/Ontologies/TAOTest.rdf#TestsManagerRole',
+                    'https://www.tao.lu/Ontologies/TAOItem.rdf#ItemsManagerRole',
+                    'https://www.tao.lu/Ontologies/TAOGroup.rdf#GroupsManagerRole',
+                    'https://www.tao.lu/Ontologies/TAOSubject.rdf#SubjectsManagerRole',
+                    'https://www.tao.lu/Ontologies/generis.rdf#taoBackOfficeManager',
+                    'https://www.tao.lu/Ontologies/TAOResultServer.rdf#ResultServerRole',
+                    'https://www.tao.lu/Ontologies/TAOLTI.rdf#LtiManagerRole',
+                    'https://www.tao.lu/Ontologies/TAO.rdf#TaoManagerRole',
+                    'https://www.tao.lu/Ontologies/TAO.rdf#SysAdminRole'
+                ],
+            ],
+        ];
+    }
+}

--- a/views/templates/blocks/userpilot.tpl
+++ b/views/templates/blocks/userpilot.tpl
@@ -1,0 +1,17 @@
+<?php $userPilotData = get_data('userpilot_data'); ?>
+<script> window.userpilotSettings = {token: "<?= $userPilotData['token'] ?>"}; </script>
+<script src="https://js.userpilot.io/sdk/latest.js"></script>
+<script>
+    userpilot.identify(
+        "<?= $userPilotData['user']['id'] ?>",
+        {
+            name: "<?= $userPilotData['user']['name'] ?>",
+            login: "<?= $userPilotData['user']['login'] ?>",
+            email: "<?= $userPilotData['user']['email'] ?>",
+            interfaceLanguage: "<?= $userPilotData['user']['interface_language'] ?>",
+            company: {
+                id: "<?= $userPilotData['tenant']['id'] ?>",
+            }
+        }
+    );
+</script>

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -1,6 +1,8 @@
 <?php
 use oat\tao\helpers\Template;
 use oat\tao\helpers\Layout;
+use oat\tao\helpers\UserPilotTemplateHelper;
+use oat\tao\model\session\Dto\UserPilotDto;
 use oat\tao\model\theme\Theme;
 
 $releaseMsgData = Layout::getReleaseMsgData();
@@ -55,5 +57,6 @@ $hasVersionWarning = empty($_COOKIE['versionWarning'])
 
 <div class="loading-bar"></div>
 <?php Layout::printAnalyticsCode(); ?>
+<?php UserPilotTemplateHelper::userPilotCode(new UserPilotDto(common_session_SessionManager::getSession())); ?>
 </body>
 </html>


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/MS-2756

## What's Changed
- Added UserPilot to TAO 3.x.
- Backported to v54.6.2

## TODO 

- [x] Unit tests
- [x] E2E tests
- [x] Update composer with packages

## Dependencies PRs

## Related PRs
- https://github.com/oat-sa/extension-tao-lti/pull/400

## How to test
- Install TAO Portal and TAO 3.x Authoring using NGS.
- cd nextgen-stack/tao
- composer require "oat-sa/extension-tao-lti":"dev-feature/MS-2756/add-userpilot-to-tao-3.x as 15.15.1" "oat-sa/tao-core":"dev-feature/MS-2756/add-userpilot-to-tao-3.x as 54.4.1"
- Setup TAO Portal - Authoring simplification
- Login to TAO Portal
- Go to Authoring by clicking on Content Bank
- Inspect source code


## Screenshots
![image](https://github.com/oat-sa/tao-core/assets/8711268/f5b79ad3-5791-439a-86c7-520d3cbed19c)