### PR TITLE
chore: update tao-core-ui 3.19.2

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -13,7 +13,7 @@
                 "@oat-sa/tao-core-libs": "^1.2.1",
                 "@oat-sa/tao-core-sdk": "^3.5.0",
                 "@oat-sa/tao-core-shared-libs": "^1.12.0",
-                "@oat-sa/tao-core-ui": "^3.20.0",
+                "@oat-sa/tao-core-ui": "^3.19.2",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
                 "gamp": "0.2.1",
@@ -84,9 +84,9 @@
             "license": "GPL-2.0"
         },
         "node_modules/@oat-sa/tao-core-ui": {
-            "version": "3.20.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-3.20.0.tgz",
-            "integrity": "sha512-lRUOrznTg4TQ6p6HPLg3QSQejRL7dax65Pt5AAxJs6chmU1nWhMdDLZ13uYSnQI3DuDBPL4Y4TDvyS8ejTWbvQ==",
+            "version": "3.19.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-3.19.2.tgz",
+            "integrity": "sha512-xQHod9Ho4ux9hraNWOCrKXC1h51R+E5IWP/CL9rNTtlTTU8uhWnFzSmjcycUu7kM18lEcwoK5zdAWyZpbYhiqQ==",
             "license": "GPL-2.0"
         },
         "node_modules/amdefine": {

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^1.2.1",
         "@oat-sa/tao-core-sdk": "^3.5.0",
         "@oat-sa/tao-core-shared-libs": "^1.12.0",
-        "@oat-sa/tao-core-ui": "^3.20.0",
+        "@oat-sa/tao-core-ui": "^3.19.2",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",
         "gamp": "0.2.1",


### PR DESCRIPTION
## Summary
- Bumps `@oat-sa/tao-core-ui` to `^3.19.2` (npm) in `views/package.json` and refreshes `views/package-lock.json` (resolves to `tao-core-ui-3.19.2.tgz`).
- Brings in the AUT-4505 video container fix from [tao-core-ui-fe PR #704](https://github.com/oat-sa/tao-core-ui-fe/pull/704).
- Note: `develop` previously constrained `@oat-sa/tao-core-ui` to `^3.20.0` (INF-494 ruby); this change intentionally pins `^3.19.2` per request.

## Test plan
- [ ] `npm ci` in `views/` succeeds
- [ ] Smoke test item authoring with vertical video (AUT-4505)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a UI library to a newer compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->