### PR TITLE
fix: preserve tree action order with QuickWins (AUT-4491)

### DIFF
--- a/views/templates/blocks/actions.tpl
+++ b/views/templates/blocks/actions.tpl
@@ -1,7 +1,12 @@
 <?php
 use oat\tao\helpers\Layout;
 
-$actions_list = Layout::isQuickWinsDesignEnabled() ? Layout::getSortedActionsByWeight('actions') : get_data('actions');
+$sortByWeight = get_data('sort_by_weight');
+if ($sortByWeight === null) {
+    $sortByWeight = Layout::isQuickWinsDesignEnabled();
+}
+
+$actions_list = $sortByWeight ? Layout::getSortedActionsByWeight('actions') : get_data('actions');
 ?>
 
     <?php foreach ($actions_list as $action): ?>

--- a/views/templates/blocks/sections.tpl
+++ b/views/templates/blocks/sections.tpl
@@ -62,14 +62,16 @@ $sections = get_data('sections');
                         <ul class="plain action-bar tree-action-bar vertical-action-bar">
                         <?php
                             Template::inc('blocks/actions.tpl', 'tao', array(
-                                'actions' => $section->getActionsByGroup('tree')
+                                'actions' => $section->getActionsByGroup('tree'),
+                                'sort_by_weight' => false
                             ));
                         ?>
                         </ul>
                         <ul class="hidden action-bar">
                         <?php
                             Template::inc('blocks/actions.tpl', 'tao', array(
-                                'actions' => $section->getActionsByGroup('none')
+                                'actions' => $section->getActionsByGroup('none'),
+                                'sort_by_weight' => false
                             ));
                         ?>
                         </ul>


### PR DESCRIPTION
## Summary
- Preserve XML-defined order for left tree actions when QuickWins is enabled.
- Keep existing QuickWins weight-based sorting as default for other action groups.
- Add explicit template override so `tree` and `none` groups render in source order.

## Validation
- `php -l views/templates/blocks/actions.tpl`
- `php -l views/templates/blocks/sections.tpl`

## Ticket
- AUT-4491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved action list sorting behavior with enhanced configurability allowing sort-by-weight to be dynamically enabled or disabled based on settings, with context-specific overrides for action bars in specialized contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/tao-core/pull/4435)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->