### PR TITLE
fix: avoid multiple updatedAt triples per one resource

### DIFF
--- a/models/classes/resources/ResourceWatcher.php
+++ b/models/classes/resources/ResourceWatcher.php
@@ -92,11 +92,14 @@ class ResourceWatcher extends ConfigurableService
             );
             $property = $this->getProperty(TaoOntology::PROPERTY_UPDATED_AT);
             $this->updatedAtCache[$resource->getUri()] = $now;
-            $resource
+
+            $resourceImpl = $resource
                 ->getModel()
                 ->getRdfsInterface()
-                ->getResourceImplementation()
-                ->setPropertyValue($resource, $property, $now);
+                ->getResourceImplementation();
+
+            $resourceImpl->removePropertyValues($resource, $property);
+            $resourceImpl->setPropertyValue($resource, $property, $now);
         }
         $taskMessage = __('Adding/updating search index for updated resource');
         $this->createResourceIndexingTask($resource, $taskMessage);

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -83,7 +83,7 @@ class ResourceWatcherTest extends TestCase
     private $featureFlagChecker;
 
     /** @var core_kernel_persistence_ResourceInterface|MockObject */
-    private $resourceImplementation;
+    private $resourceImpl;
 
     protected function setUp(): void
     {
@@ -97,7 +97,7 @@ class ResourceWatcherTest extends TestCase
         $this->search = $this->createMock(Search::class);
         $this->advancedSearchChecker = $this->createMock(AdvancedSearchChecker::class);
         $this->featureFlagChecker = $this->createMock(FeatureFlagCheckerInterface::class);
-        $this->resourceImplementation = $this->createMock(core_kernel_persistence_ResourceInterface::class);
+        $this->resourceImpl = $this->createMock(core_kernel_persistence_ResourceInterface::class);
 
         $serviceLocator = $this->getServiceManagerMock(
             [
@@ -257,15 +257,15 @@ class ResourceWatcherTest extends TestCase
             'Updating updatedAt property for resource: ' .
             'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
         );
-        $this->resourceImplementation->expects($this->atLeastOnce())->method('removePropertyValues');
-        $this->resourceImplementation->expects($this->atLeastOnce())->method('setPropertyValue');
+        $this->resourceImpl->expects($this->atLeastOnce())->method('removePropertyValues');
+        $this->resourceImpl->expects($this->atLeastOnce())->method('setPropertyValue');
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
         $rdfsInterfaceMock->expects($this->once())
-            ->method('getResourceImplementation')
+            ->method('getresourceImpl')
             ->willReturn(
-                $this->resourceImplementation
+                $this->resourceImpl
             );
         $ontologyMock->expects($this->once())
             ->method('getRdfsInterface')
@@ -306,15 +306,15 @@ class ResourceWatcherTest extends TestCase
             'Updating updatedAt property for resource: ' .
             'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
         );
-        $this->resourceImplementation->expects($this->atLeastOnce())->method('removePropertyValues');
-        $this->resourceImplementation->expects($this->atLeastOnce())->method('setPropertyValue');
+        $this->resourceImpl->expects($this->atLeastOnce())->method('removePropertyValues');
+        $this->resourceImpl->expects($this->atLeastOnce())->method('setPropertyValue');
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
         $rdfsInterfaceMock->expects($this->once())
-            ->method('getResourceImplementation')
+            ->method('getresourceImpl')
             ->willReturn(
-                $this->resourceImplementation
+                $this->resourceImpl
             );
         $ontologyMock->expects($this->once())
             ->method('getRdfsInterface')
@@ -355,15 +355,15 @@ class ResourceWatcherTest extends TestCase
             'Updating updatedAt property for resource: ' .
             'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
         );
-        $this->resourceImplementation->expects($this->atLeastOnce())->method('removePropertyValues');
-        $this->resourceImplementation->expects($this->atLeastOnce())->method('setPropertyValue');
+        $this->resourceImpl->expects($this->atLeastOnce())->method('removePropertyValues');
+        $this->resourceImpl->expects($this->atLeastOnce())->method('setPropertyValue');
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
         $rdfsInterfaceMock->expects($this->once())
-            ->method('getResourceImplementation')
+            ->method('getresourceImpl')
             ->willReturn(
-                $this->resourceImplementation
+                $this->resourceImpl
             );
         $ontologyMock->expects($this->once())
             ->method('getRdfsInterface')

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -257,8 +257,8 @@ class ResourceWatcherTest extends TestCase
             'Updating updatedAt property for resource: ' .
             'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
         );
-        $this->resourceImpl->expects($this->atLeastOnce())->method('removePropertyValues');
-        $this->resourceImpl->expects($this->atLeastOnce())->method('setPropertyValue');
+        $this->resourceImpl->expects($this->once())->method('removePropertyValues');
+        $this->resourceImpl->expects($this->once())->method('setPropertyValue');
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
@@ -306,8 +306,8 @@ class ResourceWatcherTest extends TestCase
             'Updating updatedAt property for resource: ' .
             'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
         );
-        $this->resourceImpl->expects($this->atLeastOnce())->method('removePropertyValues');
-        $this->resourceImpl->expects($this->atLeastOnce())->method('setPropertyValue');
+        $this->resourceImpl->expects($this->once())->method('removePropertyValues');
+        $this->resourceImpl->expects($this->once())->method('setPropertyValue');
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
@@ -355,8 +355,8 @@ class ResourceWatcherTest extends TestCase
             'Updating updatedAt property for resource: ' .
             'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
         );
-        $this->resourceImpl->expects($this->atLeastOnce())->method('removePropertyValues');
-        $this->resourceImpl->expects($this->atLeastOnce())->method('setPropertyValue');
+        $this->resourceImpl->expects($this->once())->method('removePropertyValues');
+        $this->resourceImpl->expects($this->once())->method('setPropertyValue');
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -82,6 +82,9 @@ class ResourceWatcherTest extends TestCase
     /** @var FeatureFlagCheckerInterface|MockObject */
     private $featureFlagChecker;
 
+    /** @var core_kernel_persistence_ResourceInterface|MockObject */
+    private $resourceImplementation;
+
     protected function setUp(): void
     {
         $this->sut = new ResourceWatcher();
@@ -94,6 +97,7 @@ class ResourceWatcherTest extends TestCase
         $this->search = $this->createMock(Search::class);
         $this->advancedSearchChecker = $this->createMock(AdvancedSearchChecker::class);
         $this->featureFlagChecker = $this->createMock(FeatureFlagCheckerInterface::class);
+        $this->resourceImplementation = $this->createMock(core_kernel_persistence_ResourceInterface::class);
 
         $serviceLocator = $this->getServiceManagerMock(
             [
@@ -129,7 +133,7 @@ class ResourceWatcherTest extends TestCase
 
         $this->mockGetUriResource($resourceUri);
 
-        $this->mockDebugLogger('triggering index update on resourceCreated event');
+        $this->expectsDebugLogMessage('triggering index update on resourceCreated event');
 
         $this->sut->catchCreatedResourceEvent(
             new ResourceCreated($this->resource)
@@ -183,7 +187,7 @@ class ResourceWatcherTest extends TestCase
 
         $this->mockGetUriResource($resourceUri);
 
-        $this->mockDebugLogger('triggering index update on resourceCreated event');
+        $this->expectsDebugLogMessage('triggering index update on resourceCreated event');
 
         $this->sut->catchCreatedResourceEvent(
             new ResourceCreated($this->resource)
@@ -221,7 +225,7 @@ class ResourceWatcherTest extends TestCase
 
         $this->mockGetUriResource($resourceUri);
 
-        $this->mockDebugLogger('triggering index update on resourceCreated event');
+        $this->expectsDebugLogMessage('triggering index update on resourceCreated event');
 
         $this->sut->catchCreatedResourceEvent(
             new ResourceCreated($this->resource)
@@ -249,17 +253,19 @@ class ResourceWatcherTest extends TestCase
 
         $this->mockGetUriResource($resourceUri);
 
-        $this->mockDebugLogger(
+        $this->expectsDebugLogMessage(
             'Updating updatedAt property for resource: ' .
             'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
         );
+        $this->resourceImplementation->expects($this->atLeastOnce())->method('removePropertyValues');
+        $this->resourceImplementation->expects($this->atLeastOnce())->method('setPropertyValue');
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
         $rdfsInterfaceMock->expects($this->once())
             ->method('getResourceImplementation')
             ->willReturn(
-                $this->createMock(core_kernel_persistence_ResourceInterface::class)
+                $this->resourceImplementation
             );
         $ontologyMock->expects($this->once())
             ->method('getRdfsInterface')
@@ -296,17 +302,19 @@ class ResourceWatcherTest extends TestCase
 
         $this->mockGetUriResource($resourceUri);
 
-        $this->mockDebugLogger(
+        $this->expectsDebugLogMessage(
             'Updating updatedAt property for resource: ' .
             'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
         );
+        $this->resourceImplementation->expects($this->atLeastOnce())->method('removePropertyValues');
+        $this->resourceImplementation->expects($this->atLeastOnce())->method('setPropertyValue');
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
         $rdfsInterfaceMock->expects($this->once())
             ->method('getResourceImplementation')
             ->willReturn(
-                $this->createMock(core_kernel_persistence_ResourceInterface::class)
+                $this->resourceImplementation
             );
         $ontologyMock->expects($this->once())
             ->method('getRdfsInterface')
@@ -343,17 +351,19 @@ class ResourceWatcherTest extends TestCase
             ->method('getUri')
             ->willReturn($resourceUri);
 
-        $this->mockDebugLogger(
+        $this->expectsDebugLogMessage(
             'Updating updatedAt property for resource: ' .
             'https://tao.docker.localhost/ontologies/tao.rdf#i5ef45f413088c8e7901a84708e84ec'
         );
+        $this->resourceImplementation->expects($this->atLeastOnce())->method('removePropertyValues');
+        $this->resourceImplementation->expects($this->atLeastOnce())->method('setPropertyValue');
 
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
         $rdfsInterfaceMock->expects($this->once())
             ->method('getResourceImplementation')
             ->willReturn(
-                $this->createMock(core_kernel_persistence_ResourceInterface::class)
+                $this->resourceImplementation
             );
         $ontologyMock->expects($this->once())
             ->method('getRdfsInterface')
@@ -463,7 +473,7 @@ class ResourceWatcherTest extends TestCase
             ->willReturn($resourceUri);
     }
 
-    private function mockDebugLogger(string $message): void
+    private function expectsDebugLogMessage(string $message): void
     {
         $this->logger->expects($this->once())
             ->method('debug')

--- a/test/unit/models/classes/resources/ResourceWatcherTest.php
+++ b/test/unit/models/classes/resources/ResourceWatcherTest.php
@@ -263,7 +263,7 @@ class ResourceWatcherTest extends TestCase
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
         $rdfsInterfaceMock->expects($this->once())
-            ->method('getresourceImpl')
+            ->method('getResourceImplementation')
             ->willReturn(
                 $this->resourceImpl
             );
@@ -312,7 +312,7 @@ class ResourceWatcherTest extends TestCase
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
         $rdfsInterfaceMock->expects($this->once())
-            ->method('getresourceImpl')
+            ->method('getResourceImplementation')
             ->willReturn(
                 $this->resourceImpl
             );
@@ -361,7 +361,7 @@ class ResourceWatcherTest extends TestCase
         $ontologyMock = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
         $rdfsInterfaceMock = $this->createMock(core_kernel_persistence_smoothsql_SmoothRdfs::class);
         $rdfsInterfaceMock->expects($this->once())
-            ->method('getresourceImpl')
+            ->method('getResourceImplementation')
             ->willReturn(
                 $this->resourceImpl
             );


### PR DESCRIPTION
## What's Changed
Fixed a regression caused by this https://github.com/oat-sa/tao-core/pull/4260/files#diff-6276791832b777d2ccdab8de777dce68467167617c591a79d9a135b788df71ebR95

- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [x] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [x] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages

## How to test
- run tao on latest release
- update some resource
- check DB: `SELECT * FROM statements WHERE predicate='http://www.tao.lu/Ontologies/TAO.rdf#UpdatedAt' AND subject = resourceId`
- see that after each update a new row appear
- checkout the PR code branch
- update the resource now
- repeat the DB check
- ensure that all duplicates gone and not appear (we keep only one updated ad property value per resource as it was before the bug)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resource update events to ensure previous "updatedAt" values are properly removed before setting a new timestamp.

* **Tests**
  * Enhanced test coverage to verify correct removal and setting of "updatedAt" values during resource updates.
  * Improved consistency in test method naming and mock usage for better reliability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->