### PR TITLE
Fix INF-357 lax local file mime type detection

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '8.1', '8.2', '8.3' ]
+        php-version: [ '8.1', '8.2', '8.3', '8.4' ]
         include:
-          - php-version: '8.3'
+          - php-version: '8.4'
             coverage: true
 
     steps:

--- a/models/classes/websource/BaseWebsource.php
+++ b/models/classes/websource/BaseWebsource.php
@@ -1,7 +1,6 @@
 <?php
 
 /**
- *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -16,18 +15,23 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2025 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\tao\model\websource;
 
+use common_Exception;
+use common_exception_Error;
+use common_exception_NotFound;
 use GuzzleHttp\Psr7\Stream;
 use oat\oatbox\Configurable;
+use oat\oatbox\filesystem\FileSystem;
 use oat\oatbox\filesystem\FilesystemException;
 use oat\oatbox\filesystem\FileSystemService;
 use oat\oatbox\service\ServiceManager;
 use Psr\Http\Message\StreamInterface;
 use tao_helpers_File;
+use tao_models_classes_FileNotFoundException;
 
 /**
  * @author Joel Bout, <joel@taotesting.com>
@@ -55,7 +59,7 @@ abstract class BaseWebsource extends Configurable implements Websource
      * @param $fileSystemId
      * @param array $customConfig
      * @return BaseWebsource
-     * @throws \common_Exception
+     * @throws common_Exception
      */
     protected static function spawn($fileSystemId, $customConfig = [])
     {
@@ -78,9 +82,9 @@ abstract class BaseWebsource extends Configurable implements Websource
     }
 
     /**
-     * @return null|\oat\oatbox\filesystem\FileSystem
-     * @throws \common_exception_Error
-     * @throws \common_exception_NotFound
+     * @return null|FileSystem
+     * @throws common_exception_Error
+     * @throws common_exception_NotFound
      */
     public function getFileSystem()
     {
@@ -95,20 +99,20 @@ abstract class BaseWebsource extends Configurable implements Websource
     /**
      * @param $filePath
      * @return StreamInterface
-     * @throws \common_exception_Error
-     * @throws \common_exception_NotFound
-     * @throws \tao_models_classes_FileNotFoundException
+     * @throws common_exception_Error
+     * @throws common_exception_NotFound
+     * @throws tao_models_classes_FileNotFoundException
      */
     public function getFileStream($filePath)
     {
         if ($filePath === '') {
-            throw new \tao_models_classes_FileNotFoundException("Empty file path");
+            throw new tao_models_classes_FileNotFoundException("Empty file path");
         }
         $fs = $this->getFileSystem();
         try {
             $resource = $fs->readStream($filePath);
         } catch (FilesystemException $e) {
-            throw new \tao_models_classes_FileNotFoundException($filePath);
+            throw new tao_models_classes_FileNotFoundException($filePath);
         }
         return new Stream($resource, ['size' => $fs->fileSize($filePath)]);
     }
@@ -117,8 +121,8 @@ abstract class BaseWebsource extends Configurable implements Websource
      * Get a file's mime-type.
      * @param string $filePath The path to the file.
      * @return string|false The file mime-type or false on failure.
-     * @throws \common_exception_Error
-     * @throws \common_exception_NotFound
+     * @throws common_exception_Error
+     * @throws common_exception_NotFound
      * @throws FilesystemException
      */
     public function getMimetype($filePath)
@@ -126,35 +130,36 @@ abstract class BaseWebsource extends Configurable implements Websource
         $mimeType = $this->getFileSystem()->mimeType($filePath);
 
         $pathParts = pathinfo($filePath);
-        if (isset($pathParts['extension'])) {
-            //manage bugs in finfo
-            switch ($pathParts['extension']) {
-                case 'js':
-                    if (
-                        in_array($mimeType, ['text/plain', 'text/html', 'text/x-asm', 'text/x-c', 'text/x-java'], true)
-                    ) {
-                        return 'text/javascript';
-                    }
-                    break;
-                case 'css':
-                    // for css files mime type can be 'text/plain' due to bug in finfo
-                    // (see more: https://bugs.php.net/bug.php?id=53035)
-                    if ($mimeType === 'text/plain' || $mimeType === 'text/x-asm') {
-                        return 'text/css';
-                    }
-                    break;
-                case 'svg':
-                case 'svgz':
-                    // when there are more than one image in svg file - finfo recognizes it as `image/svg`, while it
-                    // should be `image/svg+xml` or at least `text/plain` for a previous hack to work
-                    if (in_array($mimeType, self::ALLOWED_SVGZ_MIMETYPES, true)) {
-                        return tao_helpers_File::MIME_SVG;
-                    }
-                    break;
-                case 'mp3':
-                    return 'audio/mpeg';
-                    break;
-            }
+        if (!isset($pathParts['extension'])) {
+            return $mimeType;
+        }
+
+        //manage bugs in finfo
+        switch ($pathParts['extension']) {
+            case 'js':
+                if (
+                    in_array($mimeType, ['text/plain', 'text/html', 'text/x-asm', 'text/x-c', 'text/x-java'], true)
+                ) {
+                    return 'text/javascript';
+                }
+                break;
+            case 'css':
+                // for css files mime type can be 'text/plain' due to bug in finfo
+                // (see more: https://bugs.php.net/bug.php?id=53035)
+                if ($mimeType === 'text/plain' || $mimeType === 'text/x-asm') {
+                    return 'text/css';
+                }
+                break;
+            case 'svg':
+            case 'svgz':
+                // when there are more than one image in svg file - finfo recognizes it as `image/svg`, while it
+                // should be `image/svg+xml` or at least `text/plain` for a previous hack to work
+                if (in_array($mimeType, self::ALLOWED_SVGZ_MIMETYPES, true)) {
+                    return tao_helpers_File::MIME_SVG;
+                }
+                break;
+            case 'mp3':
+                return 'audio/mpeg';
         }
 
         return $mimeType;

--- a/models/classes/websource/BaseWebsource.php
+++ b/models/classes/websource/BaseWebsource.php
@@ -134,19 +134,16 @@ abstract class BaseWebsource extends Configurable implements Websource
             return $mimeType;
         }
 
-        //manage bugs in finfo
         switch ($pathParts['extension']) {
             case 'js':
-                if (
-                    in_array($mimeType, ['text/plain', 'text/html', 'text/x-asm', 'text/x-c', 'text/x-java'], true)
-                ) {
+                if (str_starts_with($mimeType, 'text/')) {
                     return 'text/javascript';
                 }
                 break;
             case 'css':
                 // for css files mime type can be 'text/plain' due to bug in finfo
                 // (see more: https://bugs.php.net/bug.php?id=53035)
-                if ($mimeType === 'text/plain' || $mimeType === 'text/x-asm') {
+                if (str_starts_with($mimeType, 'text/')) {
                     return 'text/css';
                 }
                 break;

--- a/test/unit/models/classes/websource/BaseWebsourceTest.php
+++ b/test/unit/models/classes/websource/BaseWebsourceTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018-2025 (original work) Open Assessment Technologies SA;
+ */
+
 namespace oat\tao\test\model\websource;
 
 use oat\generis\test\TestCase;
@@ -41,6 +59,7 @@ class BaseWebsourceTest extends TestCase
     public function mimeTypeProvider()
     {
         return [
+            ['test.js', 'text/tex', 'text/javascript'],
             ['test.js', 'text/plain', 'text/javascript'],
             ['test.js', 'text/x-asm', 'text/javascript'],
             ['test.js', 'text/x-c', 'text/javascript'],


### PR DESCRIPTION
# [INF-357](https://oat-sa.atlassian.net/browse/INF-357)

## What's Changed
8818b54f(ci: add PHP 8.4)
8ae38d74(fix: allow for any `text/`-prefixed mime types to be treated as `text/javascript` or `text/css` depending on the extension of the file that is being requested)
93980700(refactor: reduce cyclomatic complexity of BaseWebsource::getMimetype() method by adding an early return)

## TODO 
- [x] Unit tests
- [x] E2E tests

## How to test
- Import [Omron WebIME PCI.zip](https://github.com/user-attachments/files/21369628/Omron.WebIME.PCI.zip)
- Use the PCI in Item Authoring


[INF-357]: https://oat-sa.atlassian.net/browse/INF-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and correction of MIME types for file extensions such as `.js`, `.css`, `.svg`, `.svgz`, and `.mp3` to ensure more accurate file handling.

* **Tests**
  * Added a new test case to verify correct normalization of the MIME type for JavaScript files.

* **Documentation**
  * Updated license and copyright information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->