### PR TITLE
[AUT-4071] fix: fix for labels duplication in mobile view

### DIFF
--- a/views/templates/blocks/header-main-navi.tpl
+++ b/views/templates/blocks/header-main-navi.tpl
@@ -59,9 +59,12 @@ $taoAsATool   = get_data('taoAsATool');
                                 <?php if(!Layout::isQuickWinsDesignEnabled()): ?>
                                     <?= is_null($entry->getIcon()) ? '' : Layout::renderIcon($entry->getIcon(), 'icon-extension') ?>
                                 <?php endif; ?>
-                                <?php if ($entry->getId() !== 'user_settings'): ?>
-                                    <span> <?= $entry->getName() ?> </span>
-                                <?php endif ?>
+                                <?php if(Layout::isQuickWinsDesignEnabled()): ?>
+                                    <?php if ($entry->getId() !== 'user_settings'): ?>
+                                        <span> <?= $entry->getName() ?> </span>
+                                    <?php endif ?>
+                                <?php endif; ?>
+
                                 <?php $description = $entry->getDescription();
                                 if ($description): ?>
                                     <?= __($description) ?>


### PR DESCRIPTION
[AUT-4071](https://oat-sa.atlassian.net/browse/AUT-4071)

Fix for labels duplications on mobile view of setting menu.

![image](https://i.imgur.com/N9xRj9C.png)

[AUT-4071]: https://oat-sa.atlassian.net/browse/AUT-4071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ