### PR TITLE
fix: remove condition for event aggregation

### DIFF
--- a/models/classes/resources/ResourceWatcher.php
+++ b/models/classes/resources/ResourceWatcher.php
@@ -85,19 +85,16 @@ class ResourceWatcher extends ConfigurableService
         }
 
         $now = microtime(true);
+        $this->getLogger()->debug(
+            'triggering index update on resourceUpdated event'
+        );
 
-        if ($updatedAt === null || ((int) $now - (int) $updatedAt) > 0) {
-            $this->getLogger()->debug(
-                'triggering index update on resourceUpdated event'
-            );
+        $property = $this->getProperty(TaoOntology::PROPERTY_UPDATED_AT);
+        $this->updatedAtCache[$resource->getUri()] = $now;
+        $resource->editPropertyValues($property, $now);
 
-            $property = $this->getProperty(TaoOntology::PROPERTY_UPDATED_AT);
-            $this->updatedAtCache[$resource->getUri()] = $now;
-            $resource->editPropertyValues($property, $now);
-
-            $taskMessage = __('Adding/updating search index for updated resource');
-            $this->createResourceIndexingTask($resource, $taskMessage);
-        }
+        $taskMessage = __('Adding/updating search index for updated resource');
+        $this->createResourceIndexingTask($resource, $taskMessage);
     }
 
     public function catchDeletedResourceEvent(ResourceDeleted $event): void


### PR DESCRIPTION
This will prevent loosing events for indexUpdate. This change will cause the index update logic to run every time the method is called, regardless of whether the resource was actually updated recently or not.