### PR TITLE
fix: bump @oat-sa/tao-core-shared-libs to 1.11.1 (INF-466)

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/polyfill": "^7.4.4",
                 "@oat-sa/tao-core-libs": "^1.1.0",
                 "@oat-sa/tao-core-sdk": "^3.5.0",
-                "@oat-sa/tao-core-shared-libs": "^1.11.0",
+                "@oat-sa/tao-core-shared-libs": "^1.11.1",
                 "@oat-sa/tao-core-ui": "^3.19.1",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
@@ -78,9 +78,9 @@
             }
         },
         "node_modules/@oat-sa/tao-core-shared-libs": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.11.0.tgz",
-            "integrity": "sha512-tJGM9emSVl5hF4mWlwKCj4BoFtfne3YR0Cp21MjiF3STz0K0XkfAfexJx2SAO9n7fgqqx8OdwEvFUtqtBgI9Dw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.11.1.tgz",
+            "integrity": "sha512-ZdvGWOXgtLHcnB1pxK7uu7xCMDtSauOAoLFnkrCdVH29TLtQ8IMf55L7f0Tk6zzvaTBO7cEKQAfUcHnNhghbiw==",
             "license": "GPL-2.0"
         },
         "node_modules/@oat-sa/tao-core-ui": {

--- a/views/package.json
+++ b/views/package.json
@@ -12,7 +12,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/tao-core-libs": "^1.1.0",
         "@oat-sa/tao-core-sdk": "^3.5.0",
-        "@oat-sa/tao-core-shared-libs": "^1.11.0",
+        "@oat-sa/tao-core-shared-libs": "^1.11.1",
         "@oat-sa/tao-core-ui": "^3.19.1",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",


### PR DESCRIPTION
## Ticket:
INF-466

## What's Changed
- Bumped `@oat-sa/tao-core-shared-libs` from `^1.11.0` to `^1.11.1` in TAO core frontend dependencies.
- Updated lockfile entry so the resolved package is `1.11.1` with matching integrity checksum.

> Please tick the appropriate points
- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [x] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## TODO
- [ ] Unit tests
- [ ] E2E tests
- [ ] Update with packages

## Dependencies PRs
- N/A

## How to test
- Verify `views/package.json` contains `"@oat-sa/tao-core-shared-libs": "^1.11.1"`.
- Verify `views/package-lock.json` resolves `@oat-sa/tao-core-shared-libs` to `1.11.1`.
- Optionally run frontend dependency install and smoke-check core UI flows using shared libs assets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to the latest patch versions for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->