### PR TITLE
fix: INF-529 bump tao-core-shared-libs for ruby navigation

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/polyfill": "^7.4.4",
                 "@oat-sa/tao-core-libs": "^1.2.1",
                 "@oat-sa/tao-core-sdk": "^3.5.0",
-                "@oat-sa/tao-core-shared-libs": "^1.12.0",
+                "@oat-sa/tao-core-shared-libs": "^1.12.1",
                 "@oat-sa/tao-core-ui": "^3.22.0",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
@@ -78,10 +78,9 @@
             }
         },
         "node_modules/@oat-sa/tao-core-shared-libs": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.12.0.tgz",
-            "integrity": "sha512-5o6icg+PxsBHI4kihIxp1G7RAmEya7WbJhOdfPG5HNQnRwxjd18l4ThsvGG23V8cDaVk1p9rasXN1zgxC7r5tg==",
-            "license": "GPL-2.0"
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.12.1.tgz",
+            "integrity": "sha512-UWauF0iz7bN+AYD7S5Ak/bD14a/brPb4we/uY4a0LeyWDEs+HVPBoB6uaq/Bf9raD4xdq4Ewf2iE0q1adVVLGQ=="
         },
         "node_modules/@oat-sa/tao-core-ui": {
             "version": "3.22.0",

--- a/views/package.json
+++ b/views/package.json
@@ -12,7 +12,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/tao-core-libs": "^1.2.1",
         "@oat-sa/tao-core-sdk": "^3.5.0",
-        "@oat-sa/tao-core-shared-libs": "^1.12.0",
+        "@oat-sa/tao-core-shared-libs": "^1.12.1",
         "@oat-sa/tao-core-ui": "^3.22.0",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",


### PR DESCRIPTION
## Summary
- Bump `@oat-sa/tao-core-shared-libs` from `^1.12.0` to `^1.12.1` (ruby navigation fix)
- Refresh `views/package-lock.json` to lock 1.12.1

## Test plan
- [ ] Confirm `views/package.json` and lock resolve to `@oat-sa/tao-core-shared-libs@1.12.1`
- [ ] Smoke-check ruby navigation after install/build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a shared library dependency to the latest compatible patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->