### PR TITLE
Feature/adf 1789/side by side authoring

### DIFF
--- a/models/classes/Translation/Service/ResourceTranslationRetriever.php
+++ b/models/classes/Translation/Service/ResourceTranslationRetriever.php
@@ -47,6 +47,9 @@ class ResourceTranslationRetriever
             throw new ResourceTranslationException('Resource id is required');
         }
 
-        return $this->resourceTranslationRepository->find(new ResourceTranslationQuery([$id], $languageUri));
+        if (!is_array($id)) {
+            $id = explode(',', $id);
+        }
+        return $this->resourceTranslationRepository->find(new ResourceTranslationQuery($id, $languageUri));
     }
 }

--- a/views/js/services/translation.js
+++ b/views/js/services/translation.js
@@ -286,13 +286,25 @@ define(['i18n', 'core/request', 'util/url'], function (__, request, urlUtil) {
 
         /**
          * Queries the list of translations for a resource.
-         * @param {string} id - The URI of the resource.
-         * @param {function} [filter] - A filter function for the translations.
+         * @param {string|string[]} id - The URI of the resource. It may also be a list of URIs, but in this case the languageUri must also be provided.
+         * @param {string|function} [languageUri] - The URI of the language to filter the translations. It may also be a filter function.
+         * @param {function} [filter] - A filter function for the translations. When not provided through the languageUri parameter.
          * @returns {Promise<ResourceList>}
          */
-        getTranslations(id, filter) {
+        getTranslations(id, filter, languageUri) {
+            if (Array.isArray(id)) {
+                id = id.join(',');
+            }
+            const params = { id };
+            if (languageUri) {
+                if ('function' === typeof languageUri) {
+                    filter = languageUri;
+                } else {
+                    params.languageUri = languageUri;
+                }
+            }
             return request({
-                url: urlUtil.route('translations', 'Translation', 'tao', { id }),
+                url: urlUtil.route('translations', 'Translation', 'tao', params),
                 method: 'GET',
                 noToken: true
             })

--- a/views/js/services/translation.js
+++ b/views/js/services/translation.js
@@ -291,7 +291,7 @@ define(['i18n', 'core/request', 'util/url'], function (__, request, urlUtil) {
          * @param {function} [filter] - A filter function for the translations. When not provided through the languageUri parameter.
          * @returns {Promise<ResourceList>}
          */
-        getTranslations(id, filter, languageUri) {
+        getTranslations(id, languageUri, filter) {
             if (Array.isArray(id)) {
                 id = id.join(',');
             }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1789

### Summary

Add support for querying multiple resources when listing the translations.

### Details

The `id` parameter can now accept an array of URI. In this case, the language URI is necessary.
