### PR TITLE
fix: archive tasks using bulk update with predefined batch

### DIFF
--- a/actions/class.TaskQueueWebApi.php
+++ b/actions/class.TaskQueueWebApi.php
@@ -149,7 +149,7 @@ class tao_actions_TaskQueueWebApi extends tao_actions_CommonModule
             $taskLogService = $this->getTaskLogService();
 
             // Define batch size for the chunk of tasks to be processed in each iteration
-            $batchSize = 100; // Adjust this number based on server capabilities
+            $batchSize = 1000; // Adjust this number based on server capabilities
             $success = false;
 
             // If taskIds is ALL, we'll fetch all tasks using pagination


### PR DESCRIPTION
`'php error(1) in /var/www/html/tao/tao/models/classes/taskQueue/TaskLog/Entity/TaskLogEntity.php@120: Allowed memory size of 536870912 bytes exhausted`

During archiving a lot of tasks we may have the issue on the PHP side about memory size. For fixing that we will add updating by using batch size.


How to test:

1. Create a few tasks
2. Try to archive them