### PR TITLE
Fix/AUT-3626/Feature flag for solar design

### DIFF
--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -29,6 +29,7 @@ use oat\tao\model\theme\ConfigurablePlatformTheme;
 use oat\tao\model\theme\ConfigurableTheme;
 use oat\tao\model\theme\Theme;
 use oat\tao\model\theme\ThemeService;
+use oat\tao\model\theme\ThemeServiceAbstract;
 use oat\oatbox\service\ServiceManager;
 use oat\tao\model\layout\AmdLoader;
 use oat\tao\model\theme\SolarDesignCheckerInterface;
@@ -635,7 +636,7 @@ class Layout
         return self::getThemeService()->getTheme();
     }
 
-    private static function getThemeService(): ThemeService
+    private static function getThemeService(): ThemeServiceAbstract
     {
         return ServiceManager::getServiceManager()->get(ThemeService::SERVICE_ID);
     }

--- a/models/classes/theme/ThemeService.php
+++ b/models/classes/theme/ThemeService.php
@@ -15,16 +15,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2015-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
 namespace oat\tao\model\theme;
 
 use oat\oatbox\Configurable;
-use oat\tao\model\featureFlag\FeatureFlagChecker;
-use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
-use Psr\Container\ContainerInterface;
 
 /**
  *
@@ -119,22 +116,5 @@ class ThemeService extends ThemeServiceAbstract
         $this->setOption(static::OPTION_AVAILABLE, $availableThemes);
 
         return true;
-    }
-
-    public function isSolarDesignEnabled(): bool
-    {
-        return $this->getFeatureFlagChecker()->isEnabled(
-            FeatureFlagCheckerInterface::FEATURE_FLAG_SOLAR_DESIGN_ENABLED
-        );
-    }
-
-    private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
-    {
-        return $this->getContainer()->get(FeatureFlagChecker::class);
-    }
-
-    private function getContainer(): ContainerInterface
-    {
-        return $this->getServiceManager()->getContainer();
     }
 }

--- a/models/classes/theme/ThemeServiceAbstract.php
+++ b/models/classes/theme/ThemeServiceAbstract.php
@@ -228,7 +228,7 @@ abstract class ThemeServiceAbstract extends ConfigurableService implements Theme
             ->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_TAO_AS_A_TOOL);
     }
 
-    protected function getFeatureFlagChecker(): FeatureFlagCheckerInterface
+    private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
     {
         return $this->getContainer()->get(FeatureFlagChecker::class);
     }

--- a/models/classes/theme/ThemeServiceAbstract.php
+++ b/models/classes/theme/ThemeServiceAbstract.php
@@ -233,7 +233,7 @@ abstract class ThemeServiceAbstract extends ConfigurableService implements Theme
         return $this->getContainer()->get(FeatureFlagChecker::class);
     }
 
-    protected function getContainer(): ContainerInterface
+    private function getContainer(): ContainerInterface
     {
         return $this->getServiceManager()->getContainer();
     }

--- a/models/classes/theme/ThemeServiceAbstract.php
+++ b/models/classes/theme/ThemeServiceAbstract.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017-2022 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2017-2024 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
 namespace oat\tao\model\theme;
@@ -25,6 +25,7 @@ use oat\oatbox\service\ConfigurableService;
 use oat\tao\model\DynamicConfig\DynamicConfigProviderInterface;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
 use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use Psr\Container\ContainerInterface;
 
 abstract class ThemeServiceAbstract extends ConfigurableService implements ThemeServiceInterface
 {
@@ -111,6 +112,13 @@ abstract class ThemeServiceAbstract extends ConfigurableService implements Theme
         }
 
         throw new common_exception_InconsistentData('The requested theme does not exist. (' . $themeId . ')');
+    }
+
+    public function isSolarDesignEnabled(): bool
+    {
+        return $this->getFeatureFlagChecker()->isEnabled(
+            FeatureFlagCheckerInterface::FEATURE_FLAG_SOLAR_DESIGN_ENABLED
+        );
     }
 
     /**
@@ -216,9 +224,17 @@ abstract class ThemeServiceAbstract extends ConfigurableService implements Theme
 
     protected function isTaoAsToolEnabled(): bool
     {
-        return $this->getServiceManager()
-            ->getContainer()
-            ->get(FeatureFlagChecker::class)
+        return $this->getFeatureFlagChecker()
             ->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_TAO_AS_A_TOOL);
+    }
+
+    protected function getFeatureFlagChecker(): FeatureFlagCheckerInterface
+    {
+        return $this->getContainer()->get(FeatureFlagChecker::class);
+    }
+
+    protected function getContainer(): ContainerInterface
+    {
+        return $this->getServiceManager()->getContainer();
     }
 }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/AUT-3626

### Summary

Fix a blocking issue breaking any page load when a theme service does not inherit from `oat\tao\model\theme\ThemeService`.

### Details

To check if the Solar Design is enabled, the theme classes implement a check with respect to a feature flag. However, this check was placed in a parent class that is not inherited by all theme services.

This check is now moved to the abstract class.

### How to test
- check out the branch: `git checkout -t origin/fix/AUT-3626/feature-flag-for-solar-design`
- log in to TAO backoffice
- the page should load
- activate the feature flag: `php index.php 'oat\tao\scripts\tools\FeatureFlag\FeatureFlagTool' -s FEATURE_FLAG_SOLAR_DESIGN_ENABLED -v true`
- check that the Solar Design applies

Note: the issue arose with the extension taoStyles which is using another theme service (PersistenceThemeService)