### PR TITLE
fix: move translations together with a resource

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,8 +1,6 @@
 name: Continuous integration
 
 on:
-  push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -2,7 +2,7 @@ name: Continuous integration
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -7,8 +7,7 @@ on:
 
   push:
     branches:
-      - master
-      - main
+      - develop
       - release-*
 
 jobs:

--- a/models/classes/Translation/Service/TranslationMoveService.php
+++ b/models/classes/Translation/Service/TranslationMoveService.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\Translation\Service;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\tao\model\resources\Command\ResourceTransferCommand;
+use oat\tao\model\Translation\Entity\AbstractResource;
+use oat\tao\model\Translation\Query\ResourceTranslationQuery;
+use oat\tao\model\Translation\Repository\ResourceTranslationRepository;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+class TranslationMoveService
+{
+    private Ontology $ontology;
+    private ResourceTranslationRepository $resourceTranslationRepository;
+    private LoggerInterface $logger;
+
+
+    public function __construct(
+        Ontology $ontology,
+        ResourceTranslationRepository $resourceTranslationRepository,
+        LoggerInterface $logger,
+    ) {
+        $this->ontology = $ontology;
+        $this->resourceTranslationRepository = $resourceTranslationRepository;
+        $this->logger = $logger;
+    }
+
+    public function moveTranslations(ResourceTransferCommand $command): void
+    {
+        try {
+            $destinationClass = $this->ontology->getClass($command->getTo());
+            $translations = $this->resourceTranslationRepository
+                ->find(new ResourceTranslationQuery([$command->getFrom()]));
+
+            /** @var AbstractResource $translation */
+            foreach ($translations as $translation) {
+                $instance = $this->ontology->getResource($translation->getResourceUri());
+                $this->changeInstanceClassReference($instance, $destinationClass);
+            }
+        } catch (Throwable $exception) {
+            $this->logger->error(
+                sprintf(
+                    'Error moving translations for originResourceUri [%s] (%s): %s',
+                    $command->getTo(),
+                    get_class($exception),
+                    $exception->getMessage()
+                )
+            );
+        }
+    }
+
+    private function changeInstanceClassReference(
+        core_kernel_classes_Resource $instance,
+        core_kernel_classes_Class $destinationClass
+    ): void {
+        $fromClasses = $instance->getTypes();
+
+        foreach ($fromClasses as $fromClass) {
+            $instance->removeType($fromClass);
+        }
+
+        $instance->setType($destinationClass);
+    }
+}

--- a/models/classes/Translation/ServiceProvider/TranslationServiceProvider.php
+++ b/models/classes/Translation/ServiceProvider/TranslationServiceProvider.php
@@ -46,6 +46,7 @@ use oat\tao\model\Translation\Service\ResourceTranslationRetriever;
 use oat\tao\model\Translation\Service\TranslatedIntoLanguagesSynchronizer;
 use oat\tao\model\Translation\Service\TranslationCreationService;
 use oat\tao\model\Translation\Service\TranslationDeletionService;
+use oat\tao\model\Translation\Service\TranslationMoveService;
 use oat\tao\model\Translation\Service\TranslationSyncService;
 use oat\tao\model\Translation\Service\TranslationUniqueIdSetter;
 use oat\tao\model\Translation\Service\TranslationUpdateService;
@@ -180,6 +181,17 @@ class TranslationServiceProvider implements ContainerServiceProviderInterface
                 service(LoggerService::SERVICE_ID),
                 service(TranslatedIntoLanguagesSynchronizer::class),
             ])
+            ->public();
+
+        $services
+            ->set(TranslationMoveService::class, TranslationMoveService::class)
+            ->args(
+                [
+                    service(Ontology::SERVICE_ID),
+                    service(ResourceTranslationRepository::class),
+                    service(LoggerService::SERVICE_ID),
+                ]
+            )
             ->public();
 
         $services

--- a/models/classes/resources/CopierServiceProvider.php
+++ b/models/classes/resources/CopierServiceProvider.php
@@ -41,6 +41,7 @@ use oat\generis\model\fileReference\FileReferenceSerializer;
 use oat\tao\model\resources\Specification\RootClassSpecification;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\tao\model\TaoOntology;
+use oat\tao\model\Translation\Service\TranslationMoveService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -148,6 +149,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
                 [
                     service(Ontology::SERVICE_ID),
                     service(RootClassesListService::class),
+                    service(TranslationMoveService::class),
                 ]
             )
             ->call(

--- a/models/classes/resources/Service/InstanceMover.php
+++ b/models/classes/resources/Service/InstanceMover.php
@@ -31,17 +31,22 @@ use oat\tao\model\resources\Contract\PermissionCopierInterface;
 use oat\tao\model\resources\Contract\ResourceTransferInterface;
 use oat\tao\model\resources\Contract\RootClassesListServiceInterface;
 use oat\tao\model\resources\ResourceTransferResult;
+use oat\tao\model\Translation\Service\TranslationMoveService;
 
 class InstanceMover implements ResourceTransferInterface
 {
     private Ontology $ontology;
     private RootClassesListServiceInterface $rootClassesListService;
-    private PermissionCopierInterface $permissionCopier;
+    private TranslationMoveService $translationMoveService;
 
-    public function __construct(Ontology $ontology, RootClassesListServiceInterface $rootClassesListService)
-    {
+    public function __construct(
+        Ontology $ontology,
+        RootClassesListServiceInterface $rootClassesListService,
+        TranslationMoveService $translationMoveService
+    ) {
         $this->ontology = $ontology;
         $this->rootClassesListService = $rootClassesListService;
+        $this->translationMoveService = $translationMoveService;
     }
 
     public function withPermissionCopier(PermissionCopierInterface $permissionCopier): void
@@ -78,6 +83,8 @@ class InstanceMover implements ResourceTransferInterface
         if (isset($this->permissionCopier) && $command->useDestinationAcl()) {
             $this->permissionCopier->copy($to, $from);
         }
+
+        $this->translationMoveService->moveTranslations($command);
 
         return new ResourceTransferResult($from->getUri());
     }

--- a/test/unit/models/classes/Translation/Service/TranslationMoveServiceTest.php
+++ b/test/unit/models/classes/Translation/Service/TranslationMoveServiceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\Translation\Service;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Resource;
+use oat\tao\model\resources\Command\ResourceTransferCommand;
+use oat\tao\model\Translation\Entity\ResourceTranslation;
+use oat\tao\model\Translation\Exception\ResourceTranslationException;
+use oat\tao\model\Translation\Repository\ResourceTranslationRepository;
+use oat\tao\model\Translation\Entity\ResourceCollection;
+use oat\generis\model\data\Ontology;
+use oat\tao\model\Translation\Service\TranslationMoveService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class TranslationMoveServiceTest extends TestCase
+{
+    private TranslationMoveService $sut;
+    private Ontology $ontology;
+    private ResourceTranslationRepository $resourceTranslationRepository;
+    private LoggerInterface $logger;
+    private ResourceTransferCommand $transferCommand;
+
+    protected function setUp(): void
+    {
+        $this->ontology = $this->createMock(Ontology::class);
+        $this->resourceTranslationRepository = $this->createMock(ResourceTranslationRepository::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->transferCommand = new ResourceTransferCommand('fromInstanceUri', 'toClassUri', null, null);
+
+        $this->sut = new TranslationMoveService(
+            $this->ontology,
+            $this->resourceTranslationRepository,
+            $this->logger
+        );
+    }
+
+    public function testMoveTranslations(): void
+    {
+        $destinationClass = $this->createMock(core_kernel_classes_Class::class);
+        $this->ontology
+            ->expects($this->once())
+            ->method('getClass')
+            ->with('toClassUri')
+            ->willReturn($destinationClass);
+
+        $translatedResourceURI = 'translatedItemUri';
+        $translation = new ResourceTranslation($translatedResourceURI, 'label');
+        $resourceCollection = new ResourceCollection($translation);
+
+        $translationResource = $this->createMock(core_kernel_classes_Resource::class);
+
+        $this->resourceTranslationRepository
+            ->expects($this->once())
+            ->method('find')
+            ->willReturn($resourceCollection);
+
+        $this->ontology
+            ->expects($this->once())
+            ->method('getResource')
+            ->with($translatedResourceURI)
+            ->willReturn($translationResource);
+
+        $fromClass = $this->createMock(core_kernel_classes_Class::class);
+        $translationResource
+            ->expects($this->once())
+            ->method('getTypes')
+            ->willReturn([$fromClass]);
+
+        $translationResource
+            ->expects($this->once())
+            ->method('removeType')
+            ->with($fromClass);
+
+        $translationResource
+            ->expects($this->once())
+            ->method('setType')
+            ->with($destinationClass);
+
+        $this->sut->moveTranslations($this->transferCommand);
+    }
+
+    public function testMoveTranslationsNoTranslationsFound(): void
+    {
+        $destinationClass = $this->createMock(core_kernel_classes_Class::class);
+        $this->ontology
+            ->expects($this->once())
+            ->method('getClass')
+            ->with('toClassUri')
+            ->willReturn($destinationClass);
+
+        $this->resourceTranslationRepository
+            ->expects($this->once())
+            ->method('find')
+            ->willReturn(new ResourceCollection());
+
+        $this->ontology
+            ->expects($this->never())
+            ->method('getResource');
+
+        $this->sut->moveTranslations($this->transferCommand);
+    }
+
+    public function testMoveTranslationsLogsError(): void
+    {
+        $destinationClass = $this->createMock(core_kernel_classes_Class::class);
+        $this->ontology
+            ->expects($this->once())
+            ->method('getClass')
+            ->with('toClassUri')
+            ->willReturn($destinationClass);
+
+        $this->ontology
+            ->expects($this->never())
+            ->method('getResource');
+
+        $errorMessage = 'errorMessage';
+        $this->resourceTranslationRepository
+            ->expects($this->once())
+            ->method('find')
+            ->willThrowException(new ResourceTranslationException($errorMessage));
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with($this->callback(function ($arg) use ($errorMessage): bool {
+                $this->assertStringContainsString($errorMessage, $arg);
+                return true;
+            }));
+
+        $this->sut->moveTranslations($this->transferCommand);
+    }
+}

--- a/test/unit/models/classes/resources/Service/InstanceMoverTest.php
+++ b/test/unit/models/classes/resources/Service/InstanceMoverTest.php
@@ -32,6 +32,7 @@ use oat\tao\model\resources\Contract\PermissionCopierInterface;
 use oat\tao\model\resources\Contract\RootClassesListServiceInterface;
 use oat\tao\model\resources\ResourceTransferResult;
 use oat\tao\model\resources\Service\InstanceMover;
+use oat\tao\model\Translation\Service\TranslationMoveService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -47,14 +48,16 @@ class InstanceMoverTest extends TestCase
 
     /** @var MockObject|PermissionCopierInterface */
     private PermissionCopierInterface $permissionCopier;
+    private TranslationMoveService $translationMoveService;
 
     protected function setUp(): void
     {
         $this->ontology = $this->createMock(Ontology::class);
         $this->rootClassesListService = $this->createMock(RootClassesListServiceInterface::class);
         $this->permissionCopier = $this->createMock(PermissionCopierInterface::class);
+        $this->translationMoveService = $this->createMock(TranslationMoveService::class);
 
-        $this->sut = new InstanceMover($this->ontology, $this->rootClassesListService);
+        $this->sut = new InstanceMover($this->ontology, $this->rootClassesListService, $this->translationMoveService);
     }
 
     /**
@@ -149,6 +152,9 @@ class InstanceMoverTest extends TestCase
             ->expects($this->once())
             ->method('getUri')
             ->willReturn('fromInstanceUri');
+
+        $this->translationMoveService->expects($this->once())
+            ->method('moveTranslations');
 
         $this->assertEquals(
             new ResourceTransferResult('fromInstanceUri'),


### PR DESCRIPTION
This aims to keep a test/item translations (hidden resources) together with origin resource when moving it to another class. This fixes the following case:
- Create item/test
- Create a translation
- Move the origin item/test to another class
- Remove the first class (it looks empty but actually it is not due to the translation implementation)
- Check that the translations for the moved items/resource is not lost anymore
