### PR TITLE
feat: compile lang in standalone mode

### DIFF
--- a/helpers/translation/class.POUtils.php
+++ b/helpers/translation/class.POUtils.php
@@ -241,6 +241,15 @@ class tao_helpers_translation_POUtils
     //        Remove after injecting ApplicationService as a dependency.
     private static function getApplicationHelper()
     {
+        if (defined('TAO_TRANSLATE_STANDALONE_MODE') && TAO_TRANSLATE_STANDALONE_MODE) {
+            return new class {
+                public function getDefaultEncoding()
+                {
+                    return defined('TAO_DEFAULT_ENCODING') ? TAO_DEFAULT_ENCODING : 'UTF-8';
+                }
+            };
+        }
+
         return ServiceManager::getServiceManager()->get(ApplicationService::SERVICE_ID);
     }
 }

--- a/includes/translate_bootstrap.php
+++ b/includes/translate_bootstrap.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+/**
+ * Resolve the action name from CLI arguments before bootstrapping TAO.
+ *
+ * @param array $argv
+ */
+function taoTranslateResolveAction(array $argv): ?string
+{
+    for ($i = 1, $count = count($argv); $i < $count; $i++) {
+        $arg = trim($argv[$i]);
+
+        if (preg_match('/^-{1,2}a(?:ction)?=(.+)$/', $arg, $matches)) {
+            return strtolower($matches[1]);
+        }
+
+        if (in_array($arg, ['-a', '--action'], true) && isset($argv[$i + 1])) {
+            return strtolower(trim($argv[$i + 1]));
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @param array $argv
+ */
+function taoTranslateShouldUseStandaloneBootstrap(array $argv): bool
+{
+    $standaloneActions = ['compile', 'compileall'];
+    $action = taoTranslateResolveAction($argv);
+    $standaloneMode = getenv('TAO_TRANSLATE_STANDALONE');
+
+    return in_array($action, $standaloneActions, true)
+        && $standaloneMode !== false
+        && $standaloneMode !== ''
+        && $standaloneMode !== '0';
+}

--- a/includes/translate_start.php
+++ b/includes/translate_start.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+/**
+ * Lightweight bootstrap for translation compilation.
+ *
+ * Allows taoTranslate.php compile actions to run without a full TAO installation
+ * (no database, no generis.conf.php) when TAO_TRANSLATE_STANDALONE is enabled.
+ * Intended for CI environments such as GitHub Actions where extensions are
+ * installed via Composer.
+ *
+ * Optional variables that may be set before including this file:
+ * - $taoTranslateRootPath: absolute path to the TAO platform root directory
+ */
+
+if (!defined('TAO_TRANSLATE_STANDALONE_MODE')) {
+    define('TAO_TRANSLATE_STANDALONE_MODE', true);
+}
+
+if (PHP_SAPI === 'cli') {
+    $_SERVER['HTTP_HOST'] = 'http://localhost';
+}
+
+$platformRoot = null;
+
+if (isset($taoTranslateRootPath) && is_string($taoTranslateRootPath) && $taoTranslateRootPath !== '') {
+    $platformRoot = realpath($taoTranslateRootPath);
+}
+
+if ($platformRoot === false || $platformRoot === null) {
+    $platformRoot = realpath(dirname(__DIR__, 2));
+}
+
+if ($platformRoot === false) {
+    fwrite(STDERR, "Unable to resolve the TAO platform root path.\n");
+    exit(1);
+}
+
+if (!defined('ROOT_PATH')) {
+    define('ROOT_PATH', $platformRoot . DIRECTORY_SEPARATOR);
+}
+
+if (!defined('DEFAULT_LANG')) {
+    define('DEFAULT_LANG', 'en-US');
+}
+
+if (!defined('CONFIG_PATH')) {
+    define('CONFIG_PATH', ROOT_PATH . 'config' . DIRECTORY_SEPARATOR);
+}
+
+if (!defined('TAO_DEFAULT_ENCODING')) {
+    define('TAO_DEFAULT_ENCODING', 'UTF-8');
+}
+
+$autoloadPath = $platformRoot . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+if (!is_readable($autoloadPath)) {
+    fwrite(STDERR, "Composer autoload not found at '{$autoloadPath}'.\n");
+    exit(1);
+}
+
+require_once $autoloadPath;

--- a/includes/translate_start.php
+++ b/includes/translate_start.php
@@ -26,54 +26,61 @@
  * Intended for CI environments such as GitHub Actions where extensions are
  * installed via Composer.
  *
- * Optional variables that may be set before including this file:
- * - $taoTranslateRootPath: absolute path to the TAO platform root directory
+ * @param string|null $rootPath absolute path to the TAO platform root directory
  */
+function taoTranslateStandaloneBootstrap($rootPath = null)
+{
+    if (!defined('TAO_TRANSLATE_STANDALONE_MODE')) {
+        define('TAO_TRANSLATE_STANDALONE_MODE', true);
+    }
 
-if (!defined('TAO_TRANSLATE_STANDALONE_MODE')) {
-    define('TAO_TRANSLATE_STANDALONE_MODE', true);
+    if (PHP_SAPI === 'cli') {
+        $_SERVER['HTTP_HOST'] = 'http://localhost';
+    }
+
+    $platformRoot = null;
+    $explicitRootPath = is_string($rootPath) && $rootPath !== '';
+
+    if ($explicitRootPath) {
+        $platformRoot = realpath($rootPath);
+    }
+
+    if ($platformRoot === false || $platformRoot === null) {
+        if ($explicitRootPath) {
+            fwrite(STDERR, "Unable to resolve the TAO platform root path '{$rootPath}'.\n");
+            exit(1);
+        }
+
+        $platformRoot = realpath(dirname(__DIR__, 2));
+    }
+
+    if ($platformRoot === false) {
+        fwrite(STDERR, "Unable to resolve the TAO platform root path.\n");
+        exit(1);
+    }
+
+    if (!defined('ROOT_PATH')) {
+        define('ROOT_PATH', $platformRoot . DIRECTORY_SEPARATOR);
+    }
+
+    if (!defined('DEFAULT_LANG')) {
+        define('DEFAULT_LANG', 'en-US');
+    }
+
+    if (!defined('CONFIG_PATH')) {
+        define('CONFIG_PATH', ROOT_PATH . 'config' . DIRECTORY_SEPARATOR);
+    }
+
+    if (!defined('TAO_DEFAULT_ENCODING')) {
+        define('TAO_DEFAULT_ENCODING', 'UTF-8');
+    }
+
+    $autoloadPath = $platformRoot . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+    if (!is_readable($autoloadPath)) {
+        fwrite(STDERR, "Composer autoload not found at '{$autoloadPath}'.\n");
+        exit(1);
+    }
+
+    require_once $autoloadPath;
 }
-
-if (PHP_SAPI === 'cli') {
-    $_SERVER['HTTP_HOST'] = 'http://localhost';
-}
-
-$platformRoot = null;
-
-if (isset($taoTranslateRootPath) && is_string($taoTranslateRootPath) && $taoTranslateRootPath !== '') {
-    $platformRoot = realpath($taoTranslateRootPath);
-}
-
-if ($platformRoot === false || $platformRoot === null) {
-    $platformRoot = realpath(dirname(__DIR__, 2));
-}
-
-if ($platformRoot === false) {
-    fwrite(STDERR, "Unable to resolve the TAO platform root path.\n");
-    exit(1);
-}
-
-if (!defined('ROOT_PATH')) {
-    define('ROOT_PATH', $platformRoot . DIRECTORY_SEPARATOR);
-}
-
-if (!defined('DEFAULT_LANG')) {
-    define('DEFAULT_LANG', 'en-US');
-}
-
-if (!defined('CONFIG_PATH')) {
-    define('CONFIG_PATH', ROOT_PATH . 'config' . DIRECTORY_SEPARATOR);
-}
-
-if (!defined('TAO_DEFAULT_ENCODING')) {
-    define('TAO_DEFAULT_ENCODING', 'UTF-8');
-}
-
-$autoloadPath = $platformRoot . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
-
-if (!is_readable($autoloadPath)) {
-    fwrite(STDERR, "Composer autoload not found at '{$autoloadPath}'.\n");
-    exit(1);
-}
-
-require_once $autoloadPath;

--- a/scripts/taoTranslate.php
+++ b/scripts/taoTranslate.php
@@ -24,7 +24,45 @@
  *
  */
 
-require_once dirname(__FILE__) . '/../includes/raw_start.php';
+$standaloneActions = ['compile', 'compileall'];
+
+/**
+ * Resolve the action name from CLI arguments before bootstrapping TAO.
+ *
+ * @param array $argv
+ * @return string|null
+ */
+function taoTranslateResolveAction(array $argv)
+{
+    for ($i = 1, $count = count($argv); $i < $count; $i++) {
+        $arg = trim($argv[$i]);
+
+        if (preg_match('/^-{1,2}a(?:ction)?=(.+)$/', $arg, $matches)) {
+            return strtolower($matches[1]);
+        }
+
+        if (in_array($arg, ['-a', '--action'], true) && isset($argv[$i + 1])) {
+            return strtolower(trim($argv[$i + 1]));
+        }
+    }
+
+    return null;
+}
+
+$action = taoTranslateResolveAction($_SERVER['argv'] ?? []);
+$options = getopt('p:', ['root:', 'rootPath:']);
+$taoTranslateRootPath = $options['p'] ?? $options['root'] ?? $options['rootPath'] ?? null;
+$standaloneMode = getenv('TAO_TRANSLATE_STANDALONE');
+$useStandaloneBootstrap = in_array($action, $standaloneActions, true)
+    && $standaloneMode !== false
+    && $standaloneMode !== ''
+    && $standaloneMode !== '0';
+
+if ($useStandaloneBootstrap) {
+    require_once dirname(__FILE__) . '/../includes/translate_start.php';
+} else {
+    require_once dirname(__FILE__) . '/../includes/raw_start.php';
+}
 
 new tao_scripts_TaoTranslate(
     [
@@ -108,6 +146,12 @@ new tao_scripts_TaoTranslate(
             'type' => 'boolean',
             'shortcut' => 'ct',
             'description' => 'Clear translations entry when there is not translation proposal'
+        ],
+        [
+            'name' => 'rootPath',
+            'type' => 'string',
+            'shortcut' => 'p',
+            'description' => 'TAO platform root path (used for compile actions without installation)'
         ]
     ]
     ]

--- a/scripts/taoTranslate.php
+++ b/scripts/taoTranslate.php
@@ -24,42 +24,14 @@
  *
  */
 
-$standaloneActions = ['compile', 'compileall'];
+require_once dirname(__FILE__) . '/../includes/translate_bootstrap.php';
 
-/**
- * Resolve the action name from CLI arguments before bootstrapping TAO.
- *
- * @param array $argv
- * @return string|null
- */
-function taoTranslateResolveAction(array $argv)
-{
-    for ($i = 1, $count = count($argv); $i < $count; $i++) {
-        $arg = trim($argv[$i]);
+$options = getopt('r:', ['root:', 'rootPath:']);
+$taoTranslateRootPath = $options['r'] ?? $options['root'] ?? $options['rootPath'] ?? null;
 
-        if (preg_match('/^-{1,2}a(?:ction)?=(.+)$/', $arg, $matches)) {
-            return strtolower($matches[1]);
-        }
-
-        if (in_array($arg, ['-a', '--action'], true) && isset($argv[$i + 1])) {
-            return strtolower(trim($argv[$i + 1]));
-        }
-    }
-
-    return null;
-}
-
-$action = taoTranslateResolveAction($_SERVER['argv'] ?? []);
-$options = getopt('p:', ['root:', 'rootPath:']);
-$taoTranslateRootPath = $options['p'] ?? $options['root'] ?? $options['rootPath'] ?? null;
-$standaloneMode = getenv('TAO_TRANSLATE_STANDALONE');
-$useStandaloneBootstrap = in_array($action, $standaloneActions, true)
-    && $standaloneMode !== false
-    && $standaloneMode !== ''
-    && $standaloneMode !== '0';
-
-if ($useStandaloneBootstrap) {
+if (taoTranslateShouldUseStandaloneBootstrap($_SERVER['argv'] ?? [])) {
     require_once dirname(__FILE__) . '/../includes/translate_start.php';
+    taoTranslateStandaloneBootstrap($taoTranslateRootPath);
 } else {
     require_once dirname(__FILE__) . '/../includes/raw_start.php';
 }
@@ -150,7 +122,7 @@ new tao_scripts_TaoTranslate(
         [
             'name' => 'rootPath',
             'type' => 'string',
-            'shortcut' => 'p',
+            'shortcut' => 'r',
             'description' => 'TAO platform root path (used for compile actions without installation)'
         ]
     ]


### PR DESCRIPTION
## Ticket:
https://oat-sa.atlassian.net/browse/AUT-4545

### Summary
Enable taoTranslate.php to compile messages_po.js from PO files without a full TAO installation, for use in CI (e.g. GitHub Actions).

- Add a lightweight bootstrap (translate_start.php) that loads Composer autoload and defines minimal constants - no database or generis.conf.php required
- Opt-in via `TAO_TRANSLATE_STANDALONE=1` for compile / compileall only; all other actions still use the existing full bootstrap
- Add `-r / --rootPath` to override the platform root when needed
- Use a UTF-8 fallback in POUtils only in standalone mode, so normal installs are unchanged

### How to test

1. Delete config folder
2. `TAO_TRANSLATE_STANDALONE=1 php tao/scripts/taoTranslate.php -v -a compile -e taoQtiItem -l ja-JP`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation compilation now supports a standalone CLI mode for running without a full installed setup.
  * Added a `--rootPath` (`-r`) option to specify the TAO platform root directory for compile actions.
* **Chores**
  * Improved translation command bootstrapping with action detection from CLI arguments.
  * Added startup checks and lightweight standalone initialization, including default encoding and autoloader loading validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->