### PR TITLE
fix: force MathJax SVG renderer for LaTeX display

### DIFF
--- a/views/templates/client_config.tpl
+++ b/views/templates/client_config.tpl
@@ -102,8 +102,14 @@ require.config({
             exports : "MathJax",
             init : function(){
                 if(window.MathJax){
-                    MathJax.Hub.Config({showMathMenu:false, showMathMenuMSIE:false,
-                        menuSettings: { inTabOrder: false } });
+                    MathJax.Hub.Config({
+                        showMathMenu: false,
+                        showMathMenuMSIE: false,
+                        menuSettings: { inTabOrder: false, renderer: 'SVG' }
+                    });
+                    MathJax.Hub.Register.StartupHook('End Jax', function() {
+                        return MathJax.Hub.setRenderer('SVG');
+                    });
                     MathJax.Hub.Startup.onload();
                     return MathJax;
                 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/AUT-4562

## Summary
- Force MathJax 2 to use the SVG output renderer in `client_config.tpl` instead of the default HTML-CSS path from `TeX-AMS-MML_HTMLorMML-full`.
- Fixes Wiris/LaTeX radical rendering in classic authoring (e.g. `\sqrt{\frac{4}{5}} + \sqrt{\frac{3}{6}}`), where HTML-CSS absolute/clip metrics broke under authoring CSS; SVG matches preview/testrunner behavior more closely.

<img width="1840" height="972" alt="chrome_U8D8cgOrHN" src="https://github.com/user-attachments/assets/d35abfad-ef22-4e14-a531-29c666f62c32" />

## Test plan
- [ ] Authoring: insert formula via Wiris and via Latex sidebar field; verify sleep-mode display (radical bar not merged/offset)
- [ ] Reopen item and confirm formula still renders correctly
- [ ] Confirm DOM uses `<svg>` (`MathJax.Hub.config.menuSettings.renderer === "SVG"`)
- [ ] Preview / classic testrunner: same formulas render correctly
- [ ] Smoke: nested radicals, tall fractions, sums/integrals, matrices (QTI-safe LaTeX only)
- [ ] Hard reload / clear `mjx.menu` cookie if renderer appears stuck on HTML-CSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MathJax configuration to improve mathematical equation rendering consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->