### PR TITLE
feat: include property restriction in instance edit form

### DIFF
--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -34,7 +34,6 @@ use core_kernel_classes_Property as Property;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use core_kernel_classes_Resource as Resource;
 
-
 /**
  * Create a form from a  resource of your ontology.
  * Each property will be a field, regarding it's widget.

--- a/models/classes/ClassProperty/PropertyRestrictionGuard.php
+++ b/models/classes/ClassProperty/PropertyRestrictionGuard.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\ClassProperty;
+
+use core_kernel_classes_Resource as Resource;
+use core_kernel_classes_Property as Property;
+use oat\generis\model\data\Ontology;
+
+class PropertyRestrictionGuard
+{
+    private Ontology $ontology;
+
+    public function __construct(Ontology $ontology)
+    {
+        $this->ontology = $ontology;
+    }
+
+    public function isPropertyRestricted(Resource $instance, Property $property, array $restrictedProperties): bool
+    {
+        if (!in_array($property->getUri(), array_keys($restrictedProperties))) {
+            return false;
+        }
+
+        foreach ($restrictedProperties as $restrictions) {
+            foreach ($restrictions as $restriction => $values) {
+                $propertyRestriction = $this->ontology->getProperty($restriction);
+                $propertyRestrictionValue = $instance->getOnePropertyValue($propertyRestriction);
+                if ($propertyRestrictionValue && in_array((string) $propertyRestrictionValue, $values)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/models/classes/listener/PropertyServiceProvider.php
+++ b/models/classes/listener/PropertyServiceProvider.php
@@ -22,14 +22,9 @@ declare(strict_types=1);
 
 namespace oat\tao\model\listener;
 
-use common_ext_ExtensionsManager;
 use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
-use oat\oatbox\cache\SimpleCache;
-use oat\tao\model\ClientLibConfigRegistry;
-use oat\tao\model\featureFlag\Listener\FeatureFlagCacheWarmupListener;
-use oat\tao\model\featureFlag\Repository\FeatureFlagRepository;
-use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
+use oat\tao\model\ClassProperty\PropertyRestrictionGuard;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -51,5 +46,13 @@ class PropertyServiceProvider implements ContainerServiceProviderInterface
                     service(Ontology::SERVICE_ID)
                 ]
             );
+
+        $services->set(PropertyRestrictionGuard::class, PropertyRestrictionGuard::class)
+            ->args(
+                [
+                    service(Ontology::SERVICE_ID)
+                ]
+            )
+            ->public();
     }
 }

--- a/models/classes/resources/relation/service/ResourceRelationServiceProxy.php
+++ b/models/classes/resources/relation/service/ResourceRelationServiceProxy.php
@@ -64,10 +64,12 @@ class ResourceRelationServiceProxy extends ConfigurableService implements Resour
                 continue;
             }
 
+            $container = $this->getServiceManager()->getContainer();
+
             foreach ($services as $serviceId) {
                 $relations = array_merge(
                     $relations,
-                    $this->getResourceRelationService($serviceId)
+                    $container->get($serviceId)
                         ->findRelations($query)
                         ->getIterator()
                         ->getArrayCopy()
@@ -76,11 +78,6 @@ class ResourceRelationServiceProxy extends ConfigurableService implements Resour
         }
 
         return new ResourceRelationCollection(...$relations);
-    }
-
-    private function getResourceRelationService(string $serviceId): ResourceRelationServiceInterface
-    {
-        return $this->getServiceLocator()->get($serviceId);
     }
 
     private function getServices(string $type): array

--- a/test/unit/models/classes/ClassProperty/PropertyRestrictionGuardTest.php
+++ b/test/unit/models/classes/ClassProperty/PropertyRestrictionGuardTest.php
@@ -48,11 +48,10 @@ class PropertyRestrictionGuardTest extends TestCase
      */
     public function testIsPropertyRestrictedFalse(
         string $propertyUri,
-        int    $propertyGetUriCount,
-        int    $getPropertyCallCount = 0,
-        int    $getOnePropertyValueCallCount = 0
-    ): void
-    {
+        int $propertyGetUriCount,
+        int $getPropertyCallCount = 0,
+        int $getOnePropertyValueCallCount = 0
+    ): void {
         $this->property->expects(self::exactly($propertyGetUriCount))
             ->method('getUri')
             ->willReturn($propertyUri);
@@ -68,8 +67,10 @@ class PropertyRestrictionGuardTest extends TestCase
             ->willReturn('value');
 
         self::assertFalse($this->subject->isPropertyRestricted(
-            $this->instance, $this->property, $this->restrictedProperties)
-        );
+            $this->instance,
+            $this->property,
+            $this->restrictedProperties
+        ));
     }
 
     public function testIsPropertyRestrictedTrue(): void
@@ -89,8 +90,10 @@ class PropertyRestrictionGuardTest extends TestCase
             ->willReturn('diffValue');
 
         self::assertTrue($this->subject->isPropertyRestricted(
-            $this->instance, $this->property, $this->restrictedProperties)
-        );
+            $this->instance,
+            $this->property,
+            $this->restrictedProperties
+        ));
     }
 
     public function propertyNonRestrictedDataProvider(): array

--- a/test/unit/models/classes/ClassProperty/PropertyRestrictionGuardTest.php
+++ b/test/unit/models/classes/ClassProperty/PropertyRestrictionGuardTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\ClassProperty;
+
+use oat\generis\model\data\Ontology;
+use oat\tao\model\ClassProperty\PropertyRestrictionGuard;
+use PHPUnit\Framework\TestCase;
+use core_kernel_classes_Resource as Resource;
+use core_kernel_classes_Property as Property;
+
+class PropertyRestrictionGuardTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->ontologyMock = $this->createMock(Ontology::class);
+        $this->subject = new PropertyRestrictionGuard($this->ontologyMock);
+        $this->instance = $this->createMock(Resource::class);
+        $this->property = $this->createMock(Property::class);
+        $this->restrictedProperties = [
+            'propertyUri' => [
+                'restrictionPropertyUri' => ['value']
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider propertyNonRestrictedDataProvider
+     */
+    public function testIsPropertyRestrictedFalse(
+        string $propertyUri,
+        int    $propertyGetUriCount,
+        int    $getPropertyCallCount = 0,
+        int    $getOnePropertyValueCallCount = 0
+    ): void
+    {
+        $this->property->expects(self::exactly($propertyGetUriCount))
+            ->method('getUri')
+            ->willReturn($propertyUri);
+
+        $this->ontologyMock->expects(self::exactly($getPropertyCallCount))
+            ->method('getProperty')
+            ->with('restrictionPropertyUri')
+            ->willReturn($this->property);
+
+        $this->instance->expects(self::exactly($getOnePropertyValueCallCount))
+            ->method('getOnePropertyValue')
+            ->with($this->property)
+            ->willReturn('value');
+
+        self::assertFalse($this->subject->isPropertyRestricted(
+            $this->instance, $this->property, $this->restrictedProperties)
+        );
+    }
+
+    public function testIsPropertyRestrictedTrue(): void
+    {
+        $this->property->expects(self::once())
+            ->method('getUri')
+            ->willReturn('propertyUri');
+
+        $this->ontologyMock->expects(self::once())
+            ->method('getProperty')
+            ->with('restrictionPropertyUri')
+            ->willReturn($this->property);
+
+        $this->instance->expects(self::once())
+            ->method('getOnePropertyValue')
+            ->with($this->property)
+            ->willReturn('diffValue');
+
+        self::assertTrue($this->subject->isPropertyRestricted(
+            $this->instance, $this->property, $this->restrictedProperties)
+        );
+    }
+
+    public function propertyNonRestrictedDataProvider(): array
+    {
+        return [
+            'Property not in restrictedProperties list' => [
+                'propertyUriNotRestricted',
+                1
+            ],
+            'Property in restrictedProperties list' => [
+                'propertyUri',
+                1,
+                1,
+                1
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
This will allow hide property base on value on other properties. To use it we can add `tao_actions_form_Instance::RESTRICTED_PROPERTIES` with property that we want to hide. Property should include property that we want to check against. Inside Property we should include values that this property should have to allow displaying property. 

[Example in](https://github.com/oat-sa/tao-core/pull/4209) `taoMediaManager`