### PR TITLE
Fix/aut 3877/archive tasks

### DIFF
--- a/actions/class.TaskQueueWebApi.php
+++ b/actions/class.TaskQueueWebApi.php
@@ -149,7 +149,7 @@ class tao_actions_TaskQueueWebApi extends tao_actions_CommonModule
             $taskLogService = $this->getTaskLogService();
 
             // Define batch size for the chunk of tasks to be processed in each iteration
-            $batchSize = 1000; // Adjust this number based on server capabilities
+            $batchSize = $taskLogService->getOption(TaskLogInterface::OPTION_DEFAULT_BATCH_SIZE);
             $success = false;
 
             // If taskIds is ALL, we'll fetch all tasks using pagination

--- a/actions/class.TaskQueueWebApi.php
+++ b/actions/class.TaskQueueWebApi.php
@@ -149,7 +149,7 @@ class tao_actions_TaskQueueWebApi extends tao_actions_CommonModule
             $taskLogService = $this->getTaskLogService();
 
             // Define batch size for the chunk of tasks to be processed in each iteration
-            $batchSize = 100; // Adjust this number based on server capabilities
+            $batchSize = 1000; // Adjust this number based on server capabilities
             $success = false;
 
             // If taskIds is ALL, we'll fetch all tasks using pagination

--- a/migrations/Version202409301236442234_tao.php
+++ b/migrations/Version202409301236442234_tao.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\taskQueue\TaskLogInterface;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202409301236442234_tao extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Update taoTaskLog with default batch size';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $serviceManager = $this->getServiceManager();
+        $taskLog = $serviceManager->get(TaskLogInterface::SERVICE_ID);
+        $taskLog->setOption(TaskLogInterface::OPTION_DEFAULT_BATCH_SIZE, TaskLogInterface::DEFAULT_BATCH_SIZE);
+        $serviceManager->register(TaskLogInterface::SERVICE_ID, $taskLog);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $serviceManager = $this->getServiceManager();
+        $taskLog = $serviceManager->get(TaskLogInterface::SERVICE_ID);
+        $options = $taskLog->getOptions();
+        if (isset($options[TaskLogInterface::OPTION_DEFAULT_BATCH_SIZE])) {
+            unset($options[TaskLogInterface::OPTION_DEFAULT_BATCH_SIZE]);
+        }
+        $taskLog->setOptions($options);
+        $serviceManager->register(TaskLogInterface::SERVICE_ID, $taskLog);
+    }
+}

--- a/models/classes/taskQueue/TaskLogInterface.php
+++ b/models/classes/taskQueue/TaskLogInterface.php
@@ -71,6 +71,9 @@ interface TaskLogInterface extends LoggerAwareInterface
 
     public const DEFAULT_LIMIT = 20;
 
+    public const OPTION_DEFAULT_BATCH_SIZE = 'default_batch_size';
+    public const DEFAULT_BATCH_SIZE = 1000;
+
     /**
      * It's not related to the user management, just a placeholder to distinguish the user running the script from CLI.
      */

--- a/scripts/install/RegisterTaskQueueServices.php
+++ b/scripts/install/RegisterTaskQueueServices.php
@@ -39,7 +39,7 @@ class RegisterTaskQueueServices extends InstallAction
     {
         $taskLogService = new TaskLog([
             TaskLogInterface::OPTION_TASK_LOG_BROKER => new TaskLog\Broker\RdsTaskLogBroker('default'),
-            TaskLogInterface::OPTION_DEFAULT_BATCH_SIZE => 1000
+            TaskLogInterface::OPTION_DEFAULT_BATCH_SIZE => TaskLogInterface::DEFAULT_BATCH_SIZE
         ]);
         $this->registerService(TaskLogInterface::SERVICE_ID, $taskLogService);
 

--- a/scripts/install/RegisterTaskQueueServices.php
+++ b/scripts/install/RegisterTaskQueueServices.php
@@ -38,7 +38,8 @@ class RegisterTaskQueueServices extends InstallAction
     public function __invoke($params)
     {
         $taskLogService = new TaskLog([
-            TaskLogInterface::OPTION_TASK_LOG_BROKER => new TaskLog\Broker\RdsTaskLogBroker('default')
+            TaskLogInterface::OPTION_TASK_LOG_BROKER => new TaskLog\Broker\RdsTaskLogBroker('default'),
+            TaskLogInterface::OPTION_DEFAULT_BATCH_SIZE => 1000
         ]);
         $this->registerService(TaskLogInterface::SERVICE_ID, $taskLogService);
 


### PR DESCRIPTION
'php error(1) in /var/www/html/tao/tao/models/classes/taskQueue/TaskLog/Entity/TaskLogEntity.php@120: Allowed memory size of 536870912 bytes exhausted

During archiving a lot of tasks we may have the issue on the PHP side about memory size. For fixing that we will add updating by using batch size.

How to test:

1. Create a few tasks
2. Try to archive them


Deployed on unit07
