### PR TITLE
[Fix] Keep translation QTI ID the same

### DIFF
--- a/models/classes/Translation/Service/TranslationUniqueIdSetter.php
+++ b/models/classes/Translation/Service/TranslationUniqueIdSetter.php
@@ -71,12 +71,10 @@ class TranslationUniqueIdSetter
             AbstractQtiIdentifierSetter::OPTION_IDENTIFIER => $uniqueIdentifier,
         ]);
 
-        if ($this->featureFlagChecker->isEnabled('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')) {
-            $resource->editPropertyValues(
-                $this->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER),
-                $uniqueIdentifier
-            );
-        }
+        $resource->editPropertyValues(
+            $this->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER),
+            $uniqueIdentifier
+        );
     }
 
     private function getOriginalResource(core_kernel_classes_Resource $resource): core_kernel_classes_Resource

--- a/models/classes/Translation/Service/TranslationUniqueIdSetter.php
+++ b/models/classes/Translation/Service/TranslationUniqueIdSetter.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2024 (original work) Open Assessment Technologies SA.
+ * Copyright (c) 2024-2025 (original work) Open Assessment Technologies SA.
  */
 
 declare(strict_types=1);
@@ -59,24 +59,24 @@ class TranslationUniqueIdSetter
 
     public function __invoke(core_kernel_classes_Resource $resource): void
     {
-        if (
-            !$this->featureFlagChecker->isEnabled('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')
-            || !$this->featureFlagChecker->isEnabled('FEATURE_FLAG_TRANSLATION_ENABLED')
-        ) {
+        if (!$this->featureFlagChecker->isEnabled('FEATURE_FLAG_TRANSLATION_ENABLED')) {
             return;
         }
 
         $originalResource = $this->getOriginalResource($resource);
         $uniqueIdentifier = $this->getUniqueId($originalResource);
 
-        $resource->editPropertyValues(
-            $this->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER),
-            $uniqueIdentifier
-        );
         $this->getQtiIdentifierSetter($resource)->set([
             AbstractQtiIdentifierSetter::OPTION_RESOURCE => $resource,
             AbstractQtiIdentifierSetter::OPTION_IDENTIFIER => $uniqueIdentifier,
         ]);
+
+        if ($this->featureFlagChecker->isEnabled('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')) {
+            $resource->editPropertyValues(
+                $this->getProperty(TaoOntology::PROPERTY_UNIQUE_IDENTIFIER),
+                $uniqueIdentifier
+            );
+        }
     }
 
     private function getOriginalResource(core_kernel_classes_Resource $resource): core_kernel_classes_Resource

--- a/test/unit/models/classes/Translation/Service/TranslationUniqueIdSetterTest.php
+++ b/test/unit/models/classes/Translation/Service/TranslationUniqueIdSetterTest.php
@@ -62,75 +62,6 @@ class TranslationUniqueIdSetterTest extends TestCase
         $this->sut->addQtiIdentifierSetter($this->qtiIdentifierSetter, 'resourceType');
     }
 
-    public function testUniqueIdFeatureDisabled(): void
-    {
-        $this->featureFlagChecker
-            ->expects($this->exactly(2))
-            ->method('isEnabled')
-            ->withConsecutive(
-                ['FEATURE_FLAG_TRANSLATION_ENABLED'],
-                ['FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER']
-            )
-            ->willReturnOnConsecutiveCalls(true, false);
-
-        $originalResourceUriProperty = $this->createPropertyMock();
-        $uniqueIdProperty = $this->createPropertyMock();
-
-        $this->ontology
-            ->expects($this->exactly(2))
-            ->method('getProperty')
-            ->withConsecutive(
-                [TaoOntology::PROPERTY_TRANSLATION_ORIGINAL_RESOURCE_URI],
-                [TaoOntology::PROPERTY_UNIQUE_IDENTIFIER]
-            )
-            ->willReturnOnConsecutiveCalls(
-                $originalResourceUriProperty,
-                $uniqueIdProperty
-            );
-
-        $this->resource
-            ->expects($this->once())
-            ->method('getOnePropertyValue')
-            ->with($originalResourceUriProperty)
-            ->willReturn('originalResourceUri');
-
-        $originalResource = $this->createResourceMock();
-
-        $this->ontology
-            ->expects($this->once())
-            ->method('getResource')
-            ->with('originalResourceUri')
-            ->willReturn($originalResource);
-
-        $identifier = $this->createMock(core_kernel_classes_Literal::class);
-        $identifier->literal = 'identifier';
-
-        $originalResource
-            ->expects($this->once())
-            ->method('getOnePropertyValue')
-            ->with($uniqueIdProperty)
-            ->willReturn($identifier);
-
-        $this->resource
-            ->expects($this->never())
-            ->method('editPropertyValues');
-
-        $this->resource
-            ->expects($this->once())
-            ->method('getRootId')
-            ->willReturn('resourceType');
-
-        $this->qtiIdentifierSetter
-            ->expects($this->once())
-            ->method('set')
-            ->with([
-                AbstractQtiIdentifierSetter::OPTION_RESOURCE => $this->resource,
-                AbstractQtiIdentifierSetter::OPTION_IDENTIFIER => 'identifier',
-            ]);
-
-        $this->sut->__invoke($this->resource);
-    }
-
     public function testTranslationFeatureDisabled(): void
     {
         $this->featureFlagChecker
@@ -306,13 +237,10 @@ class TranslationUniqueIdSetterTest extends TestCase
     public function testSuccess(): void
     {
         $this->featureFlagChecker
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('isEnabled')
-            ->withConsecutive(
-                ['FEATURE_FLAG_TRANSLATION_ENABLED'],
-                ['FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER']
-            )
-            ->willReturnOnConsecutiveCalls(true, true);
+            ->with('FEATURE_FLAG_TRANSLATION_ENABLED')
+            ->willReturn(true);
 
         $originalResourceUriProperty = $this->createPropertyMock();
         $uniqueIdProperty = $this->createPropertyMock();

--- a/test/unit/models/classes/Translation/Service/TranslationUniqueIdSetterTest.php
+++ b/test/unit/models/classes/Translation/Service/TranslationUniqueIdSetterTest.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2024 (original work) Open Assessment Technologies SA.
+ * Copyright (c) 2024-2025 (original work) Open Assessment Technologies SA.
  */
 
 declare(strict_types=1);
@@ -65,18 +65,68 @@ class TranslationUniqueIdSetterTest extends TestCase
     public function testUniqueIdFeatureDisabled(): void
     {
         $this->featureFlagChecker
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('isEnabled')
-            ->with('FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER')
-            ->willReturn(false);
+            ->withConsecutive(
+                ['FEATURE_FLAG_TRANSLATION_ENABLED'],
+                ['FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER']
+            )
+            ->willReturnOnConsecutiveCalls(true, false);
+
+        $originalResourceUriProperty = $this->createPropertyMock();
+        $uniqueIdProperty = $this->createPropertyMock();
+
+        $this->ontology
+            ->expects($this->exactly(2))
+            ->method('getProperty')
+            ->withConsecutive(
+                [TaoOntology::PROPERTY_TRANSLATION_ORIGINAL_RESOURCE_URI],
+                [TaoOntology::PROPERTY_UNIQUE_IDENTIFIER]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $originalResourceUriProperty,
+                $uniqueIdProperty
+            );
+
+        $this->resource
+            ->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->with($originalResourceUriProperty)
+            ->willReturn('originalResourceUri');
+
+        $originalResource = $this->createResourceMock();
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getResource')
+            ->with('originalResourceUri')
+            ->willReturn($originalResource);
+
+        $identifier = $this->createMock(core_kernel_classes_Literal::class);
+        $identifier->literal = 'identifier';
+
+        $originalResource
+            ->expects($this->once())
+            ->method('getOnePropertyValue')
+            ->with($uniqueIdProperty)
+            ->willReturn($identifier);
 
         $this->resource
             ->expects($this->never())
-            ->method($this->anything());
+            ->method('editPropertyValues');
+
+        $this->resource
+            ->expects($this->once())
+            ->method('getRootId')
+            ->willReturn('resourceType');
 
         $this->qtiIdentifierSetter
-            ->expects($this->never())
-            ->method('set');
+            ->expects($this->once())
+            ->method('set')
+            ->with([
+                AbstractQtiIdentifierSetter::OPTION_RESOURCE => $this->resource,
+                AbstractQtiIdentifierSetter::OPTION_IDENTIFIER => 'identifier',
+            ]);
 
         $this->sut->__invoke($this->resource);
     }
@@ -84,13 +134,10 @@ class TranslationUniqueIdSetterTest extends TestCase
     public function testTranslationFeatureDisabled(): void
     {
         $this->featureFlagChecker
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('isEnabled')
-            ->withConsecutive(
-                ['FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER'],
-                ['FEATURE_FLAG_TRANSLATION_ENABLED']
-            )
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->with('FEATURE_FLAG_TRANSLATION_ENABLED')
+            ->willReturn(false);
 
         $this->resource
             ->expects($this->never())
@@ -106,13 +153,10 @@ class TranslationUniqueIdSetterTest extends TestCase
     public function testNoOriginalResourceUri(): void
     {
         $this->featureFlagChecker
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('isEnabled')
-            ->withConsecutive(
-                ['FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER'],
-                ['FEATURE_FLAG_TRANSLATION_ENABLED']
-            )
-            ->willReturnOnConsecutiveCalls(true, true);
+            ->with('FEATURE_FLAG_TRANSLATION_ENABLED')
+            ->willReturn(true);
 
         $originalResourceUriProperty = $this->createPropertyMock();
 
@@ -142,13 +186,10 @@ class TranslationUniqueIdSetterTest extends TestCase
     public function testNoUniqueId(): void
     {
         $this->featureFlagChecker
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('isEnabled')
-            ->withConsecutive(
-                ['FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER'],
-                ['FEATURE_FLAG_TRANSLATION_ENABLED']
-            )
-            ->willReturnOnConsecutiveCalls(true, true);
+            ->with('FEATURE_FLAG_TRANSLATION_ENABLED')
+            ->willReturn(true);
 
         $originalResourceUriProperty = $this->createPropertyMock();
         $uniqueIdProperty = $this->createPropertyMock();
@@ -199,13 +240,10 @@ class TranslationUniqueIdSetterTest extends TestCase
     public function testNoQtiIdentifierSetterForSpecifiedType(): void
     {
         $this->featureFlagChecker
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('isEnabled')
-            ->withConsecutive(
-                ['FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER'],
-                ['FEATURE_FLAG_TRANSLATION_ENABLED']
-            )
-            ->willReturnOnConsecutiveCalls(true, true);
+            ->with('FEATURE_FLAG_TRANSLATION_ENABLED')
+            ->willReturn(true);
 
         $originalResourceUriProperty = $this->createPropertyMock();
         $uniqueIdProperty = $this->createPropertyMock();
@@ -246,7 +284,7 @@ class TranslationUniqueIdSetterTest extends TestCase
             ->willReturn($identifier);
 
         $this->resource
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('editPropertyValues')
             ->with($uniqueIdProperty, 'identifier');
 
@@ -271,8 +309,8 @@ class TranslationUniqueIdSetterTest extends TestCase
             ->expects($this->exactly(2))
             ->method('isEnabled')
             ->withConsecutive(
-                ['FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER'],
-                ['FEATURE_FLAG_TRANSLATION_ENABLED']
+                ['FEATURE_FLAG_TRANSLATION_ENABLED'],
+                ['FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER']
             )
             ->willReturnOnConsecutiveCalls(true, true);
 


### PR DESCRIPTION
# [AUT-3772](https://oat-sa.atlassian.net/browse/AUT-3772)

## Changes
* Keep the same QTI identifier for translations even if unique ID feature flag disabled

## How to test
1. Disable `FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER` feature flag
2. Enable `FEATURE_FLAG_TRANSLATION_ENABLED` feature flag
3. Create new Item/Test
4. Add some content
5. Mark Item/Test as `Ready for translation`
6. Translate Item/Test
7. Compare original and translation QTI IDs

* Previous behaviour: QTI ID is different
* New behaviour: QTI ID is the same

## Companion PRs
* https://github.com/oat-sa/extension-tao-itemqti/pull/2687
* https://github.com/oat-sa/extension-tao-testqti/pull/2579

[AUT-3772]: https://oat-sa.atlassian.net/browse/AUT-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ