### PR TITLE
feat: enable disabled actions by feature flags

### DIFF
--- a/models/classes/action/ActionBlackList.php
+++ b/models/classes/action/ActionBlackList.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2024 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -37,21 +37,23 @@ class ActionBlackList extends ConfigurableService
 
     public function isDisabled(string $action): bool
     {
-       return $this->isDisabledByDefault($action) && !$this->isEnabledByFeatureFlag($action) || $this->isDisabledByFeatureFlag($action);
+        return ($this->isDisabledByDefault($action) && !$this->isEnabledByFeatureFlag($action))
+            || $this->isDisabledByFeatureFlag($action);
     }
 
-    private function isDisabledByDefault($action) {
+    private function isDisabledByDefault(string $action): bool
+    {
         return array_search($action, (array) $this->getOption(self::OPTION_DISABLED_ACTIONS, [])) !== false;
     }
 
-    private function isDisabledByFeatureFlag($action)
+    private function isDisabledByFeatureFlag(string $action): bool
     {
         $disabledActionsMap = $this->getOption(self::OPTION_DISABLED_ACTIONS_FLAG_MAP, []);
         return isset($disabledActionsMap[$action])
             && $this->getFeatureFlagChecker()->isEnabled($disabledActionsMap[$action]);
     }
 
-    private function isEnabledByFeatureFlag($action)
+    private function isEnabledByFeatureFlag(string $action): bool
     {
         $enabledActionsByFeatureFlagMap = $this->getOption(self::OPTION_ENABLED_ACTIONS_BY_FEATURE_FLAG_MAP, []);
         return isset($enabledActionsByFeatureFlagMap[$action])

--- a/models/classes/action/ActionBlackList.php
+++ b/models/classes/action/ActionBlackList.php
@@ -33,16 +33,29 @@ class ActionBlackList extends ConfigurableService
     public const SERVICE_ID = 'tao/ActionBlackList';
     public const OPTION_DISABLED_ACTIONS = 'disabledActions';
     public const OPTION_DISABLED_ACTIONS_FLAG_MAP = 'disabledActionsMap';
+    public const OPTION_ENABLED_ACTIONS_BY_FEATURE_FLAG_MAP = 'enabledActionsByFeatureFlagMap';
 
     public function isDisabled(string $action): bool
     {
-        $disabledActionsMap = $this->getOption(self::OPTION_DISABLED_ACTIONS_FLAG_MAP, []);
+       return $this->isDisabledByDefault($action) && !$this->isEnabledByFeatureFlag($action) || $this->isDisabledByFeatureFlag($action);
+    }
 
-        return array_search($action, (array) $this->getOption(self::OPTION_DISABLED_ACTIONS, [])) !== false ||
-            (
-                isset($disabledActionsMap[$action]) &&
-                $this->getFeatureFlagChecker()->isEnabled($disabledActionsMap[$action])
-            );
+    private function isDisabledByDefault($action) {
+        return array_search($action, (array) $this->getOption(self::OPTION_DISABLED_ACTIONS, [])) !== false;
+    }
+
+    private function isDisabledByFeatureFlag($action)
+    {
+        $disabledActionsMap = $this->getOption(self::OPTION_DISABLED_ACTIONS_FLAG_MAP, []);
+        return isset($disabledActionsMap[$action])
+            && $this->getFeatureFlagChecker()->isEnabled($disabledActionsMap[$action]);
+    }
+
+    private function isEnabledByFeatureFlag($action)
+    {
+        $enabledActionsByFeatureFlagMap = $this->getOption(self::OPTION_ENABLED_ACTIONS_BY_FEATURE_FLAG_MAP, []);
+        return isset($enabledActionsByFeatureFlagMap[$action])
+            && $this->getFeatureFlagChecker()->isEnabled($enabledActionsByFeatureFlagMap[$action]);
     }
 
     private function getFeatureFlagChecker(): FeatureFlagChecker

--- a/test/unit/models/classes/action/ActionBlackListTest.php
+++ b/test/unit/models/classes/action/ActionBlackListTest.php
@@ -49,15 +49,22 @@ class ActionBlackListTest extends TestCase
 
         $this->actionBlackListMock
             ->method('isEnabled')
-            ->with('DISABLE_ACTION_BY_FEATURE_FLAG')
+            ->with($this->callback(function ($envVarName) {
+                return in_array($envVarName, ['FEATURE_FLAG_ENABLE_ONE_ACTION', 'DISABLE_ACTION_BY_FEATURE_FLAG']);
+            }))
             ->willReturn(true);
 
         $this->subject->setOption(ActionBlackList::OPTION_DISABLED_ACTIONS, [
-            'some-action-to-disable'
+            'some-action-to-disable',
+            'action-disabled-by-default-but-enabled-by-ff'
         ]);
 
         $this->subject->setOption(ActionBlackList::OPTION_DISABLED_ACTIONS_FLAG_MAP, [
             'some-action-disabled-by-feature-flag' => 'DISABLE_ACTION_BY_FEATURE_FLAG'
+        ]);
+
+        $this->subject->setOption(ActionBlackList::OPTION_ENABLED_ACTIONS_BY_FEATURE_FLAG_MAP, [
+            'action-disabled-by-default-but-enabled-by-ff' => 'FEATURE_FLAG_ENABLE_ONE_ACTION'
         ]);
     }
 
@@ -74,7 +81,8 @@ class ActionBlackListTest extends TestCase
         return [
             'configurable service value' => ['some-action-to-disable', true],
             'feature flag value' => ['some-action-disabled-by-feature-flag', true],
-            'action not disabled' => ['some-action-that-is-not-disabled', false]
+            'action not disabled' => ['some-action-that-is-not-disabled', false],
+            'disabled action toggled on by ff' => ['action-disabled-by-default-but-enabled-by-ff', false],
         ];
     }
 }


### PR DESCRIPTION
This PR aims to add ability to enable disabled action by feature flag.

How to test:
```php
return new oat\tao\model\action\ActionBlackList(array(
    'disabledActions' => array(
        'action-name'
    ),
    'enabledActionsByFeatureFlagMap' => array(
       'action-name' => 'FEATURE_FLAG_THAT_ENABLES_ACTION_NAME'
    )
));
```
- Add some action id in a list of `disabledActions` in  `config/tao/ActionBlackList.conf.php` as above
- Validate that action button is **not visible** in TAO3.x UI (existing functionality)
- Add a map pair into `enabledActionsByFeatureFlagMap` in the same conf file
- Set the chosen environment variable to `true`; validate that action button is **visible**
- Set the chosen environment variable to `false`; validate that action button is **not visible**