### PR TITLE
[AUT-4281] Fix: jQuery onload error fix

### DIFF
--- a/views/build/config/requirejs.build.json
+++ b/views/build/config/requirejs.build.json
@@ -50,6 +50,12 @@
   }],
 
   "shim": {
+    "select2-origin/select2": {
+      "deps": ["jquery"]
+    },
+    "select2": {
+      "deps": ["select2-origin/select2"]
+    },
     "moment": {
       "exports": "moment"
     },

--- a/views/templates/client_config.tpl
+++ b/views/templates/client_config.tpl
@@ -89,6 +89,8 @@ require.config({
     }],
    shim : {
         'jqueryui'              : { deps : ['jquery'] },
+        'select2-origin/select2': { deps : ['jquery'] },
+        'select2'               : { deps : ['select2-origin/select2'] },
         'moment'                : { exports : 'moment' },
         'handlebars'            : { exports : 'Handlebars' },
         'ckeditor'              : { exports : 'CKEDITOR' },


### PR DESCRIPTION
## Ticket: https://oat-sa.atlassian.net/browse/AUT-4281

## What's Changed
- Fixed race condition with select2 and jQuery

Was:
<img width="1840" height="972" alt="chrome_KTugyJ3CJF" src="https://github.com/user-attachments/assets/fe6b34c8-ec9d-4913-bb6d-2e34440483eb" />

Fixed:
<img width="1840" height="972" alt="chrome_NtIWAkRsmh" src="https://github.com/user-attachments/assets/47fea914-a747-4282-a6cb-424a73b4ced8" />


> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages

## Dependencies PRs
- https://github.com/oat-sa/..

## How to test
- Explain here how to test or make a small demo to our team how this works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed module initialization sequencing for the Select2 component to ensure dependencies load in the correct order, improving component stability and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->