### PR TITLE
fix: preserve logout redirect after session timeout

### DIFF
--- a/models/classes/clientConfig/ClientConfigServiceProvider.php
+++ b/models/classes/clientConfig/ClientConfigServiceProvider.php
@@ -36,6 +36,7 @@ use oat\tao\model\CookiePolicy\Service\CookiePolicyConfigurationRetriever;
 use oat\tao\model\featureFlag\FeatureFlagConfigSwitcher;
 use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
 use oat\tao\model\menu\MenuService;
+use oat\tao\model\mvc\DefaultUrlService;
 use oat\tao\model\routing\ResolverFactory;
 use oat\tao\model\security\xsrf\TokenService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -69,6 +70,7 @@ class ClientConfigServiceProvider implements ContainerServiceProviderInterface
                     service(DateFormatterFactory::class),
                     service(MenuService::class),
                     service(CookiePolicyConfigurationRetriever::class),
+                    service(DefaultUrlService::SERVICE_ID),
                 ]
             );
     }

--- a/models/classes/clientConfig/ClientConfigStorage.php
+++ b/models/classes/clientConfig/ClientConfigStorage.php
@@ -39,6 +39,7 @@ use oat\tao\model\CookiePolicy\Service\CookiePolicyConfigurationRetriever;
 use oat\tao\model\featureFlag\FeatureFlagConfigSwitcher;
 use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
 use oat\tao\model\menu\MenuService;
+use oat\tao\model\mvc\DefaultUrlService;
 use oat\tao\model\routing\ResolverFactory;
 use oat\tao\model\security\xsrf\TokenService;
 use oat\tao\model\session\Context\UserDataSessionContext;
@@ -63,6 +64,7 @@ class ClientConfigStorage
     private tao_helpers_Mode $modeHelper;
     private DateFormatterFactory $dateFormatterFactory;
     private MenuService $menuService;
+    private DefaultUrlService $defaultUrlService;
 
     private array $config = [];
     private CookiePolicyConfigurationRetriever $cookiePolicyConfigurationRetriever;
@@ -82,7 +84,8 @@ class ClientConfigStorage
         tao_helpers_Mode $modeHelper,
         DateFormatterFactory $dateFormatterFactory,
         MenuService $menuService,
-        CookiePolicyConfigurationRetriever $cookiePolicyConfigurationRetriever
+        CookiePolicyConfigurationRetriever $cookiePolicyConfigurationRetriever,
+        DefaultUrlService $defaultUrlService
     ) {
         $this->tokenService = $tokenService;
         $this->clientLibRegistry = $clientLibRegistry;
@@ -99,6 +102,7 @@ class ClientConfigStorage
         $this->dateFormatterFactory = $dateFormatterFactory;
         $this->menuService = $menuService;
         $this->cookiePolicyConfigurationRetriever = $cookiePolicyConfigurationRetriever;
+        $this->defaultUrlService = $defaultUrlService;
     }
 
     /**
@@ -182,6 +186,7 @@ class ClientConfigStorage
                         'featureFlags' => $this->featureFlagRepository->list(),
                         'cookiePolicy' => $this->cookiePolicyConfigurationRetriever->retrieve()->jsonSerialize(),
                         'currentUser' => $this->getUserData($currentSession),
+                        'sessionRedirects' => $this->getSessionRedirects(),
                         'previewerExternalFeUrl' => $previewerExternalFeUrl,
                     ]
                 ),
@@ -224,6 +229,46 @@ class ClientConfigStorage
             'uri' => $uri,
             'login' => $login,
         ];
+    }
+
+    private function getSessionRedirects(): array
+    {
+        return [
+            'logoutUrl' => $this->resolveRedirectUrl('logout'),
+            'loginUrl' => $this->resolveLoginUrl(),
+        ];
+    }
+
+    private function resolveRedirectUrl(string $routeName): ?string
+    {
+        try {
+            $url = $this->defaultUrlService->getRedirectUrl($routeName);
+
+            return $url === '' ? null : $url;
+        } catch (Throwable $exception) {
+            $this->logger->warning(
+                sprintf(
+                    'Unable to resolve client config redirect URL for route "%s": %s',
+                    $routeName,
+                    $exception->getMessage()
+                )
+            );
+
+            return null;
+        }
+    }
+
+    private function resolveLoginUrl(): ?string
+    {
+        try {
+            return $this->defaultUrlService->getLoginUrl();
+        } catch (Throwable $exception) {
+            $this->logger->warning(
+                sprintf('Unable to resolve client config login URL: %s', $exception->getMessage())
+            );
+
+            return null;
+        }
     }
 
     private function getClientTimeout(): int

--- a/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
+++ b/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php
@@ -44,6 +44,7 @@ use oat\tao\model\featureFlag\FeatureFlagConfigSwitcher;
 use oat\tao\model\featureFlag\Repository\FeatureFlagRepositoryInterface;
 use oat\tao\model\menu\MenuService;
 use oat\tao\model\menu\Perspective;
+use oat\tao\model\mvc\DefaultUrlService;
 use oat\tao\model\routing\Resolver;
 use oat\tao\model\routing\ResolverFactory;
 use oat\tao\model\security\xsrf\TokenService;
@@ -101,6 +102,9 @@ class ClientConfigStorageTest extends TestCase
     /** @var CookiePolicyConfigurationRetriever|MockObject */
     private CookiePolicyConfigurationRetriever $cookiePolicyConfigurationRetriever;
 
+    /** @var DefaultUrlService|MockObject */
+    private DefaultUrlService $defaultUrlService;
+
     private ClientConfigStorage $sut;
 
     protected function setUp(): void
@@ -124,6 +128,7 @@ class ClientConfigStorageTest extends TestCase
         $this->dateFormatterFactory = $this->createMock(DateFormatterFactory::class);
         $this->menuService = $this->createMock(MenuService::class);
         $this->cookiePolicyConfigurationRetriever = $this->createMock(CookiePolicyConfigurationRetriever::class);
+        $this->defaultUrlService = $this->createMock(DefaultUrlService::class);
 
         $this->sut = new ClientConfigStorage(
             $this->tokenService,
@@ -140,13 +145,15 @@ class ClientConfigStorageTest extends TestCase
             $this->modeHelper,
             $this->dateFormatterFactory,
             $this->menuService,
-            $this->cookiePolicyConfigurationRetriever
+            $this->cookiePolicyConfigurationRetriever,
+            $this->defaultUrlService
         );
     }
 
     public function testGetConfig(): void
     {
         $locale = 'en-US';
+        $previewerExternalFeUrl = isset($_ENV['PREVIEWER_EXTERNAL_FE_URL']) ? $_ENV['PREVIEWER_EXTERNAL_FE_URL'] : null;
 
         $query = $this->createMock(GetConfigQuery::class);
         $query
@@ -331,6 +338,17 @@ class ClientConfigStorageTest extends TestCase
                 'FEATURE_FLAG' => false,
             ]);
 
+        $this->defaultUrlService
+            ->expects($this->once())
+            ->method('getRedirectUrl')
+            ->with('logout')
+            ->willReturn('https://portal.ngs.test/logout');
+
+        $this->defaultUrlService
+            ->expects($this->once())
+            ->method('getLoginUrl')
+            ->willReturn('https://portal.ngs.test/login');
+
         $this->clientConfigService
             ->expects($this->once())
             ->method('getExtendedConfig')
@@ -384,7 +402,11 @@ class ClientConfigStorageTest extends TestCase
                             'uri' => 'https://user.taotesting.com',
                             'login' => 'adminLogin'
                         ],
-                        'previewerExternalFeUrl' => null
+                        'sessionRedirects' => [
+                            'logoutUrl' => 'https://portal.ngs.test/logout',
+                            'loginUrl' => 'https://portal.ngs.test/login',
+                        ],
+                        'previewerExternalFeUrl' => $previewerExternalFeUrl
                     ],
                     JSON_THROW_ON_ERROR
                 ),

--- a/views/js/layout/logout-event.js
+++ b/views/js/layout/logout-event.js
@@ -22,10 +22,11 @@
  *
  * @author Alexander Zagovorichev <zagovorichev@1pt.com>
  */
-define(['jquery', 'lodash', 'i18n', 'util/url', 'ui/dialog/alert'], function (
+define(['jquery', 'lodash', 'i18n', 'context', 'util/url', 'ui/dialog/alert'], function (
     $,
     _,
     __,
+    context,
     url,
     alert
 ) {
@@ -33,7 +34,9 @@ define(['jquery', 'lodash', 'i18n', 'util/url', 'ui/dialog/alert'], function (
 
     var defaults = {
         message: __('You have been logged out. Please login again'),
-        redirectUrl: url.route('logout', 'Main', 'tao')
+        redirectUrl: _.get(context, 'sessionRedirects.logoutUrl')
+            || _.get(context, 'sessionRedirects.loginUrl')
+            || url.route('logout', 'Main', 'tao')
     };
 
     /**


### PR DESCRIPTION
## Summary

- make backoffice logout redirect timeout-safe when a 403 happens after session expiration
- precompute logout/login URLs on backend and expose them in client config
- use precomputed URLs in `logout-event.js` before falling back to route-based redirect

## Changes

- inject `DefaultUrlService` into `ClientConfigStorage` and service provider wiring
- add `sessionRedirects.logoutUrl` and `sessionRedirects.loginUrl` to generated client config
- update logout event frontend logic to prefer `context.sessionRedirects` URLs
- extend `ClientConfigStorageTest` assertions and mocks for new redirect fields

## Testing

- phpunit: `tao/test/unit/models/classes/clientConfig/ClientConfigStorageTest.php` (PASS)
- phpcs: changed PHP files (PASS)



https://github.com/user-attachments/assets/b0b44366-6461-4e14-b73f-9e1211b23a6f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-based redirect URLs to client configuration, including login and logout destinations.
  * Updated logout behavior to prefer these session redirects before using the default logout link.

* **Bug Fixes**
  * Improved redirect handling when session URL values are unavailable or cannot be resolved, helping avoid broken navigation paths.

* **Tests**
  * Updated unit coverage to reflect the new redirect data and environment-based URL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->