### PR TITLE
[AUT-3938]: Weight attribute handling for actions lists

### DIFF
--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -651,11 +651,11 @@ class Layout
     public static function getSortedActionsByWeight($key)
     {
         $data = get_data($key);
-    
+
         usort($data, function ($a, $b) {
             return $a->getWeight() < $b->getWeight();
         });
-    
+
         return $data;
     }
 }

--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -640,4 +640,21 @@ class Layout
     {
         return ServiceManager::getServiceManager()->get(ThemeService::SERVICE_ID);
     }
+
+    /**
+     * Get data from the request context with sorting by weight.
+     *
+     * @param string $key A key to identify the data.
+     * @return mixed The data bound to the key. If no data is bound to the provided key, null is return.
+     */
+
+    public static function getSortedActionsByWeight($key) {
+        $data = get_data($key);
+    
+        usort($data, function($a,$b){
+            return $a->getWeight() < $b->getWeight();
+        });
+    
+        return $data;
+    }
 }

--- a/helpers/Layout.php
+++ b/helpers/Layout.php
@@ -648,10 +648,11 @@ class Layout
      * @return mixed The data bound to the key. If no data is bound to the provided key, null is return.
      */
 
-    public static function getSortedActionsByWeight($key) {
+    public static function getSortedActionsByWeight($key)
+    {
         $data = get_data($key);
     
-        usort($data, function($a,$b){
+        usort($data, function ($a, $b) {
             return $a->getWeight() < $b->getWeight();
         });
     

--- a/models/classes/menu/Action.php
+++ b/models/classes/menu/Action.php
@@ -67,7 +67,8 @@ class Action implements PhpSerializable, iAction, ServiceManagerAwareInterface
             'group' => isset($node['group']) ? (string) $node['group'] : self::GROUP_DEFAULT,
             'extension' => $extension,
             'controller' => $controller,
-            'action' => $action
+            'action' => $action,
+            'weight' => isset($node['weight']) ? (int) $node['weight'] : self::WEIGHT_DEFAULT
         ];
 
         if (isset($node->icon)) {
@@ -231,5 +232,10 @@ class Action implements PhpSerializable, iAction, ServiceManagerAwareInterface
             . \common_Utils::toPHPVariableString($this->data) . ','
             . \common_Utils::toPHPVariableString(self::SERIAL_VERSION)
         . ")";
+    }
+
+    public function getWeight()
+    {
+        return $this->data['weight'];
     }
 }

--- a/views/templates/blocks/actions.tpl
+++ b/views/templates/blocks/actions.tpl
@@ -1,7 +1,7 @@
 <?php
 use oat\tao\helpers\Layout;
 
-$actions_list = Layout::isQuickWinsDesignEnabled() ? get_data_with_weight('actions') : get_data('actions');
+$actions_list = Layout::isQuickWinsDesignEnabled() ? Layout::getSortedActionsByWeight('actions') : get_data('actions');
 ?>
 
     <?php foreach ($actions_list as $action): ?>

--- a/views/templates/blocks/actions.tpl
+++ b/views/templates/blocks/actions.tpl
@@ -1,8 +1,10 @@
 <?php
 use oat\tao\helpers\Layout;
+
+$actions_list = Layout::isQuickWinsDesignEnabled() ? get_data_with_weight('actions') : get_data('actions');
 ?>
 
-    <?php foreach (get_data('actions') as $action): ?>
+    <?php foreach ($actions_list as $action): ?>
     <li class="action <?= get_data('action_classes')?>"
         id="<?=$action->getId()?>"
         title="<?= __($action->getName()) ?>"


### PR DESCRIPTION
Ticket: [AUT-3938](https://oat-sa.atlassian.net/browse/AUT-3938)

Connected PRs:
oat-sa/extension-tao-deliver-connect: [#250](https://github.com/oat-sa/extension-tao-deliver-connect/pull/250)
oat-sa/extension-tao-delivery-rdf: [#496](https://github.com/oat-sa/extension-tao-delivery-rdf/pull/496)
oat-sa/extension-tao-testtaker: [#248](https://github.com/oat-sa/extension-tao-testtaker/pull/248)
oat-sa/extension-tao-item: [#671](https://github.com/oat-sa/extension-tao-item/pull/671)
oat-sa/extension-tao-itemqti: [#2643](https://github.com/oat-sa/extension-tao-itemqti/pull/2643)
oat-sa/extension-tao-group: [#187](https://github.com/oat-sa/extension-tao-group/pull/187)
oat-sa/extension-tao-test: [#494](https://github.com/oat-sa/extension-tao-test/pull/494)
oat-sa/extension-tao-backoffice: [#189](https://github.com/oat-sa/extension-tao-backoffice/pull/189)
oat-sa/extension-tao-dac-simple: [#256](https://github.com/oat-sa/extension-tao-dac-simple/pull/256)

[AUT-3938]: https://oat-sa.atlassian.net/browse/AUT-3938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ