### PR TITLE
fix: bump oat-sa/tao-core-shared-libs to ^1.11.2 for INF-466

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/polyfill": "^7.4.4",
                 "@oat-sa/tao-core-libs": "^1.1.0",
                 "@oat-sa/tao-core-sdk": "^3.5.0",
-                "@oat-sa/tao-core-shared-libs": "^1.11.1",
+                "@oat-sa/tao-core-shared-libs": "^1.11.2",
                 "@oat-sa/tao-core-ui": "^3.19.0",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
@@ -78,9 +78,9 @@
             }
         },
         "node_modules/@oat-sa/tao-core-shared-libs": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.11.1.tgz",
-            "integrity": "sha512-ZdvGWOXgtLHcnB1pxK7uu7xCMDtSauOAoLFnkrCdVH29TLtQ8IMf55L7f0Tk6zzvaTBO7cEKQAfUcHnNhghbiw==",
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.11.2.tgz",
+            "integrity": "sha512-t8gk9+LcXq9rSycSmH6W5Qqn79pquZ/EGPhQNdUFFCedFckzHKlNq+kZm9DlGIHkhHlY/r5Iwr3xWbM04n1gUA==",
             "license": "GPL-2.0"
         },
         "node_modules/@oat-sa/tao-core-ui": {
@@ -102,7 +102,8 @@
         "node_modules/async": {
             "version": "0.2.10",
             "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+            "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+            "peer": true
         },
         "node_modules/codemirror": {
             "version": "5.65.20",
@@ -122,7 +123,8 @@
             "version": "2.5.8",
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
             "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
-            "license": "(MPL-2.0 OR Apache-2.0)"
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "peer": true
         },
         "node_modules/eve-raphael": {
             "version": "0.5.0",
@@ -140,13 +142,15 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/gamp/-/gamp-0.2.1.tgz",
             "integrity": "sha512-dZy17z9sc1k8mU/esu5Rb3/0ZMEJldkRnikb+c8KtNLslGzJqBX7TJfaAlUaoCT9cw6h+SCUTO3tvuRBVCgbkg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/handlebars": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
             "integrity": "sha512-l7sLUTqXCkc1Ypoy8mSOWZFEZJK3VYQYnLfIVTRJeSHdgzt6hXkQ0uPGugydPa99KyyBdsi0J3WvYfm/HX5naQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "optimist": "~0.3"
             },
@@ -170,25 +174,29 @@
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.3.4.tgz",
             "integrity": "sha512-AQ2CdPEyHqiEEQ1FFgMBj79UEsU1+rUwSXuhOkflvB65p4iECft28SN/PvhD/Y9OtNge8aH1qTibjAi+RXQMqQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jquery": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
             "integrity": "sha512-gK7jP5cOEUzjyL0dy7MEMfeSFlmt1yNSdZK98CL8W6o0DiNVW5O9hLcD2bdl48mL8q7bEJgd7d9AhhDaN+iDSQ==",
-            "deprecated": "This version is deprecated. Please upgrade to the latest version or find support at https://www.herodevs.com/support/jquery-nes."
+            "deprecated": "This version is deprecated. Please upgrade to the latest version or find support at https://www.herodevs.com/support/jquery-nes.",
+            "peer": true
         },
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/moment": {
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
             "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -198,6 +206,7 @@
             "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
             "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "moment": "^2.29.4"
             },
@@ -220,6 +229,7 @@
             "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
             "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -230,6 +240,7 @@
             "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
             "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "eve-raphael": "0.5.0"
             }
@@ -243,7 +254,8 @@
         "node_modules/select2": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/select2/-/select2-3.5.1.tgz",
-            "integrity": "sha512-IFX3UFPpPyK1I1Kuw1R1x+upMyNAZbMlkFhiTnRCRR7ii0KU1brmJMLa3GZcrMWCHiQlm0eKqb6i4XO4pqOrGQ=="
+            "integrity": "sha512-IFX3UFPpPyK1I1Kuw1R1x+upMyNAZbMlkFhiTnRCRR7ii0KU1brmJMLa3GZcrMWCHiQlm0eKqb6i4XO4pqOrGQ==",
+            "peer": true
         },
         "node_modules/source-map": {
             "version": "0.1.43",
@@ -263,6 +275,7 @@
             "integrity": "sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==",
             "deprecated": "Tooltip.js is not supported anymore, please migrate to tippy.js",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "popper.js": "^1.0.2"
             }

--- a/views/package.json
+++ b/views/package.json
@@ -12,7 +12,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/tao-core-libs": "^1.1.0",
         "@oat-sa/tao-core-sdk": "^3.5.0",
-        "@oat-sa/tao-core-shared-libs": "^1.11.1",
+        "@oat-sa/tao-core-shared-libs": "^1.11.2",
         "@oat-sa/tao-core-ui": "^3.19.0",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",


### PR DESCRIPTION
## Summary
- update `oat-sa/tao-core-shared-libs` to `^1.11.2` in `views/package.json`
- refresh `views/package-lock.json` using `npm update @oat-sa/tao-core-shared-libs --package-lock-only`

## Validation
- verified the tracked diff is limited to:
  - `views/package.json`
  - `views/package-lock.json`
- `views/package-lock.json` is kept exactly as generated by npm
- no additional tracked files are included
