### PR TITLE
[AUT-4070] fix: fix redundant grey space in tree section

### DIFF
--- a/views/scss/inc/_action-bars.scss
+++ b/views/scss/inc/_action-bars.scss
@@ -434,6 +434,7 @@ body.qc-wins {
         }
         .taotree.tree {
             padding-left: .5rem;
+            border: none;
 
             ul.ltr, ul.rtl {
                 margin: 0;


### PR DESCRIPTION
[AUT-4070](https://oat-sa.atlassian.net/browse/AUT-4070)

Fix for redundant grey border in right of tree section

![image](https://i.imgur.com/m6tr2rd.png)

[AUT-4070]: https://oat-sa.atlassian.net/browse/AUT-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ