### PR TITLE
fix: use TaoLtiSession to decide theme selection

### DIFF
--- a/models/classes/theme/ThemeService.php
+++ b/models/classes/theme/ThemeService.php
@@ -23,7 +23,6 @@ namespace oat\tao\model\theme;
 
 use common_session_SessionManager;
 use oat\oatbox\Configurable;
-use oat\tao\model\session\Business\Service\SessionCookieService;
 use oat\taoLti\models\classes\TaoLtiSession;
 
 /**

--- a/models/classes/theme/ThemeService.php
+++ b/models/classes/theme/ThemeService.php
@@ -21,7 +21,10 @@
 
 namespace oat\tao\model\theme;
 
+use common_session_SessionManager;
 use oat\oatbox\Configurable;
+use oat\tao\model\session\Business\Service\SessionCookieService;
+use oat\taoLti\models\classes\TaoLtiSession;
 
 /**
  *
@@ -34,7 +37,7 @@ class ThemeService extends ThemeServiceAbstract
      */
     public function getCurrentThemeId()
     {
-        if ($this->isTaoAsToolEnabled()) {
+        if (common_session_SessionManager::getSession() instanceof TaoLtiSession) {
             return PortalTheme::THEME_ID;
         }
 


### PR DESCRIPTION
When user access to Tao 3.x from Tao Portal Tao will have back button that will lead back to Tao Portal
When user login using Tao login page we will use regular Tao Theme


https://github.com/oat-sa/tao-core/assets/16231681/76775c8b-f490-4670-8038-5e1fcf868424

https://github.com/oat-sa/tao-core/assets/16231681/0f89e58f-1ec0-4f8c-a1d9-f667cc633e78



