### PR TITLE
fix: update TAO version to 2026.07

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -371,9 +371,9 @@ return [
     ],
     'constants' => [
         #TAO version number
-        'TAO_VERSION' => '2026.06',
+        'TAO_VERSION' => '2026.07',
         #TAO version label
-        'TAO_VERSION_NAME' => '2026.06',
+        'TAO_VERSION_NAME' => '2026.07',
         #the name to display
         'PRODUCT_NAME' => 'TAO',
         #TAO release status, use to add specific footer to TAO, available alpha, beta, demo, stable


### PR DESCRIPTION
## Summary
- Bump TAO release version metadata in `tao/manifest.php` for July 2026 release line.
- Update both constants to keep UI/version reporting consistent.

## Changes
- `TAO_VERSION`: `2026.06` -> `2026.07`
- `TAO_VERSION_NAME`: `2026.06` -> `2026.07`

## Validation
- Verified updated values are present in `tao/manifest.php`.

## Jira
- AUT-4599


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version from 2026.06 to 2026.07

<!-- end of auto-generated comment: release notes by coderabbit.ai -->