### PR TITLE
fix/ADF-1827/add-sync-by-id

### DIFF
--- a/models/classes/Translation/Service/TranslationSyncService.php
+++ b/models/classes/Translation/Service/TranslationSyncService.php
@@ -63,6 +63,11 @@ class TranslationSyncService
         $requestParams = $request->getParsedBody();
         $id = $requestParams['id'] ?? null;
 
+        return $this->syncById($id);
+    }
+
+    public function syncById(string $id): core_kernel_classes_Resource 
+    {
         if (empty($id)) {
             throw new ResourceTranslationException('Resource id is required');
         }

--- a/models/classes/Translation/Service/TranslationSyncService.php
+++ b/models/classes/Translation/Service/TranslationSyncService.php
@@ -66,7 +66,7 @@ class TranslationSyncService
         return $this->syncById($id);
     }
 
-    public function syncById(string $id): core_kernel_classes_Resource 
+    public function syncById(string $id): core_kernel_classes_Resource
     {
         if (empty($id)) {
             throw new ResourceTranslationException('Resource id is required');


### PR DESCRIPTION
related to https://oat-sa.atlassian.net/browse/ADF-1827

### Description

Adds syncById method to api of TranslationSyncService

### How to test 

checkout related taoTests branches:
 - https://github.com/oat-sa/extension-tao-test/tree/fix/ADF-1827/sync-translations-on-authoring
 - https://github.com/oat-sa/extension-tao-testqti/tree/fix/ADF-1827/remove-translation-sync-call


#### Steps to reproduce / check if issue is fixed:
 
 - create an item
 - create test 
 - add item to the test 
 - create test translation to some language, save it
 - add translation to the item in that language
 - go back to tests and edit the translation of the test you have created

label should exist for the item