### PR TITLE
[AUT-4059] fix: removing subheading with typo from items tree

### DIFF
--- a/views/templates/blocks/sections.tpl
+++ b/views/templates/blocks/sections.tpl
@@ -87,7 +87,6 @@ $sections = get_data('sections');
                             </div>
                         <?php endforeach; ?>
                     </div>
-                    <?= Layout::isQuickWinsDesignEnabled() ? "<h3 class='navi-heading'>" . $tree->get('className') . "s bank</h3>" : '' ?> <!-- TODO: i18n -->
                     <div class="tree-action-bar-box">
                         <ul class="plain action-bar tree-action-bar vertical-action-bar">
                         <?php


### PR DESCRIPTION
[AUT-4059](https://oat-sa.atlassian.net/browse/AUT-4059)

Subheading with typos is removed

![image](https://i.imgur.com/FRD40wr.png)

[AUT-4059]: https://oat-sa.atlassian.net/browse/AUT-4059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ