### PR TITLE
[Fix] Keep original resource permissions during clone action

### DIFF
--- a/actions/class.RdfController.php
+++ b/actions/class.RdfController.php
@@ -684,7 +684,16 @@ abstract class tao_actions_RdfController extends tao_actions_CommonModule
         }
         $this->validateInstanceRoot($uri);
 
-        $clone = $this->getClassService()->cloneInstance($this->getCurrentInstance(), $this->getCurrentClass());
+        $result = $this->getResourceTransfer()->transfer(
+            new ResourceTransferCommand(
+                $this->getCurrentInstance()->getUri(),
+                $this->getCurrentClass()->getUri(),
+                ResourceTransferCommand::ACL_KEEP_ORIGINAL,
+                ResourceTransferCommand::TRANSFER_MODE_CLONE
+            )
+        );
+        $clone = $this->getResource($result->getDestination());
+
         if ($clone !== null) {
             $this->returnJson([
                 'success' => true,

--- a/models/classes/resources/Command/ResourceTransferCommand.php
+++ b/models/classes/resources/Command/ResourceTransferCommand.php
@@ -30,6 +30,7 @@ class ResourceTransferCommand
     public const ACL_USE_DESTINATION = 'acl.use.destination';
     public const TRANSFER_MODE_COPY = 'copy';
     public const TRANSFER_MODE_MOVE = 'move';
+    public const TRANSFER_MODE_CLONE = 'clone';
     private const ACL_OPTIONS = [
         self::ACL_KEEP_ORIGINAL,
         self::ACL_USE_DESTINATION,
@@ -37,6 +38,7 @@ class ResourceTransferCommand
     private const TRANSFER_MODE_OPTIONS = [
         self::TRANSFER_MODE_COPY,
         self::TRANSFER_MODE_MOVE,
+        self::TRANSFER_MODE_CLONE,
     ];
 
     private string $from;
@@ -105,6 +107,11 @@ class ResourceTransferCommand
     public function isMoveTo(): bool
     {
         return $this->transferMode === self::TRANSFER_MODE_MOVE;
+    }
+
+    public function isCloneTo(): bool
+    {
+        return $this->transferMode === self::TRANSFER_MODE_CLONE;
     }
 
     public function getOptions(): array

--- a/models/classes/resources/Service/ResourceTransferProxy.php
+++ b/models/classes/resources/Service/ResourceTransferProxy.php
@@ -78,7 +78,7 @@ class ResourceTransferProxy implements ResourceTransferInterface
             return $this->classMover;
         }
 
-        if ($command->isCopyTo()) {
+        if ($command->isCopyTo() || $command->isCloneTo()) {
             return $this->instanceCopier;
         }
 


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/ADF-1602

## What's Changed
- `cloneInstance` method in `class.RdfController` updated to use resource transfer logic instead of deprecated functionality
- Added new resource transfer mode - `clone`
- Now `clone` resource transfer mode will generate new label for cloned instance (to keep previous logic, that was used in deprecated functionality)

## How to test
1. Make sure `taoDacSimple` extension installed
2. Go to items/tests tab
3. Create new folder
4. Set specific permissions for this folder
   1. for better visibility, you can set `grant` permissions
5. Create new resource inside this folder (permissions must be inherited)
6. Change permissions for this resource
   1. (with step 4.1) for better visibility, you can unset `grant` and `write` permissions
7. Click on `Duplicate` for resource
8. Check permissions for duplicated resource

**Previous behavior**: duplicated resource use folder permissions
**Current behavior**: duplicated resource use original resource permissions