### PR TITLE
fix: keep empty element when no children defined as user_settings

### DIFF
--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -457,6 +457,16 @@ class tao_actions_Main extends tao_actions_CommonModule
                 }
                 $entries[$i] = $entry;
             }
+
+            //We want to always keep user settings menu dropdown even if there is no children to place logout button.
+            if (empty($children) && $perspective->getId() === 'user_settings') {
+                $entry = [
+                    'perspective' => $perspective,
+                    'children'    => []
+                ];
+
+                $entries[$i] = $entry;
+            }
         }
         return $entries;
     }


### PR DESCRIPTION
This is required to keep logout button when no children are included in User Settings.  

![Screenshot 2024-06-13 at 16 26 37](https://github.com/oat-sa/tao-core/assets/16231681/c0115365-3d42-4b1f-aeb7-50944840213a)
