### PR TITLE
Feature/AUT-3626/Feature flag to enable the Solar Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Here you can find the environment variables including feature flags
 | FEATURE_FLAG_ADVANCED_SEARCH_DISABLED  | Disable advanced search feature, if set to 1                                                                                         | -             |
 | FEATURE_FLAG_STATISTIC_METADATA_IMPORT | Enable statistics metadata import                                                                                                    | -             |
 | FEATURE_FLAG_CKEDITOR_SOURCEDIALOG     | Enable source editing for ckeditor                                                                                                   | false         |
+| FEATURE_FLAG_SOLAR_DESIGN_ENABLED      | Activate the Solar Design mode                                                                                                       | -             |
 | GOOGLE_APPLICATION_CREDENTIALS         | Path to GCP credentials path                                                                                                         | -             |
 | DATA_STORE_STATISTIC_PUB_SUB_TOPIC     | Topic name for statistic metadata Pub/Sub                                                                                            | -             |
 | REDIRECT_AFTER_LOGOUT_URL              | Allows to configure the redirect after logout via environment variable. The fallback is the configured redirect on urlroute.conf.php | -             |

--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2014-2024 (original work) Open Assessment Technologies SA;
  *
  *
  */
@@ -260,6 +260,14 @@ class Layout
     {
         $settingsMenu = get_data('settings-menu');
         return empty(get_data('main-menu')) && empty($settingsMenu) || count($settingsMenu) < 3;
+    }
+
+    /**
+     * Tells if the Solar Design System should apply.
+     */
+    public static function isSolarDesignEnabled(): bool
+    {
+        return self::getThemeService()->isSolarDesignEnabled();
     }
 
 
@@ -613,6 +621,11 @@ class Layout
      */
     protected static function getCurrentTheme()
     {
-        return ServiceManager::getServiceManager()->get(ThemeService::SERVICE_ID)->getTheme();
+        return self::getThemeService()->getTheme();
+    }
+
+    private static function getThemeService(): ThemeService
+    {
+        return ServiceManager::getServiceManager()->get(ThemeService::SERVICE_ID);
     }
 }

--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -31,6 +31,7 @@ use oat\tao\model\theme\Theme;
 use oat\tao\model\theme\ThemeService;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\layout\AmdLoader;
+use oat\tao\model\theme\SolarDesignCheckerInterface;
 
 class Layout
 {
@@ -267,9 +268,19 @@ class Layout
      */
     public static function isSolarDesignEnabled(): bool
     {
-        return self::getThemeService()->isSolarDesignEnabled();
-    }
+        // if FEATURE_FLAG_SOLAR_DESIGN_ENABLED is active, the feature is always on
+        if (self::getThemeService()->isSolarDesignEnabled()) {
+            return true;
+        }
 
+        // a theme can also require the feature based on an option
+        $theme = self::getCurrentTheme();
+        if ($theme instanceof SolarDesignCheckerInterface) {
+            return $theme->isSolarDesignEnabled();
+        }
+
+        return false;
+    }
 
     /**
      * Retrieve the template with the actual content

--- a/models/classes/featureFlag/FeatureFlagCheckerInterface.php
+++ b/models/classes/featureFlag/FeatureFlagCheckerInterface.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2024 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -29,6 +29,7 @@ interface FeatureFlagCheckerInterface
     public const FEATURE_FLAG_LISTS_DEPENDENCY_ENABLED = 'FEATURE_FLAG_LISTS_DEPENDENCY_ENABLED';
     public const FEATURE_FLAG_STATISTIC_METADATA_IMPORT = 'FEATURE_FLAG_STATISTIC_METADATA_IMPORT';
     public const FEATURE_FLAG_PASSWORD_CHANGE_DISABLED = 'FEATURE_FLAG_PASSWORD_CHANGE_DISABLED';
+    public const FEATURE_FLAG_SOLAR_DESIGN_ENABLED = 'FEATURE_FLAG_SOLAR_DESIGN_ENABLED';
 
     public function isEnabled(string $feature): bool;
 }

--- a/models/classes/theme/ConfigurablePlatformTheme.php
+++ b/models/classes/theme/ConfigurablePlatformTheme.php
@@ -35,9 +35,10 @@ use oat\tao\helpers\Template;
  * @deprecated until operation issues as resolved
  * @package oat\tao\model\theme
  */
-class ConfigurablePlatformTheme extends Configurable implements Theme
+class ConfigurablePlatformTheme extends Configurable implements Theme, SolarDesignCheckerInterface
 {
     use PortalTemplateFinderTrait;
+    use SolarDesignCheckerTrait;
 
     /** Theme extension id key */
     public const EXTENSION_ID = 'extensionId';

--- a/models/classes/theme/ConfigurableTheme.php
+++ b/models/classes/theme/ConfigurableTheme.php
@@ -50,8 +50,10 @@ use oat\tao\helpers\Template;
  * @package oat\tao\model\theme
  * @deprecated use oat\tao\model\theme\ConfigurablePlatformTheme instead
  */
-class ConfigurableTheme extends Configurable implements Theme
+class ConfigurableTheme extends Configurable implements Theme, SolarDesignCheckerInterface
 {
+    use SolarDesignCheckerTrait;
+
     /** Theme id offset in the options. */
     public const THEME_ID    = 'id';
 

--- a/models/classes/theme/SolarDesignCheckerInterface.php
+++ b/models/classes/theme/SolarDesignCheckerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\theme;
+
+interface SolarDesignCheckerInterface
+{
+    public const SOLAR_DESIGN_ENABLED = 'solarDesignEnabled';
+
+    public function isSolarDesignEnabled(): bool;
+}

--- a/models/classes/theme/SolarDesignCheckerTrait.php
+++ b/models/classes/theme/SolarDesignCheckerTrait.php
@@ -27,10 +27,7 @@ trait SolarDesignCheckerTrait
     public function isSolarDesignEnabled(): bool
     {
         $themeData = $this->getThemeData();
-        if (array_key_exists(SolarDesignCheckerInterface::SOLAR_DESIGN_ENABLED, $themeData) &&
-            $themeData[SolarDesignCheckerInterface::SOLAR_DESIGN_ENABLED]) {
-            return true;
-        }
-        return false;
+
+        return !empty($themeData[SolarDesignCheckerInterface::SOLAR_DESIGN_ENABLED]);
     }
 }

--- a/models/classes/theme/SolarDesignCheckerTrait.php
+++ b/models/classes/theme/SolarDesignCheckerTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\theme;
+
+trait SolarDesignCheckerTrait
+{
+    public function isSolarDesignEnabled(): bool
+    {
+        $themeData = $this->getThemeData();
+        if (array_key_exists(SolarDesignCheckerInterface::SOLAR_DESIGN_ENABLED, $themeData) &&
+            $themeData[SolarDesignCheckerInterface::SOLAR_DESIGN_ENABLED]) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/models/classes/theme/ThemeService.php
+++ b/models/classes/theme/ThemeService.php
@@ -15,13 +15,16 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2015-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
 namespace oat\tao\model\theme;
 
 use oat\oatbox\Configurable;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  *
@@ -116,5 +119,22 @@ class ThemeService extends ThemeServiceAbstract
         $this->setOption(static::OPTION_AVAILABLE, $availableThemes);
 
         return true;
+    }
+
+    public function isSolarDesignEnabled(): bool
+    {
+        return $this->getFeatureFlagChecker()->isEnabled(
+            FeatureFlagCheckerInterface::FEATURE_FLAG_SOLAR_DESIGN_ENABLED
+        );
+    }
+
+    private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
+    {
+        return $this->getContainer()->get(FeatureFlagChecker::class);
+    }
+
+    private function getContainer(): ContainerInterface
+    {
+        return $this->getServiceManager()->getContainer();
     }
 }

--- a/views/templates/layout.tpl
+++ b/views/templates/layout.tpl
@@ -33,7 +33,7 @@ $hasVersionWarning = empty($_COOKIE['versionWarning'])
     <link rel="stylesheet" href="<?= Layout::getThemeStylesheet(Theme::CONTEXT_BACKOFFICE) ?>" />
 </head>
 
-<body<?php Layout::isSmallNavi() && print ' class="small-navi"'?>>
+<body class="<?= Layout::isSolarDesignEnabled() ? 'solar-design' : '' ?><?= Layout::isSmallNavi() ? ' small-navi' : '' ?>">
 <?php Template::inc('blocks/requirement-check.tpl', 'tao'); ?>
 
 <div class="content-wrap">


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/AUT-3626

### Summary

Add a feature flag to enable the Solar Design to the authoring.

### Details

Feature flag for activating the solar design system: `FEATURE_FLAG_SOLAR_DESIGN_ENABLED`

The feature flag will be activated with:
```sh
php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_SOLAR_DESIGN_ENABLED -v true
```

Once activated, the CSS class `solar-design` is added to the body element of the page.

### How to test

- check out the branch: `git checkout -t origin/feature/AUT-3626/feature-flag-for-solar-design`
- activate the feature flag: `php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_SOLAR_DESIGN_ENABLED -v true`
- log in to TAO backoffice
- open the browser dev tools, and check that the body element received the CSS class `solar-design`
