### PR TITLE
fix: add missing access to global manager

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -346,6 +346,7 @@ return [
         [AccessRule::GRANT, TaoRoles::TAO_MANAGER, ['ext' => 'tao', 'mod' => 'WebService']],
         [AccessRule::GRANT, TaoRoles::TAO_MANAGER, ['ext' => 'tao', 'mod' => 'Security']],
         [AccessRule::GRANT, TaoRoles::TAO_MANAGER, ['ext' => 'tao', 'mod' => 'WebHooks']],
+        [AccessRule::GRANT, TaoRoles::GLOBAL_MANAGER, ['ext' => 'tao', 'mod' => 'Translation']],
         [AccessRule::GRANT, TaoRoles::BACK_OFFICE, ['ext' => 'tao', 'mod' => 'ClassMetadata']],
         [AccessRule::GRANT, TaoRoles::REST_PUBLISHER, ['ext' => 'tao', 'mod' => 'TaskQueue', 'act' => 'get']],
         [AccessRule::GRANT, TaoRoles::REST_PUBLISHER, ['ext' => 'tao', 'mod' => 'TaskQueue', 'act' => 'getStatus']],


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1823

# Goal 

- Translation access is give to GlobalManager during installation

# Evidence it works

![Screenshot 2024-11-14 at 15 04 02](https://github.com/user-attachments/assets/19c2dbda-7621-456e-94ac-8b6f6dfadba2)

![Screenshot 2024-11-14 at 15 04 57](https://github.com/user-attachments/assets/2caddb60-fa72-4533-93db-dbd24f728c64)

