### PR TITLE
fix: move updating updated_at to the generis during global onUpdate

### DIFF
--- a/models/classes/resources/ResourceWatcher.php
+++ b/models/classes/resources/ResourceWatcher.php
@@ -78,22 +78,6 @@ class ResourceWatcher extends ConfigurableService
     public function catchUpdatedResourceEvent(ResourceUpdated $event): void
     {
         $resource = $event->getResource();
-        $updatedAt = $this->getUpdatedAt($resource);
-
-        if ($updatedAt instanceof core_kernel_classes_Literal) {
-            $updatedAt = (int) $updatedAt->literal;
-        }
-
-        $now = microtime(true);
-        if ($updatedAt === null || ((int) $now - (int) $updatedAt) > 0) {
-            $this->getLogger()->debug(
-                'triggering index update on resourceUpdated event'
-            );
-
-            $property = $this->getProperty(TaoOntology::PROPERTY_UPDATED_AT);
-            $this->updatedAtCache[$resource->getUri()] = $now;
-            $resource->editPropertyValues($property, $now);
-        }
         $taskMessage = __('Adding/updating search index for updated resource');
         $this->createResourceIndexingTask($resource, $taskMessage);
     }

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -25,6 +25,10 @@ namespace oat\tao\test\unit\models\classes\resources;
 use core_kernel_classes_Class;
 use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
+use core_kernel_persistence_ResourceInterface;
+use core_kernel_persistence_smoothsql_SmoothModel;
+use core_kernel_persistence_smoothsql_SmoothRdfs;
+use core_kernel_persistence_starsql_StarModel;
 use Exception;
 use oat\generis\model\data\event\ResourceCreated;
 use oat\generis\model\data\event\ResourceDeleted;
@@ -227,6 +231,51 @@ class ResourceWatcherTest extends TestCase
     // phpcs:enable PSR1.Methods.CamelCapsMethodName
 
     // phpcs:disable PSR1.Methods.CamelCapsMethodName
+    public function testCatchUpdatedResourceEvent_mustCreateIndexTaskInCaseResourceIsSupportedByIndex(): void
+    {
+        $classUri = 'https://tao.docker.localhost/ontologies/tao.rdf#Item';
+        $this->mockHasClassSupportIndexUpdater($classUri);
+        $this->mockAdvancedSearchEnabled(true);
+
+        $this->mockGetTypesResource($classUri);
+
+        $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
+        $this->mockCreateTaskQueueDispatcher(
+            $resourceUri,
+            'Adding/updating search index for updated resource',
+            new UpdateResourceInIndex()
+        );
+
+        $this->mockGetPropertyOntology($this->atLeast(1));
+
+        $this->mockGetUriResource($resourceUri);
+
+        $this->mockDebugLogger('Updating updatedAt property for resource: https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec');
+
+        $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
+        $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
+        $rdfsInterfaceMock->expects($this->once())
+            ->method('getResourceImplementation')
+            ->willReturn(
+                $this->createMock(core_kernel_persistence_ResourceInterface::class)
+            );
+        $ontologyMock->expects($this->once())
+            ->method('getRdfsInterface')
+            ->willReturn(
+                $rdfsInterfaceMock
+            );
+        $this->resource->expects($this->once())->method('getModel')
+            ->willReturn(
+                $ontologyMock
+            );
+
+        $this->sut->catchUpdatedResourceEvent(
+            new ResourceUpdated($this->resource)
+        );
+    }
+    // phpcs:enable PSR1.Methods.CamelCapsMethodName
+
+    // phpcs:disable PSR1.Methods.CamelCapsMethodName
     public function testCatchUpdatedResourceEvent_mustNotCreateIndexTask(): void
     {
         $advancedSearchEnabled = false;
@@ -240,6 +289,29 @@ class ResourceWatcherTest extends TestCase
             new UpdateResourceInIndex(),
             $advancedSearchEnabled
         );
+
+        $this->mockGetPropertyOntology($this->atLeast(1));
+
+        $this->mockGetUriResource($resourceUri);
+
+        $this->mockDebugLogger('Updating updatedAt property for resource: https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec');
+
+        $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
+        $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
+        $rdfsInterfaceMock->expects($this->once())
+            ->method('getResourceImplementation')
+            ->willReturn(
+                $this->createMock(core_kernel_persistence_ResourceInterface::class)
+            );
+        $ontologyMock->expects($this->once())
+            ->method('getRdfsInterface')
+            ->willReturn(
+                $rdfsInterfaceMock
+            );
+        $this->resource->expects($this->once())->method('getModel')
+            ->willReturn(
+                $ontologyMock
+            );
 
         $this->sut->catchUpdatedResourceEvent(
             new ResourceUpdated($this->resource)
@@ -259,10 +331,31 @@ class ResourceWatcherTest extends TestCase
             new UpdateClassInIndex()
         );
 
+        $this->mockGetPropertyOntology($this->atLeast(1));
+
         $this->resource = $this->createMock(core_kernel_classes_Class::class);
         $this->resource->expects($this->any())
             ->method('getUri')
             ->willReturn($resourceUri);
+
+        $this->mockDebugLogger('Updating updatedAt property for resource: https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec');
+
+        $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
+        $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
+        $rdfsInterfaceMock->expects($this->once())
+            ->method('getResourceImplementation')
+            ->willReturn(
+                $this->createMock(core_kernel_persistence_ResourceInterface::class)
+            );
+        $ontologyMock->expects($this->once())
+            ->method('getRdfsInterface')
+            ->willReturn(
+                $rdfsInterfaceMock
+            );
+        $this->resource->expects($this->once())->method('getModel')
+            ->willReturn(
+                $ontologyMock
+            );
 
         $this->sut->catchUpdatedResourceEvent(
             new ResourceUpdated($this->resource)

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -242,12 +242,6 @@ class ResourceWatcherTest extends TestCase
             new UpdateResourceInIndex()
         );
 
-        $this->mockGetPropertyOntology($this->atLeast(1));
-
-        $this->mockGetUriResource($resourceUri);
-
-        $this->resource->expects($this->once())->method('editPropertyValues');
-
         $this->sut->catchUpdatedResourceEvent(
             new ResourceUpdated($this->resource)
         );
@@ -269,10 +263,6 @@ class ResourceWatcherTest extends TestCase
             $advancedSearchEnabled
         );
 
-        $this->mockGetPropertyOntology($this->atLeast(1));
-
-        $this->mockGetUriResource($resourceUri);
-
         $this->sut->catchUpdatedResourceEvent(
             new ResourceUpdated($this->resource)
         );
@@ -291,14 +281,10 @@ class ResourceWatcherTest extends TestCase
             new UpdateClassInIndex()
         );
 
-        $this->mockGetPropertyOntology($this->atLeast(1));
-
         $this->resource = $this->createMock(core_kernel_classes_Class::class);
         $this->resource->expects($this->any())
             ->method('getUri')
             ->willReturn($resourceUri);
-
-        $this->resource->expects($this->once())->method('editPropertyValues');
 
         $this->sut->catchUpdatedResourceEvent(
             new ResourceUpdated($this->resource)

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -227,28 +227,6 @@ class ResourceWatcherTest extends TestCase
     // phpcs:enable PSR1.Methods.CamelCapsMethodName
 
     // phpcs:disable PSR1.Methods.CamelCapsMethodName
-    public function testCatchUpdatedResourceEvent_mustCreateIndexTaskInCaseResourceIsSupportedByIndex(): void
-    {
-        $classUri = 'https://tao.docker.localhost/ontologies/tao.rdf#Item';
-        $this->mockHasClassSupportIndexUpdater($classUri);
-        $this->mockAdvancedSearchEnabled(true);
-
-        $this->mockGetTypesResource($classUri);
-
-        $resourceUri = 'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec';
-        $this->mockCreateTaskQueueDispatcher(
-            $resourceUri,
-            'Adding/updating search index for updated resource',
-            new UpdateResourceInIndex()
-        );
-
-        $this->sut->catchUpdatedResourceEvent(
-            new ResourceUpdated($this->resource)
-        );
-    }
-    // phpcs:enable PSR1.Methods.CamelCapsMethodName
-
-    // phpcs:disable PSR1.Methods.CamelCapsMethodName
     public function testCatchUpdatedResourceEvent_mustNotCreateIndexTask(): void
     {
         $advancedSearchEnabled = false;

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -246,8 +246,6 @@ class ResourceWatcherTest extends TestCase
 
         $this->mockGetUriResource($resourceUri);
 
-        $this->mockDebugLogger('triggering index update on resourceUpdated event');
-
         $this->resource->expects($this->once())->method('editPropertyValues');
 
         $this->sut->catchUpdatedResourceEvent(
@@ -275,8 +273,6 @@ class ResourceWatcherTest extends TestCase
 
         $this->mockGetUriResource($resourceUri);
 
-        $this->mockDebugLogger('triggering index update on resourceUpdated event');
-
         $this->sut->catchUpdatedResourceEvent(
             new ResourceUpdated($this->resource)
         );
@@ -301,8 +297,6 @@ class ResourceWatcherTest extends TestCase
         $this->resource->expects($this->any())
             ->method('getUri')
             ->willReturn($resourceUri);
-
-        $this->mockDebugLogger('triggering index update on resourceUpdated event');
 
         $this->resource->expects($this->once())->method('editPropertyValues');
 

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -26,7 +26,6 @@ use core_kernel_classes_Class;
 use core_kernel_classes_Property;
 use core_kernel_classes_Resource;
 use core_kernel_persistence_ResourceInterface;
-use core_kernel_persistence_smoothsql_SmoothModel;
 use core_kernel_persistence_smoothsql_SmoothRdfs;
 use core_kernel_persistence_starsql_StarModel;
 use Exception;
@@ -250,7 +249,10 @@ class ResourceWatcherTest extends TestCase
 
         $this->mockGetUriResource($resourceUri);
 
-        $this->mockDebugLogger('Updating updatedAt property for resource: https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec');
+        $this->mockDebugLogger(
+            'Updating updatedAt property for resource: ' .
+            'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
+        );
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
@@ -294,7 +296,10 @@ class ResourceWatcherTest extends TestCase
 
         $this->mockGetUriResource($resourceUri);
 
-        $this->mockDebugLogger('Updating updatedAt property for resource: https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec');
+        $this->mockDebugLogger(
+            'Updating updatedAt property for resource: ' .
+            'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
+        );
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
@@ -338,7 +343,10 @@ class ResourceWatcherTest extends TestCase
             ->method('getUri')
             ->willReturn($resourceUri);
 
-        $this->mockDebugLogger('Updating updatedAt property for resource: https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec');
+        $this->mockDebugLogger(
+            'Updating updatedAt property for resource: ' .
+            'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
+        );
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);


### PR DESCRIPTION
We found that during updating we also try to update the updatedAt which will also trigger onUpdate event which will be collected by the Event Aggregator
https://github.com/oat-sa/tao-core/blob/v54.39.2/models/classes/resources/ResourceWatcher.php#L95

How to test:
1. Update any resource and check that updatedAt was updated with the current timestamp
2. Import any test and check that we have only needed number of index tasks in task queue
