### PR TITLE
fix: remove the extra "Content Bank" title from the nav bar

### DIFF
--- a/views/templates/blocks/portal/back-button.tpl
+++ b/views/templates/blocks/portal/back-button.tpl
@@ -4,7 +4,6 @@ if (get_data('userLabel')): ?>
     <a href="<?= get_data('portalUrl'); ?>" title="<?= __("Back to Portal"); ?>" class="lft portal-back">
         <span class="icon-back-button glyph"></span>
     </a>
-    <span class="lft header-title"><?= __("Content bank") ?></span>
 <?php else: ?>
     <?php Template::inc('blocks/header-logo.tpl'); ?>
 <?php endif; ?>


### PR DESCRIPTION
# [ADF-1727](https://oat-sa.atlassian.net/browse/ADF-1727)

This PR removes the not-needed "Content Bank" title from TAO 3.x' nav bar when launched via TAO Portal.

|Before|After|
|-|-|
|<img width="719" alt="image" src="https://github.com/user-attachments/assets/e1e9586a-6f87-48b8-bc6f-1fd8d5d8baa0">|<img width="719" alt="image" src="https://github.com/user-attachments/assets/68c866d6-8426-4ee9-a62a-ebfb5fbfae1c">|

[ADF-1727]: https://oat-sa.atlassian.net/browse/ADF-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ