### PR TITLE
INF-431: fallback when full name is empty

### DIFF
--- a/views/templates/blocks/header-main-navi.tpl
+++ b/views/templates/blocks/header-main-navi.tpl
@@ -104,16 +104,15 @@ $taoAsATool   = get_data('taoAsATool');
 
                     <?php endforeach ?>
 
-                <?php elseif(!empty($userLabel)): ?>
-
+                <?php else: ?>
+                    <?php $displayName = !empty($userLabel) ? $userLabel : __('User'); ?>
                     <li class="infoControl user-label-outside-menu">
                         <span class="a">
                             <span class="icon-user"></span>
-                            <span><?=$userLabel?></span>
+                            <span><?= $displayName ?></span>
                         </span>
                     </li>
                 <?php endif; ?>
-
                 <?php if(has_data('unread-notification')): ?>
                     <li data-env="user" class="li-logout">
                         <a id="logout" href="<?= get_data('notification-url') ?>" title="<?= __('Messages') ?>">


### PR DESCRIPTION
## Summary
- add a fallback label when the full name/label is empty in the header menu

## Testing
https://github.com/user-attachments/assets/d4b38197-2f06-4381-965a-ceeb10f7203c



## Ticket
- INF-431

## Related
https://github.com/oat-sa/extension-lti-test-review/pull/161/changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The header user label now displays a default name when unavailable, ensuring consistent user identification display in the navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->