### PR TITLE
fix: generating trao booklet form

### DIFF
--- a/actions/form/class.Instance.php
+++ b/actions/form/class.Instance.php
@@ -130,7 +130,7 @@ class tao_actions_form_Instance extends tao_actions_form_Generis
             // Using restricted properties passed when creating editInstanceForm
             // we can hide properties base on other resource properties
             $restrictedProperties = $this->options[self::RESTRICTED_PROPERTIES] ?? [];
-            if ($this->isPropertyRestricted($instance, $property, $restrictedProperties)) {
+            if ($instance && $this->isPropertyRestricted($instance, $property, $restrictedProperties)) {
                 continue;
             }
 


### PR DESCRIPTION
Fix next error:
```Uncaught TypeError: tao_actions_form_Instance::isPropertyRestricted(): Argument #1 ($instance) must be of type core_kernel_classes_Resource, null given, called in /var/www/html/tao/actions/form/class.Instance.php on line 133```
<img width="1593" height="456" alt="image" src="https://github.com/user-attachments/assets/d5f3b7f6-1d71-47fd-bf46-2c651d62c245" />

https://github.com/user-attachments/assets/d6ec0f52-9f37-4cdb-87e9-e1c41f076402



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when opening or building forms without an existing item.
  * Applied property restrictions only when an item exists, improving reliability during form creation.
  * Ensured correct field availability for new-item forms (no unintended restrictions when no instance is present).
  * Existing edit workflows remain unchanged; general behavior and performance are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->