### PR TITLE
feat: add new interface to implement in ACL domain

### DIFF
--- a/models/classes/accessControl/AclRoleProvider.php
+++ b/models/classes/accessControl/AclRoleProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2025 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\accessControl;
+
+interface AclRoleProvider
+{
+    public const SERVICE_ID = 'tao/AclRoleProvider';
+    public function get(): string;
+}


### PR DESCRIPTION
This pull request introduces a new interface, `AclRoleProvider`, to the access control model. This interface is designed to standardize how access control roles are provided throughout the codebase.

Access control improvements:

* Added a new `AclRoleProvider` interface in `models/classes/accessControl/AclRoleProvider.php`, which defines a contract for retrieving access control roles and includes a service identifier constant.

https://github.com/oat-sa/extension-tao-lti/pull/440
https://github.com/oat-sa/extension-tao-dac-simple/pull/264


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced an internal contract to standardize how access-control roles are retrieved. This improves consistency across components and lays groundwork for future enhancements. No changes to existing behavior or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->