### PR TITLE
fix: back to platform button

### DIFF
--- a/views/templates/blocks/portal/back-button.tpl
+++ b/views/templates/blocks/portal/back-button.tpl
@@ -1,6 +1,6 @@
 <?php
 use oat\tao\helpers\Template;
-if (get_data('userLabel')): ?>
+if (get_data('portalUrl')): ?>
     <a href="<?= get_data('portalUrl'); ?>" title="<?= __("Back to Portal"); ?>" class="lft portal-back">
         <span class="icon-back-button glyph"></span>
     </a>


### PR DESCRIPTION
To fix issue:
When login via LTI by a user who does not have a name set in platform, we see logo instead of back button