### PR TITLE
Backport tao-core-ui 3.19.2 to 2026.02

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -13,7 +13,7 @@
                 "@oat-sa/tao-core-libs": "^1.1.0",
                 "@oat-sa/tao-core-sdk": "^3.5.0",
                 "@oat-sa/tao-core-shared-libs": "^1.11.4",
-                "@oat-sa/tao-core-ui": "^3.19.0",
+                "@oat-sa/tao-core-ui": "^3.19.2",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
                 "gamp": "0.2.1",
@@ -84,9 +84,9 @@
             "license": "GPL-2.0"
         },
         "node_modules/@oat-sa/tao-core-ui": {
-            "version": "3.19.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-3.19.0.tgz",
-            "integrity": "sha512-wi4U6YHQSQPLfxLxRucLYJo3l6GMXTynO8RvDwfJsv/bBdvISxBAHdAMBfbqik517yoJpdW6ou+KauRQwzmu3A==",
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-3.19.2.tgz",
+            "integrity": "sha512-xQHod9Ho4ux9hraNWOCrKXC1h51R+E5IWP/CL9rNTtlTTU8uhWnFzSmjcycUu7kM18lEcwoK5zdAWyZpbYhiqQ==",
             "license": "GPL-2.0"
         },
         "node_modules/amdefine": {

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^1.1.0",
         "@oat-sa/tao-core-sdk": "^3.5.0",
         "@oat-sa/tao-core-shared-libs": "^1.11.4",
-        "@oat-sa/tao-core-ui": "^3.19.0",
+        "@oat-sa/tao-core-ui": "^3.19.2",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",
         "gamp": "0.2.1",


### PR DESCRIPTION
## Summary

- Backport from v55.0.1.11
- Target release v55.0.1.12
- Bumps `@oat-sa/tao-core-ui` to `^3.19.2` (https://www.npmjs.com/package/@oat-sa/tao-core-ui/v/3.19.2)

## Test plan

- [ ] Verify CI passes
- [ ] Confirm `views/package-lock.json` resolves to `tao-core-ui-3.19.2.tgz`