### PR TITLE
chore: update tao-core-ui 3.21.0

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -376,9 +376,9 @@ return [
     ],
     'constants' => [
         #TAO version number
-        'TAO_VERSION' => '2026.08',
+        'TAO_VERSION' => '2026.08 LTS',
         #TAO version label
-        'TAO_VERSION_NAME' => '2026.08',
+        'TAO_VERSION_NAME' => '2026.08 LTS',
         #the name to display
         'PRODUCT_NAME' => 'TAO',
         #TAO release status, use to add specific footer to TAO, available alpha, beta, demo, stable

--- a/manifest.php
+++ b/manifest.php
@@ -376,9 +376,9 @@ return [
     ],
     'constants' => [
         #TAO version number
-        'TAO_VERSION' => '2026.07',
+        'TAO_VERSION' => '2026.08',
         #TAO version label
-        'TAO_VERSION_NAME' => '2026.07',
+        'TAO_VERSION_NAME' => '2026.08',
         #the name to display
         'PRODUCT_NAME' => 'TAO',
         #TAO release status, use to add specific footer to TAO, available alpha, beta, demo, stable

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -13,7 +13,7 @@
                 "@oat-sa/tao-core-libs": "^1.2.1",
                 "@oat-sa/tao-core-sdk": "^3.5.0",
                 "@oat-sa/tao-core-shared-libs": "^1.12.0",
-                "@oat-sa/tao-core-ui": "^3.20.0",
+                "@oat-sa/tao-core-ui": "^3.21.0",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
                 "gamp": "0.2.1",
@@ -84,9 +84,9 @@
             "license": "GPL-2.0"
         },
         "node_modules/@oat-sa/tao-core-ui": {
-            "version": "3.20.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-3.20.0.tgz",
-            "integrity": "sha512-lRUOrznTg4TQ6p6HPLg3QSQejRL7dax65Pt5AAxJs6chmU1nWhMdDLZ13uYSnQI3DuDBPL4Y4TDvyS8ejTWbvQ==",
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-ui/-/tao-core-ui-3.21.0.tgz",
+            "integrity": "sha512-UcehtJwYU25AIGrIUhRLc/inXLm6j98mPagzxfF5p1AfPX9pVj6yKuswFCC6VNIejj0Epb0xSDhV647Eq2o9wQ==",
             "license": "GPL-2.0"
         },
         "node_modules/amdefine": {

--- a/views/package.json
+++ b/views/package.json
@@ -13,7 +13,7 @@
         "@oat-sa/tao-core-libs": "^1.2.1",
         "@oat-sa/tao-core-sdk": "^3.5.0",
         "@oat-sa/tao-core-shared-libs": "^1.12.0",
-        "@oat-sa/tao-core-ui": "^3.20.0",
+        "@oat-sa/tao-core-ui": "^3.21.0",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",
         "gamp": "0.2.1",


### PR DESCRIPTION
## Summary
Bump `@oat-sa/tao-core-ui` to `^3.21.0`.
Bump Release version

- npm: https://www.npmjs.com/package/@oat-sa/tao-core-ui/v/3.21.0

## Test plan
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a UI dependency to a newer version, bringing potential stability improvements and general interface enhancements.
  * Updated the application’s displayed version metadata to the latest release (version number and label).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->