### PR TITLE
fix: booklet download from tasks queue

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -13,7 +13,7 @@
                 "@oat-sa/tao-core-libs": "^1.0.0",
                 "@oat-sa/tao-core-sdk": "^3.2.1",
                 "@oat-sa/tao-core-shared-libs": "^1.6.1",
-                "@oat-sa/tao-core-ui": "git://github.com/oat-sa/tao-core-ui-fe#fix/LSI-5002/booklet-download",
+                "@oat-sa/tao-core-ui": "^3.9.2",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
                 "gamp": "0.2.1",
@@ -80,9 +80,9 @@
             "integrity": "sha512-KnW5RnCOjewkimfDgh/+w9J77bc3gWH5YR1fIHon6j86ywFL+Fevcn5ghdZZrWTzwEMZfEju39VhI7LjXUWKnA=="
         },
         "node_modules/@oat-sa/tao-core-ui": {
-            "version": "3.9.1",
-            "resolved": "git+ssh://git@github.com/oat-sa/tao-core-ui-fe.git#44e1cc0099e9c737722ad81f7927e26d0644be1f",
-            "license": "GPL-2.0"
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-3.9.2.tgz",
+            "integrity": "sha512-CmHGaJxrsVCnmUgrcLTL9ggFFRHI0zRwjWYNYM6jvdUKT2EJs1YsAGQfV8SbBQjk1R/STbujEm2jDEmESKRdAA=="
         },
         "node_modules/amdefine": {
             "version": "1.0.1",

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -13,7 +13,7 @@
                 "@oat-sa/tao-core-libs": "^1.0.0",
                 "@oat-sa/tao-core-sdk": "^3.2.1",
                 "@oat-sa/tao-core-shared-libs": "^1.6.1",
-                "@oat-sa/tao-core-ui": "^3.9.1",
+                "@oat-sa/tao-core-ui": "git://github.com/oat-sa/tao-core-ui-fe#fix/LSI-5002/booklet-download",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
                 "gamp": "0.2.1",
@@ -81,8 +81,8 @@
         },
         "node_modules/@oat-sa/tao-core-ui": {
             "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-3.9.1.tgz",
-            "integrity": "sha512-Bq1VB59bg6UU6kzdAWbuNFO89cD293qJQmt+gJq73F8tiH8WKc+a4aNYEUhtwM4p4YZxio5E7bqFTr8bUpwPFA=="
+            "resolved": "git+ssh://git@github.com/oat-sa/tao-core-ui-fe.git#44e1cc0099e9c737722ad81f7927e26d0644be1f",
+            "license": "GPL-2.0"
         },
         "node_modules/amdefine": {
             "version": "1.0.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^1.0.0",
         "@oat-sa/tao-core-sdk": "^3.2.1",
         "@oat-sa/tao-core-shared-libs": "^1.6.1",
-        "@oat-sa/tao-core-ui": "^3.9.1",
+        "@oat-sa/tao-core-ui": "git://github.com/oat-sa/tao-core-ui-fe#fix/LSI-5002/booklet-download",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",
         "gamp": "0.2.1",

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^1.0.0",
         "@oat-sa/tao-core-sdk": "^3.2.1",
         "@oat-sa/tao-core-shared-libs": "^1.6.1",
-        "@oat-sa/tao-core-ui": "git://github.com/oat-sa/tao-core-ui-fe#fix/LSI-5002/booklet-download",
+        "@oat-sa/tao-core-ui": "^3.9.2",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",
         "gamp": "0.2.1",


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/LSI-5002

## What's Changed

- Fixed the issue when user is not able to download the PDF generated from booklet

## How to test

- In the Tests tab, select a test
- Click “New booklet” button
- Click “Generate”
- In the Background tasks, find the task with generated booklet
- Click “Download” icon
- The booklet should be downloaded successfully