### PR TITLE
feat: extend event logs

### DIFF
--- a/models/classes/Translation/Event/TranslationActionEvent.php
+++ b/models/classes/Translation/Event/TranslationActionEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\Translation\Event;
+
+use JsonSerializable;
+use oat\oatbox\event\Event;
+
+class TranslationActionEvent implements Event, JsonSerializable
+{
+    public const ACTION_CREATED = 'translation.created';
+    public const ACTION_UPDATED = 'translation.updated';
+    public const ACTION_DELETED = 'translation.deleted';
+
+    private string $action;
+    private string $originalResourceId;
+    private string $translationResourceId;
+    private string $locale;
+    private array $data;
+
+    public function __construct(
+        string $action,
+        string $originalResourceId,
+        string $translationResourceId,
+        string $locale,
+        array $data = []
+    ) {
+        $this->action = $action;
+        $this->originalResourceId = $originalResourceId;
+        $this->translationResourceId = $translationResourceId;
+        $this->locale = $locale;
+        $this->data = $data;
+    }
+
+    public function getName(): string
+    {
+        return __CLASS__;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'action' => $this->action,
+            'originalResourceId' => $this->originalResourceId,
+            'translationResourceId' => $this->translationResourceId,
+            'locale' => $this->locale,
+            'data' => $this->data,
+        ];
+    }
+}

--- a/models/classes/Translation/Event/TranslationActionEvent.php
+++ b/models/classes/Translation/Event/TranslationActionEvent.php
@@ -32,6 +32,7 @@ class TranslationActionEvent implements Event, JsonSerializable
     public const ACTION_DELETED = 'translation.deleted';
 
     private string $action;
+    private string $type;
     private string $originalResourceId;
     private string $translationResourceId;
     private string $locale;
@@ -39,12 +40,14 @@ class TranslationActionEvent implements Event, JsonSerializable
 
     public function __construct(
         string $action,
+        string $type,
         string $originalResourceId,
         string $translationResourceId,
         string $locale,
         array $data = []
     ) {
         $this->action = $action;
+        $this->type = $type;
         $this->originalResourceId = $originalResourceId;
         $this->translationResourceId = $translationResourceId;
         $this->locale = $locale;
@@ -60,6 +63,7 @@ class TranslationActionEvent implements Event, JsonSerializable
     {
         return [
             'action' => $this->action,
+            'type' => $this->type,
             'originalResourceId' => $this->originalResourceId,
             'translationResourceId' => $this->translationResourceId,
             'locale' => $this->locale,

--- a/models/classes/Translation/Service/TranslationCreationService.php
+++ b/models/classes/Translation/Service/TranslationCreationService.php
@@ -201,6 +201,7 @@ class TranslationCreationService
 
             $this->eventManager->trigger(new TranslationActionEvent(
                 TranslationActionEvent::ACTION_CREATED,
+                $rootId,
                 $resourceUri,
                 $clonedInstanceUri,
                 $language->getCode()

--- a/models/classes/Translation/Service/TranslationCreationService.php
+++ b/models/classes/Translation/Service/TranslationCreationService.php
@@ -24,6 +24,7 @@ namespace oat\tao\model\Translation\Service;
 
 use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
+use oat\oatbox\event\EventManager;
 use oat\tao\model\Language\Business\Contract\LanguageRepositoryInterface;
 use oat\tao\model\Language\Language;
 use oat\tao\model\resources\Command\ResourceTransferCommand;
@@ -31,6 +32,7 @@ use oat\tao\model\resources\Contract\ResourceTransferInterface;
 use oat\tao\model\TaoOntology;
 use oat\tao\model\Translation\Command\CreateTranslationCommand;
 use oat\tao\model\Translation\Entity\ResourceTranslatable;
+use oat\tao\model\Translation\Event\TranslationActionEvent;
 use oat\tao\model\Translation\Exception\ResourceTranslationException;
 use oat\tao\model\Translation\Query\ResourceTranslatableQuery;
 use oat\tao\model\Translation\Query\ResourceTranslationQuery;
@@ -48,6 +50,7 @@ class TranslationCreationService
     private LanguageRepositoryInterface $languageRepository;
     private LoggerInterface $logger;
     private TranslatedIntoLanguagesSynchronizer $translatedIntoLanguagesSynchronizer;
+    private EventManager $eventManager;
 
     private array $resourceTransferServices;
     private array $callables;
@@ -58,7 +61,8 @@ class TranslationCreationService
         ResourceTranslationRepository $resourceTranslationRepository,
         LanguageRepositoryInterface $languageRepository,
         LoggerInterface $logger,
-        TranslatedIntoLanguagesSynchronizer $translatedIntoLanguagesSynchronizer
+        TranslatedIntoLanguagesSynchronizer $translatedIntoLanguagesSynchronizer,
+        EventManager $eventManager
     ) {
         $this->ontology = $ontology;
         $this->resourceTranslatableRepository = $resourceTranslatableRepository;
@@ -66,6 +70,7 @@ class TranslationCreationService
         $this->languageRepository = $languageRepository;
         $this->logger = $logger;
         $this->translatedIntoLanguagesSynchronizer = $translatedIntoLanguagesSynchronizer;
+        $this->eventManager = $eventManager;
     }
 
     public function setResourceTransfer(string $resourceType, ResourceTransferInterface $resourceTransfer): void
@@ -193,6 +198,13 @@ class TranslationCreationService
             }
 
             $this->translatedIntoLanguagesSynchronizer->sync($instance);
+
+            $this->eventManager->trigger(new TranslationActionEvent(
+                TranslationActionEvent::ACTION_CREATED,
+                $resourceUri,
+                $clonedInstanceUri,
+                $language->getCode()
+            ));
 
             return $clonedInstance;
         } catch (Throwable $exception) {

--- a/models/classes/Translation/Service/TranslationDeletionService.php
+++ b/models/classes/Translation/Service/TranslationDeletionService.php
@@ -93,9 +93,9 @@ class TranslationDeletionService
 
             /** @var AbstractResource $translation */
             foreach ($translations as $translation) {
-                $resource = $this->ontology->getResource($translation->getResourceUri());
+                $translationResource = $this->ontology->getResource($translation->getResourceUri());
 
-                $this->resourceDeleter->delete($resource);
+                $this->resourceDeleter->delete($translationResource);
 
                 $this->eventManager->trigger(new TranslationActionEvent(
                     TranslationActionEvent::ACTION_DELETED,
@@ -106,7 +106,7 @@ class TranslationDeletionService
                 ));
             }
 
-            $this->translatedIntoLanguagesSynchronizer->sync($this->ontology->getResource($resourceUri));
+            $this->translatedIntoLanguagesSynchronizer->sync($resource);
 
             return $resource;
         } catch (Throwable $exception) {

--- a/models/classes/Translation/Service/TranslationDeletionService.php
+++ b/models/classes/Translation/Service/TranslationDeletionService.php
@@ -75,6 +75,9 @@ class TranslationDeletionService
         }
 
         try {
+            $resource = $this->ontology->getResource($resourceUri);
+            $rootId = $resource->getRootId();
+
             $translations = $this->resourceTranslationRepository
                 ->find(new ResourceTranslationQuery([$resourceUri], $languageUri));
 
@@ -96,6 +99,7 @@ class TranslationDeletionService
 
                 $this->eventManager->trigger(new TranslationActionEvent(
                     TranslationActionEvent::ACTION_DELETED,
+                    $rootId,
                     $resourceUri,
                     $translation->getResourceUri(),
                     $translation->getLanguageCode()

--- a/models/classes/Translation/Service/TranslationUpdateService.php
+++ b/models/classes/Translation/Service/TranslationUpdateService.php
@@ -91,6 +91,7 @@ class TranslationUpdateService
 
             $this->eventManager->trigger(new TranslationActionEvent(
                 TranslationActionEvent::ACTION_UPDATED,
+                $instance->getRootId(),
                 $this->getOriginalResourceUri($instance),
                 $instance->getUri(),
                 $this->getLocaleCode($instance),

--- a/models/classes/Translation/ServiceProvider/TranslationServiceProvider.php
+++ b/models/classes/Translation/ServiceProvider/TranslationServiceProvider.php
@@ -26,6 +26,7 @@ use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\generis\model\resource\Service\ResourceDeleter;
+use oat\oatbox\event\EventManager;
 use oat\oatbox\log\LoggerService;
 use oat\oatbox\user\UserLanguageServiceInterface;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
@@ -140,6 +141,7 @@ class TranslationServiceProvider implements ContainerServiceProviderInterface
                     service(LanguageRepositoryInterface::class),
                     service(LoggerService::SERVICE_ID),
                     service(TranslatedIntoLanguagesSynchronizer::class),
+                    service(EventManager::SERVICE_ID),
                 ]
             )
             ->public();
@@ -153,6 +155,7 @@ class TranslationServiceProvider implements ContainerServiceProviderInterface
                     service(ResourceTranslationRepository::class),
                     service(LoggerService::SERVICE_ID),
                     service(TranslatedIntoLanguagesSynchronizer::class),
+                    service(EventManager::SERVICE_ID),
                 ]
             )
             ->public();
@@ -164,6 +167,7 @@ class TranslationServiceProvider implements ContainerServiceProviderInterface
                     service(Ontology::SERVICE_ID),
                     service(LoggerService::SERVICE_ID),
                     service(TranslatedIntoLanguagesSynchronizer::class),
+                    service(EventManager::SERVICE_ID),
                 ]
             )
             ->public();

--- a/test/unit/models/classes/Translation/Event/TranslationActionEventTest.php
+++ b/test/unit/models/classes/Translation/Event/TranslationActionEventTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\Translation\Event;
+
+use JsonSerializable;
+use oat\oatbox\event\Event;
+use oat\tao\model\Translation\Event\TranslationActionEvent;
+use PHPUnit\Framework\TestCase;
+
+class TranslationActionEventTest extends TestCase
+{
+    public function testEvent(): void
+    {
+        $sut = new TranslationActionEvent(
+            'someAction',
+            'originalResourceId',
+            'translationResourceId',
+            'locale'
+        );
+
+        $this->assertInstanceOf(Event::class, $sut);
+        $this->assertInstanceOf(JsonSerializable::class, $sut);
+        $this->assertEquals(
+            [
+                'action' => 'someAction',
+                'originalResourceId' => 'originalResourceId',
+                'translationResourceId' => 'translationResourceId',
+                'locale' => 'locale',
+                'data' => []
+            ],
+            $sut->jsonSerialize()
+        );
+    }
+}

--- a/test/unit/models/classes/Translation/Event/TranslationActionEventTest.php
+++ b/test/unit/models/classes/Translation/Event/TranslationActionEventTest.php
@@ -33,6 +33,7 @@ class TranslationActionEventTest extends TestCase
     {
         $sut = new TranslationActionEvent(
             'someAction',
+            'item',
             'originalResourceId',
             'translationResourceId',
             'locale'
@@ -43,6 +44,7 @@ class TranslationActionEventTest extends TestCase
         $this->assertEquals(
             [
                 'action' => 'someAction',
+                'type' => 'item',
                 'originalResourceId' => 'originalResourceId',
                 'translationResourceId' => 'translationResourceId',
                 'locale' => 'locale',

--- a/test/unit/models/classes/Translation/Service/TranslationCreationServiceTest.php
+++ b/test/unit/models/classes/Translation/Service/TranslationCreationServiceTest.php
@@ -27,6 +27,7 @@ namespace oat\tao\test\unit\models\classes\Translation\Service;
 use core_kernel_classes_Class;
 use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
+use oat\oatbox\event\EventManager;
 use oat\tao\model\Language\Business\Contract\LanguageRepositoryInterface;
 use oat\tao\model\Language\Language;
 use oat\tao\model\Language\LanguageCollection;
@@ -90,6 +91,7 @@ class TranslationCreationServiceTest extends TestCase
             $this->languageRepository,
             $this->logger,
             $this->translatedIntoLanguagesSynchronizer,
+            $this->createMock(EventManager::class)
         );
 
         $this->service->setResourceTransfer(TaoOntology::CLASS_URI_ITEM, $this->resourceTransfer);
@@ -122,7 +124,7 @@ class TranslationCreationServiceTest extends TestCase
             ->method('getUri')
             ->willReturn($languageUri);
         $language
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('getCode')
             ->willReturn('pt-BR');
 

--- a/test/unit/models/classes/Translation/Service/TranslationDeletionServiceTest.php
+++ b/test/unit/models/classes/Translation/Service/TranslationDeletionServiceTest.php
@@ -88,7 +88,7 @@ class TranslationDeletionServiceTest extends TestCase
             ->method('getParsedBody')
             ->willReturn(
                 [
-                    'id' => $resourceUri,
+                    'id' => $translationResourceId,
                     'languageUri' => $languageUri,
                 ]
             );
@@ -108,7 +108,7 @@ class TranslationDeletionServiceTest extends TestCase
         $this->ontology
             ->expects($this->exactly(2))
             ->method('getResource')
-            ->withConsecutive([$translationResourceId], ['id1'])
+            ->withConsecutive([$translationResourceId], [$translationResourceId])
             ->willReturnOnConsecutiveCalls($translationResource, $originalResource);
 
         $this->translatedIntoLanguagesSynchronizer

--- a/test/unit/models/classes/Translation/Service/TranslationDeletionServiceTest.php
+++ b/test/unit/models/classes/Translation/Service/TranslationDeletionServiceTest.php
@@ -26,6 +26,8 @@ namespace oat\tao\test\unit\models\classes\Translation\Service;
 
 use core_kernel_classes_Resource;
 use oat\generis\model\resource\Contract\ResourceDeleterInterface;
+use oat\oatbox\event\EventManager;
+use oat\tao\model\TaoOntology;
 use oat\tao\model\Translation\Entity\ResourceTranslation;
 use oat\tao\model\Translation\Exception\ResourceTranslationException;
 use oat\tao\model\Translation\Repository\ResourceTranslationRepository;
@@ -71,6 +73,7 @@ class TranslationDeletionServiceTest extends TestCase
             $this->resourceTranslationRepository,
             $this->logger,
             $this->translatedIntoLanguagesSynchronizer,
+            $this->createMock(EventManager::class)
         );
     }
 
@@ -91,6 +94,7 @@ class TranslationDeletionServiceTest extends TestCase
             );
 
         $translation = new ResourceTranslation($translationResourceId, 'something');
+        $translation->addMetadata(TaoOntology::PROPERTY_LANGUAGE, $languageUri, 'pt-BR');
         $resourceCollection = new ResourceCollection($translation);
 
         $translationResource = $this->createMock(core_kernel_classes_Resource::class);


### PR DESCRIPTION
# [ADF-1851](https://oat-sa.atlassian.net/browse/ADF-1851)

## Changes
* Added new event to cover translation actions:
  * Create
  * Update
  * Delete
* New event is triggered in related services to create/update/delete a translation
* New event will share the following information:
  * Action (create/update/delete)
  * Original resource URI
  * Translation resource URI
  * Locale code
  * Additional data, e.g. changed properties (old -> new)

[ADF-1851]: https://oat-sa.atlassian.net/browse/ADF-1851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ