### PR TITLE
Fix/INF-465/can not select first character after ruby in Chrome

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/polyfill": "^7.4.4",
                 "@oat-sa/tao-core-libs": "^1.1.0",
                 "@oat-sa/tao-core-sdk": "^3.5.0",
-                "@oat-sa/tao-core-shared-libs": "^1.11.3",
+                "@oat-sa/tao-core-shared-libs": "^1.11.4",
                 "@oat-sa/tao-core-ui": "^3.19.1",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
@@ -78,9 +78,10 @@
             }
         },
         "node_modules/@oat-sa/tao-core-shared-libs": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.11.3.tgz",
-            "integrity": "sha512-Y4M1hds6pAlxZe2qpd3wTAvjiz3ST71KvNQw/CtatD4ebu/O9dLaVEcnGI7IC32ck2WYDxz8vlmigY2fM4NZ+A=="
+            "version": "1.11.4",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.11.4.tgz",
+            "integrity": "sha512-xVw9apIrOXp1d2U0D8FhUb/EnUW3tNnExfeX7dZkshnRHf5MJ68S5fwY/g2e+4TAuR1f/6WUKxVDxfh0CCTHtg==",
+            "license": "GPL-2.0"
         },
         "node_modules/@oat-sa/tao-core-ui": {
             "version": "3.19.1",

--- a/views/package.json
+++ b/views/package.json
@@ -12,7 +12,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/tao-core-libs": "^1.1.0",
         "@oat-sa/tao-core-sdk": "^3.5.0",
-        "@oat-sa/tao-core-shared-libs": "^1.11.3",
+        "@oat-sa/tao-core-shared-libs": "^1.11.4",
         "@oat-sa/tao-core-ui": "^3.19.1",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/INF-465

- [x] apply https://github.com/oat-sa/tao-core-shared-libs-fe/pull/68

### Related PRs:
- https://github.com/oat-sa/ckeditor-dev/pull/69
- https://github.com/oat-sa/tao-core-shared-libs-fe/pull/68
- https://github.com/oat-sa/tao-core/pull/4422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the core shared library dependency to the next patch release (from ^1.11.3 to ^1.11.4), adjusting dependency configuration.
  * No changes to public/exported interfaces or user-facing functionality; installation behavior unaffected for end users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/tao-core/pull/4422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->