### PR TITLE
fix: remove interactionsource and sourcedialog buttons from item property editor

### DIFF
--- a/views/js/uiForm.js
+++ b/views/js/uiForm.js
@@ -360,7 +360,20 @@
                 }
 
                 var editor = ckeditor.replace(this);
-                editor.config = ckConfigurator.getConfig(editor, 'htmlField', {resize_enabled : false });
+                var configOptions = {
+                    resize_enabled: false,
+                    interactionsource: false,
+                    sourcedialog: false
+                };
+
+                var removePlugins = [];
+
+                removePlugins.push('interactionsource');
+                removePlugins.push('sourcedialog');
+
+                configOptions.removePlugins = removePlugins.join(',');
+
+                editor.config = ckConfigurator.getConfig(editor, 'htmlField', configOptions);
                 self.htmlEditors[propertyUri] = editor;
             });
 


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/HKD-763
## What's Changed
- remove `interactionsource` and `sourcedialog` buttons from item property editor

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## How to test
- Enable `interactionsource` and `sourcedialog` via FF `FEATURE_FLAG_CKEDITOR_SOURCEDIALOG` and `FEATURE_FLAG_CKEDITOR_INTERACTION_SOURCE`
- Go to Item schema and add property with Text Html Editor type
- Observe there is no additional buttons
- Go to item Authoring and buttons are there like should be

## Video

https://github.com/user-attachments/assets/3f792cb3-d422-4969-b0c1-e031760c0df9

