### PR TITLE
fix: allow ar-SA locale available in the UI

### DIFF
--- a/locales/ar-SA/lang.rdf
+++ b/locales/ar-SA/lang.rdf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xml:base="http://www.tao.lu/Ontologies/TAO.rdf#"
+	xmlns:tao="http://www.tao.lu/Ontologies/TAO.rdf#"
+>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAO.rdf#Langar-SA">
+    <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#Languages"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Arabic (Saudi Arabia)]]></rdfs:label>
+    <rdf:value><![CDATA[ar-SA]]></rdf:value>
+    <tao:LanguageUsages rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#LanguageUsageData"/>
+    <tao:LanguageOrientation rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#OrientationRightToLeft"/>
+  </rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
# Goal

https://oat-sa.atlassian.net/browse/ADF-2079

- Allow ar-SA to be available in the UI
- The locale must be publishable as delivery translated in Portal
- The locale must be selectable as locale in Test Runner.

<img width="1774" height="572" alt="Screenshot 2025-09-18 at 08 32 26" src="https://github.com/user-attachments/assets/4377d64d-0b82-4034-b9e3-34dae2fcf8fb" />

<img width="654" height="425" alt="Screenshot 2025-09-18 at 08 30 57" src="https://github.com/user-attachments/assets/0c31a2de-6f1f-48b7-916a-0977008626a4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Arabic (Saudi Arabia) locale option.
  - Supports right-to-left text orientation for improved readability.
  - Enables proper display of labels and language metadata for ar-SA.
  - Prepares the UI to recognize and present Arabic (Saudi Arabia) in language selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->