### PR TITLE
fix: INF-529 backport tao-core-shared-libs 1.12.1 to v55.0.1.13

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/polyfill": "^7.4.4",
                 "@oat-sa/tao-core-libs": "^1.1.0",
                 "@oat-sa/tao-core-sdk": "^3.5.0",
-                "@oat-sa/tao-core-shared-libs": "^1.11.4",
+                "@oat-sa/tao-core-shared-libs": "^1.12.1",
                 "@oat-sa/tao-core-ui": "^3.19.2",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
@@ -78,10 +78,9 @@
             }
         },
         "node_modules/@oat-sa/tao-core-shared-libs": {
-            "version": "1.11.4",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.11.4.tgz",
-            "integrity": "sha512-xVw9apIrOXp1d2U0D8FhUb/EnUW3tNnExfeX7dZkshnRHf5MJ68S5fwY/g2e+4TAuR1f/6WUKxVDxfh0CCTHtg==",
-            "license": "GPL-2.0"
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.12.1.tgz",
+            "integrity": "sha512-UWauF0iz7bN+AYD7S5Ak/bD14a/brPb4we/uY4a0LeyWDEs+HVPBoB6uaq/Bf9raD4xdq4Ewf2iE0q1adVVLGQ=="
         },
         "node_modules/@oat-sa/tao-core-ui": {
             "version": "3.19.2",

--- a/views/package.json
+++ b/views/package.json
@@ -12,7 +12,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/tao-core-libs": "^1.1.0",
         "@oat-sa/tao-core-sdk": "^3.5.0",
-        "@oat-sa/tao-core-shared-libs": "^1.11.4",
+        "@oat-sa/tao-core-shared-libs": "^1.12.1",
         "@oat-sa/tao-core-ui": "^3.19.2",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",


### PR DESCRIPTION
## Summary
- Backport of [#4499](https://github.com/oat-sa/tao-core/pull/4499) onto `v55.0.1.12` → target `v55.0.1.13`
- Bumps `@oat-sa/tao-core-shared-libs` from `^1.11.4` to `^1.12.1` (ruby navigation fix)
- Keeps `@oat-sa/tao-core-ui` at `^3.19.2` for this release line (cherry-pick conflict resolved manually)

## Context
- [INF-529](https://oat-sa.atlassian.net/browse/INF-529)
- Base: `release-55.0.1.13` (from tag `v55.0.1.12`)

## Test plan
- [ ] Confirm `views/package.json` / lock resolve to `@oat-sa/tao-core-shared-libs@1.12.1`
- [ ] Smoke-check ruby navigation after install/build
- [ ] Confirm `tao-core-ui` remains `3.19.2`

[INF-529]: https://oat-sa.atlassian.net/browse/INF-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ