### PR TITLE
fix: root class must be retrieved if root class

### DIFF
--- a/models/classes/GenerisTreeFactory.php
+++ b/models/classes/GenerisTreeFactory.php
@@ -364,7 +364,7 @@ class GenerisTreeFactory
         $mainClass = array_pop($parentClassIds);
 
         return in_array(
-            $mainClass,
+            $mainClass ?? $class->getUri(),
             [
                 TaoOntology::CLASS_URI_ITEM,
                 TaoOntology::CLASS_URI_TEST

--- a/models/classes/GenerisTreeFactory.php
+++ b/models/classes/GenerisTreeFactory.php
@@ -360,11 +360,8 @@ class GenerisTreeFactory
             return false;
         }
 
-        $parentClassIds = $class->getParentClassesIds();
-        $mainClass = array_pop($parentClassIds);
-
         return in_array(
-            $mainClass ?? $class->getUri(),
+            $class->getRootId() ?? $class->getUri(),
             [
                 TaoOntology::CLASS_URI_ITEM,
                 TaoOntology::CLASS_URI_TEST

--- a/models/classes/GenerisTreeFactory.php
+++ b/models/classes/GenerisTreeFactory.php
@@ -360,8 +360,11 @@ class GenerisTreeFactory
             return false;
         }
 
+        $parentClassIds = $class->getParentClassesIds();
+        $mainClass = array_pop($parentClassIds);
+
         return in_array(
-            $class->getRootId() ?? $class->getUri(),
+            $mainClass ?? $class->getUri(),
             [
                 TaoOntology::CLASS_URI_ITEM,
                 TaoOntology::CLASS_URI_TEST


### PR DESCRIPTION
# Goal

- In case class is root class, use this to filter out translations