### PR TITLE
fix: update original test after sync metadata

### DIFF
--- a/models/classes/Translation/Service/TranslatedIntoLanguagesSynchronizer.php
+++ b/models/classes/Translation/Service/TranslatedIntoLanguagesSynchronizer.php
@@ -33,11 +33,18 @@ class TranslatedIntoLanguagesSynchronizer
 {
     private Ontology $ontology;
     private ResourceTranslationRepository $resourceTranslationRepository;
+    private array $callbacks;
 
     public function __construct(Ontology $ontology, ResourceTranslationRepository $resourceTranslationRepository)
     {
         $this->ontology = $ontology;
         $this->resourceTranslationRepository = $resourceTranslationRepository;
+    }
+
+    public function addCallback(string $type, callable $callback): void
+    {
+        $this->callbacks[$type] = $this->callbacks[$type] ?? [];
+        $this->callbacks[$type][] = $callback;
     }
 
     public function sync(core_kernel_classes_Resource $resource): void
@@ -57,6 +64,10 @@ class TranslatedIntoLanguagesSynchronizer
                 $property,
                 TaoOntology::LANGUAGE_PREFIX . $translation->getLanguageCode()
             );
+        }
+
+        foreach (($this->callbacks[$originalResource->getRootId()] ?? []) as $callback) {
+            $callback($originalResource);
         }
     }
 

--- a/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
+++ b/models/classes/dataBinding/class.GenerisInstanceDataBinder.php
@@ -192,6 +192,10 @@ class tao_models_classes_dataBinding_GenerisInstanceDataBinder extends tao_model
             return false;
         }
 
+        if ($property->getWidget()->getUri() === tao_helpers_form_elements_Readonly::WIDGET_ID) {
+            return true;
+        }
+
         if ($this->getFeatureFlagChecker()->isEnabled('FEATURE_FLAG_STATISTIC_METADATA_IMPORT')) {
             return $property->isStatistical();
         }

--- a/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
+++ b/test/unit/models/classes/dataBinding/GenerisInstanceDataBinderTest.php
@@ -71,9 +71,13 @@ class GenerisInstanceDataBinderTest extends TestCase
     /** @var Ontology|MockObject */
     private $ontology;
 
+    /** @var core_kernel_classes_Property|MockObject */
+    private $widget;
+
     public function setUp(): void
     {
         $this->eventManagerMock = $this->createMock(EventManager::class);
+        $this->widget = $this->createMock(core_kernel_classes_Property::class);
 
         $this->classType1 = $this->createMock(core_kernel_classes_Class::class);
         $this->classType1
@@ -105,6 +109,14 @@ class GenerisInstanceDataBinderTest extends TestCase
         $this->property2
             ->method('getUri')
             ->willReturn(self::URI_PROPERTY_2);
+
+        $this->property1
+            ->method('getWidget')
+            ->willReturn($this->widget);
+
+        $this->property2
+            ->method('getWidget')
+            ->willReturn($this->widget);
 
         $this->target
             ->method('getUri')


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1855

# Goal 

Allow callbacks to be executed for original test after sync it

# Related PRs

- https://github.com/oat-sa/extension-tao-test/pull/495