### PR TITLE
fix: restore install tao and update resourses

### DIFF
--- a/models/classes/resources/ResourceWatcher.php
+++ b/models/classes/resources/ResourceWatcher.php
@@ -85,14 +85,15 @@ class ResourceWatcher extends ConfigurableService
         }
 
         $now = microtime(true);
-        $this->getLogger()->debug(
-            'triggering index update on resourceUpdated event'
-        );
+        if ($updatedAt === null || ((int) $now - (int) $updatedAt) > 0) {
+            $this->getLogger()->debug(
+                'triggering index update on resourceUpdated event'
+            );
 
-        $property = $this->getProperty(TaoOntology::PROPERTY_UPDATED_AT);
-        $this->updatedAtCache[$resource->getUri()] = $now;
-        $resource->editPropertyValues($property, $now);
-
+            $property = $this->getProperty(TaoOntology::PROPERTY_UPDATED_AT);
+            $this->updatedAtCache[$resource->getUri()] = $now;
+            $resource->editPropertyValues($property, $now);
+        }
         $taskMessage = __('Adding/updating search index for updated resource');
         $this->createResourceIndexingTask($resource, $taskMessage);
     }


### PR DESCRIPTION
Restoring install TAO.
During installation, TAO generate a huge amount of data, what generate a lot of update events (creating roles, users, object). Its killing environments.


How to reproduce: 
1. Without the fix, try to install TAO using NGS