### PR TITLE
Fix/TR-6195/Upgrade tao-core-sdk

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@babel/polyfill": "^7.4.4",
                 "@oat-sa/tao-core-libs": "^1.0.0",
-                "@oat-sa/tao-core-sdk": "^3.1.1",
+                "@oat-sa/tao-core-sdk": "^3.2.1",
                 "@oat-sa/tao-core-shared-libs": "^1.6.1",
                 "@oat-sa/tao-core-ui": "^3.4.0",
                 "codemirror": "^5.54.0",
@@ -64,13 +64,14 @@
             }
         },
         "node_modules/@oat-sa/tao-core-sdk": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-3.1.1.tgz",
-            "integrity": "sha512-0buO1HnJ5hDRSg5qRjEhkiWbMyVpnRs7G6kkCu7p73K4p395orGnNO7o5+7lEQhomLsiMAdYQQf6KQIcmdvuUA==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-sdk/-/tao-core-sdk-3.2.1.tgz",
+            "integrity": "sha512-PCYizZi06f6rzBlyP9Hpabza2wO439KT9fb2vtJmqM7SkHlr7AHReMXu+HjfP3y3k16Z84Fd3ODIFMcP0GwjAQ==",
             "dependencies": {
-                "fastestsmallesttextencoderdecoder": "1.0.14",
                 "idb-wrapper": "1.7.2",
-                "webcrypto-shim": "0.1.7"
+                "jquery": "1.9.1",
+                "lodash": "^4.17.21",
+                "moment": "^2.29.4"
             }
         },
         "node_modules/@oat-sa/tao-core-shared-libs": {
@@ -118,11 +119,6 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
             "integrity": "sha512-jrxnPsCGqng1UZuEp9DecX/AuSyAszATSjf4oEcRxvfxa1Oux4KkIPKBAAWWnpdwfARtr+Q0o9aPYWjsROD7ug=="
-        },
-        "node_modules/fastestsmallesttextencoderdecoder": {
-            "version": "1.0.14",
-            "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.14.tgz",
-            "integrity": "sha512-ov+uDh4DMZHpZvcGwlCb9tfntaHwRI7SK+/6XkdXhksZLJcMoTJ20FZx3GvujnsGjMvJVQ71LkduEUEPwX1BvQ=="
         },
         "node_modules/fs": {
             "version": "0.0.1-security",
@@ -269,11 +265,6 @@
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.12.tgz",
             "integrity": "sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A=="
-        },
-        "node_modules/webcrypto-shim": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.7.tgz",
-            "integrity": "sha512-JAvAQR5mRNRxZW2jKigWMjCMkjSdmP5cColRP1U/pTg69VgHXEi1orv5vVpJ55Zc5MIaPc1aaurzd9pjv2bveg=="
         },
         "node_modules/wordwrap": {
             "version": "0.0.3",

--- a/views/package.json
+++ b/views/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/tao-core-libs": "^1.0.0",
-        "@oat-sa/tao-core-sdk": "^3.1.1",
+        "@oat-sa/tao-core-sdk": "^3.2.1",
         "@oat-sa/tao-core-shared-libs": "^1.6.1",
         "@oat-sa/tao-core-ui": "^3.4.0",
         "codemirror": "^5.54.0",


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-6195

Goal: TAO 3.x still working

- `tao-core-sdk` changes: https://github.com/oat-sa/tao-core-sdk-fe/pull/187
- local `oat-sa-tao-core-sdk-3.1.2.tgz` must be removed before merge

Deployed to: https://test-tr-6195-authoring.v3.playground.taocloud.org/