### PR TITLE
fix: update TAO version to 2026.09

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -378,9 +378,9 @@ return [
     ],
     'constants' => [
         #TAO version number
-        'TAO_VERSION' => '2026.08 LTS',
+        'TAO_VERSION' => '2026.09',
         #TAO version label
-        'TAO_VERSION_NAME' => '2026.08 LTS',
+        'TAO_VERSION_NAME' => '2026.09',
         #the name to display
         'PRODUCT_NAME' => 'TAO',
         #TAO release status, use to add specific footer to TAO, available alpha, beta, demo, stable


### PR DESCRIPTION
## Summary
- Bump TAO release version metadata in `manifest.php` for the September 2026 monthly (non-LTS) release line.
- Update both constants so UI/version reporting stays consistent.

## Changes
- `TAO_VERSION`: `2026.08 LTS` → `2026.09`
- `TAO_VERSION_NAME`: `2026.08 LTS` → `2026.09`

## Validation
- Verified updated values are present in `manifest.php`.

## Jira
- AUT-4658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the displayed TAO version from **2026.08 LTS** to **2026.09**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->