### PR TITLE
fix EP-765 add information about current user's identity to access tokens generated by AccessTokenService

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -12,9 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '8.3', '8.4' ]
+        php-version: [ '8.3', '8.4', '8.5' ]
         include:
-          - php-version: '8.4'
+          - php-version: '8.5'
             coverage: true
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,9 @@
         "open-telemetry/api": "^1.0",
         "open-telemetry/sdk": "^1.0"
     },
+    "require-dev": {
+        "lcobucci/jwt": "~5"
+    },
     "suggest": {
         "ext-opentelemetry": "Required at runtime to export task-queue traces (TaskQueueTelemetry is a no-op without it)"
     },

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "oat-sa/jig": "~0.2",
         "oat-sa/composer-npm-bridge": "~0.4.2||dev-master",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=17.0.0",
+        "oat-sa/generis": ">=17.3.0",
         "composer/package-versions-deprecated": "^1.11",
         "paragonie/random_compat": "^2.0",
         "phpdocumentor/reflection-docblock": "^5.2",

--- a/models/classes/accessControl/AccessControlServiceProvider.php
+++ b/models/classes/accessControl/AccessControlServiceProvider.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\tao\model\accessControl;
 
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\oatbox\user\UserService;
 use oat\tao\model\accessControl\Service\AccessTokenService;
 use oat\tao\model\accessControl\Service\ConfigurationService;
 use oat\tao\model\accessControl\Service\DeleteRoleService;
@@ -60,7 +61,7 @@ class AccessControlServiceProvider implements ContainerServiceProviderInterface
 
         $services->set(AccessTokenService::class, AccessTokenService::class)
             ->public()
-            ->args([service(SharedCache::class)]);
+            ->args([service(UserService::class), service(SharedCache::class)]);
 
         $services->set(ConfigurationService::class, ConfigurationService::class)
             ->public()

--- a/models/classes/accessControl/Service/AccessTokenService.php
+++ b/models/classes/accessControl/Service/AccessTokenService.php
@@ -24,6 +24,7 @@ namespace oat\tao\model\accessControl\Service;
 
 use common_session_SessionManager as SessionManager;
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use oat\generis\model\user\UserRdf;
@@ -33,24 +34,15 @@ use RuntimeException;
 
 class AccessTokenService
 {
-    private UserService $userService;
-    private Client $client;
-    private CacheInterface $cache;
-    private float $ttlScale;
+    private readonly ClientInterface $client;
 
-    /**
-     * @see Client
-     */
     public function __construct(
-        UserService $userService,
-        CacheInterface $cache,
-        float $ttlScale = 0.5,
-        array $clientConfig = ['timeout' => 5.0, 'connect_timeout' => 2.0]
+        private readonly UserService $userService,
+        private readonly CacheInterface $cache,
+        private readonly float $ttlScale = 0.5,
+        ?ClientInterface $client = null
     ) {
-        $this->userService = $userService;
-        $this->client = new Client($clientConfig);
-        $this->cache = $cache;
-        $this->ttlScale = $ttlScale;
+        $this->client = $client ?? new Client(['timeout' => 5.0, 'connect_timeout' => 2.0]);
     }
 
     public function fetchTokens(string $role = ''): array

--- a/models/classes/accessControl/Service/AccessTokenService.php
+++ b/models/classes/accessControl/Service/AccessTokenService.php
@@ -63,7 +63,7 @@ class AccessTokenService
             throw new RuntimeException('OAuth2 credentials not found.', 404);
         }
         $userId = $this->getUserLogin();
-        $key = "$authUri/$clientId/$userId/$role";
+        $key = hash('sha256', "$authUri/$clientId/$userId/$role");
         $value = $this->cache->get($key);
         if ($value) {
             return json_decode($value, true);

--- a/models/classes/accessControl/Service/AccessTokenService.php
+++ b/models/classes/accessControl/Service/AccessTokenService.php
@@ -55,7 +55,7 @@ class AccessTokenService
             throw new RuntimeException('OAuth2 credentials not found.', 404);
         }
         $userId = $this->getUserLogin();
-        $key = hash('sha256', "$authUri/$clientId/$userId/$role");
+        $key = hash('sha256', "{$this->getTenantId()}/$authUri/$clientId/$userId/$role");
         $value = $this->cache->get($key);
         if ($value) {
             return json_decode($value, true);

--- a/models/classes/accessControl/Service/AccessTokenService.php
+++ b/models/classes/accessControl/Service/AccessTokenService.php
@@ -22,33 +22,38 @@ declare(strict_types=1);
 
 namespace oat\tao\model\accessControl\Service;
 
+use common_session_SessionManager as SessionManager;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
+use oat\generis\model\user\UserRdf;
+use oat\oatbox\user\UserService;
 use Psr\SimpleCache\CacheInterface;
 use RuntimeException;
 
 class AccessTokenService
 {
+    private UserService $userService;
+    private Client $client;
     private CacheInterface $cache;
     private float $ttlScale;
-    private array $clientConfig;
 
     /**
      * @see Client
-     * @param array $clientConfig
      */
     public function __construct(
+        UserService $userService,
         CacheInterface $cache,
         float $ttlScale = 0.5,
         array $clientConfig = ['timeout' => 5.0, 'connect_timeout' => 2.0]
     ) {
-        $this->clientConfig = $clientConfig;
+        $this->userService = $userService;
+        $this->client = new Client($clientConfig);
         $this->cache = $cache;
         $this->ttlScale = $ttlScale;
     }
 
-    public function fetchTokens(): array
+    public function fetchTokens(string $role = ''): array
     {
         $authUri = $_ENV['ENV_AUTH_URI'] ?? getenv('ENV_AUTH_URI');
         $clientId = $_ENV['ENV_CLIENT_ID'] ?? getenv('ENV_CLIENT_ID');
@@ -57,22 +62,35 @@ class AccessTokenService
         if (!$authUri || !$clientId || !$clientSecret) {
             throw new RuntimeException('OAuth2 credentials not found.', 404);
         }
-        $key = "$authUri/$clientId";
+        $userId = $this->getUserLogin();
+        $key = "$authUri/$clientId/$userId/$role";
         $value = $this->cache->get($key);
         if ($value) {
             return json_decode($value, true);
         }
 
-        $client = new Client($this->clientConfig);
-        $request = new Request('POST', "$authUri?with-refresh-token=true", [], json_encode([
-            'grant_type' => 'client_credentials',
-            'client_id' => $clientId,
-            'client_secret' => $clientSecret
-        ]));
+        $request = new Request(
+            'POST',
+            sprintf(
+                "%s?%s",
+                $authUri,
+                http_build_query(array_filter([
+                    'with-refresh-token' => true,
+                    'with-user-identifier' => SessionManager::buildUserIdentityString($userId, $role),
+                    'with-user-role' => 'ROLE_LTI_USER', // required to force a User ID
+                ]), arg_separator: '&'),
+            ),
+            [],
+            json_encode([
+                'grant_type' => 'client_credentials',
+                'client_id' => $clientId,
+                'client_secret' => $clientSecret
+            ])
+        );
         $request = $request->withAddedHeader('Content-Type', 'application/json');
 
         try {
-            $response = $client->send($request);
+            $response = $this->client->send($request);
         } catch (GuzzleException $exception) {
             throw new RuntimeException('Failed to fetch Auth tokens.', 424, $exception);
         }
@@ -95,8 +113,7 @@ class AccessTokenService
 
     public function extractAccessTokenFromRequest(): string
     {
-        $authorizationHeader = explode(' ', $_SERVER['HTTP_AUTHORIZATION'] ?? '', 2);
-        return array_pop($authorizationHeader);
+        return SessionManager::extractAccessTokenFromRequest();
     }
 
     public function extractAccessTokenPayloadFromRequest(): array
@@ -108,12 +125,36 @@ class AccessTokenService
 
     public function parseAccessToken(string $accessToken): array
     {
-        @[$_, $payload] = explode('.', $accessToken);
-        $rawToken = base64_decode(strtr($payload ?? '', '-_', '+/'));
-        $token = json_decode($rawToken, true);
+        $token = SessionManager::parseAccessToken($accessToken);
         if (empty($token['tenant_id'])) {
             throw new RuntimeException('Unauthorized', 401);
         }
+        if ($token['tenant_id'] !== $this->getTenantId()) {
+            throw new RuntimeException('Not found', 404);
+        }
         return $token;
+    }
+
+    private function getTenantId(): string
+    {
+        $tenantId = $_ENV['TENANT_ID'] ?? getenv('TENANT_ID');
+        if (!$tenantId) {
+            throw new RuntimeException('Tenant configuration not found.', 404);
+        }
+        return $tenantId;
+    }
+
+    private function getUserLogin(): ?string
+    {
+        $user = SessionManager::getSession()->getUser();
+        $login = current($user->getPropertyValues(UserRdf::PROPERTY_LOGIN));
+
+        if (!$login) {
+            $generisUser = $this->userService->getUser($user->getIdentifier());
+
+            $login = current($generisUser->getPropertyValues(UserRdf::PROPERTY_LOGIN));
+        }
+
+        return $login ?: null;
     }
 }

--- a/test/unit/models/classes/accessControl/Service/AccessTokenServiceTest.php
+++ b/test/unit/models/classes/accessControl/Service/AccessTokenServiceTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\accessControl\Service;
+
+use DateTimeImmutable;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Response;
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\JwtFacade;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use oat\oatbox\cache\NoCache;
+use oat\oatbox\user\BasicUser;
+use oat\oatbox\user\UserService;
+use oat\tao\model\accessControl\Service\AccessTokenService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class AccessTokenServiceTest extends TestCase
+{
+    private const ENV_AUTH_URI = 'http://auth-service:8080';
+    private const ENV_CLIENT_ID = 'test-client-id';
+    private const ENV_CLIENT_SECRET = 'test-client-secret';
+    private const TENANT_ID = 'test-tenant-id';
+    private AccessTokenService $sut;
+    private UserService&MockObject $userService;
+    private ClientInterface&MockObject $client;
+
+    /**
+     * @before
+     */
+    public function init(): void
+    {
+        $this->userService = $this->createMock(UserService::class);
+        $this->client = $this->createMock(ClientInterface::class);
+        $this->sut = new AccessTokenService(
+            $this->userService,
+            new NoCache(),
+            client: $this->client,
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFetchTokensFailsWithoutConfiguration(): void
+    {
+        $this->expectExceptionObject(new RuntimeException('OAuth2 credentials not found.', 404));
+        $this->sut->fetchTokens();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFetchTokensFailsWhenClientReportsErrors(): void
+    {
+        $exception = $this->createMock(GuzzleException::class);
+        $this->expectExceptionObject(new RuntimeException('Failed to fetch Auth tokens.', 424, $exception));
+        $user = new BasicUser('identifier', [], 'username');
+
+        $this->initEnvVars();
+        $this->client
+            ->expects($this->once())
+            ->method('send')
+            ->willThrowException($exception);
+        $this->userService
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+        $this->sut->fetchTokens();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFetchTokensFailsWhenClientResponseIsEmpty(): void
+    {
+        $exception = $this->createMock(GuzzleException::class);
+        $this->expectExceptionObject(new RuntimeException('Failed to fetch Auth tokens.', 424, $exception));
+        $user = new BasicUser('identifier', [], 'username');
+
+        $this->initEnvVars();
+        $this->client
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(new Response(200, [], ''));
+        $this->userService
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+        $this->sut->fetchTokens();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFetchTokensFailsWhenClientResponseIsUnexpected(): void
+    {
+        $exception = $this->createMock(GuzzleException::class);
+        $this->expectExceptionObject(new RuntimeException('Failed to fetch Auth tokens.', 424, $exception));
+        $user = new BasicUser('identifier', [], 'username');
+
+        $this->initEnvVars();
+        $this->client
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(new Response(301, [], 'Location: somewhere-else'));
+        $this->userService
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+        $this->sut->fetchTokens();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFetchTokensFailsWhenAccessTokenHasMismatchingTenantId(): void
+    {
+        $this->expectExceptionObject(new RuntimeException('Not found', 404));
+        $userId = 'username';
+        $user = new BasicUser('identifier', [], $userId);
+
+        $this->initEnvVars();
+        $this->client
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(
+                new Response(200, [], json_encode([
+                    'access_token' => $this->generateAccessToken($userId, 'another-tenant-id')
+                ]))
+            );
+        $this->userService
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+        $this->sut->fetchTokens();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFetchTokensFailsWhenAccessTokenHasEmptyTenantId(): void
+    {
+        $this->expectExceptionObject(new RuntimeException('Unauthorized', 401));
+        $userId = 'username';
+        $user = new BasicUser('identifier', [], $userId);
+
+        $this->initEnvVars();
+        $this->client
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(
+                new Response(200, [], json_encode([
+                    'access_token' => $this->generateAccessToken($userId, '')
+                ]))
+            );
+        $this->userService
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+        $this->sut->fetchTokens();
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFetchTokens(): void
+    {
+        $userId = 'username';
+        $user = new BasicUser('identifier', [], $userId);
+
+        $this->initEnvVars();
+        $expected = ['access_token' => $this->generateAccessToken($userId)];
+        $this->client
+            ->expects($this->once())
+            ->method('send')
+            ->willReturn(new Response(200, [], json_encode($expected)));
+        $this->userService
+            ->expects($this->once())
+            ->method('getUser')
+            ->willReturn($user);
+        $this->assertSame($expected, $this->sut->fetchTokens());
+    }
+
+    private function generateAccessToken(string $userId, string $tenantId = self::TENANT_ID): string
+    {
+        $key = InMemory::base64Encoded(bin2hex(random_bytes(32)));
+        return (new JwtFacade())->issue(
+            new Sha256(),
+            $key,
+            static fn(
+                Builder $builder,
+                DateTimeImmutable $issuedAt,
+            ): Builder => $builder
+                ->issuedBy('https://backoffice.ngs.test')
+                ->expiresAt($issuedAt->modify('+1 minute'))
+                ->withClaim('user', ['login' => $userId])
+                ->withClaim('tenant_id', $tenantId)
+        )->toString();
+    }
+
+    private function initEnvVars(): void
+    {
+        $_ENV['ENV_AUTH_URI'] = self::ENV_AUTH_URI;
+        $_ENV['ENV_CLIENT_ID'] = self::ENV_CLIENT_ID;
+        $_ENV['ENV_CLIENT_SECRET'] = self::ENV_CLIENT_SECRET;
+        $_ENV['TENANT_ID'] = self::TENANT_ID;
+    }
+}


### PR DESCRIPTION
## Ticket: [EP-765](https://oat-sa.atlassian.net/browse/EP-765)

## What's Changed
This adds support for storing User Identity information in a bearer access token

> Please tick the appropriate points
- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [x] Release version change
- [x] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [x] New code is not subject to concurrency issues (if applicable)
- [x] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful

## Dependencies
- https://github.com/oat-sa/generis/pull/1181

[EP-693]: https://oat-sa.atlassian.net/browse/EP-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Access tokens now reflect the active user and selected role.
  - Token requests support tenant-aware validation and session-based authentication.

- **Bug Fixes**
  - Improved caching helps prevent credentials from being mixed between users or roles.
  - Invalid, incomplete, or unexpected authentication responses are handled more reliably.

- **Chores**
  - Expanded compatibility testing to include PHP 8.5.
  - Added comprehensive automated coverage for token retrieval scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[EP-765]: https://oat-sa.atlassian.net/browse/EP-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ