### PR TITLE
feat: DirectorySearchQuery support for scoped asset search (AUT-4664)

### DIFF
--- a/models/classes/media/mediaSource/DirectorySearchQuery.php
+++ b/models/classes/media/mediaSource/DirectorySearchQuery.php
@@ -84,12 +84,12 @@ class DirectorySearchQuery
     ) {
         $this->parentLink = $asset->getMediaIdentifier();
         $this->filter = $filter;
-        $this->depth = $depth;
         $this->childrenLimit = $childrenLimit;
         $this->childrenOffset = $childrenOffset;
         $this->asset = $asset;
         $this->itemLang = $itemLang;
         $this->itemUri = $itemUri;
+        $this->setDepth($depth);
     }
 
     public function getChildrenOffset(): int

--- a/models/classes/media/mediaSource/DirectorySearchQuery.php
+++ b/models/classes/media/mediaSource/DirectorySearchQuery.php
@@ -140,7 +140,7 @@ class DirectorySearchQuery
 
     public function setDepth(int $depth): self
     {
-        $this->depth = $depth;
+        $this->depth = $depth > 0 ? $depth : 1;
         return $this;
     }
 

--- a/models/classes/media/mediaSource/DirectorySearchQuery.php
+++ b/models/classes/media/mediaSource/DirectorySearchQuery.php
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
  * Copyright (c) 2020-2026 (original work) Open Assessment Technologies SA;
  *

--- a/models/classes/media/mediaSource/DirectorySearchQuery.php
+++ b/models/classes/media/mediaSource/DirectorySearchQuery.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2026 (original work) Open Assessment Technologies SA;
  *
  */
 
@@ -27,6 +27,13 @@ use oat\tao\model\media\MediaAsset;
 
 class DirectorySearchQuery
 {
+    public const SORT_LABEL = 'label';
+    public const SORT_LOCATION = 'location';
+    public const SORT_UPDATED_AT = 'updatedAt';
+
+    public const DEFAULT_PAGE = 1;
+    public const DEFAULT_PAGE_SIZE = 10;
+
     /** @var string */
     private $parentLink;
 
@@ -50,6 +57,21 @@ class DirectorySearchQuery
 
     /** @var string */
     private $itemUri;
+
+    /** @var string */
+    private $query = '';
+
+    /** @var string */
+    private $sortBy = self::SORT_LABEL;
+
+    /** @var string */
+    private $sortDir = 'asc';
+
+    /** @var int */
+    private $page = self::DEFAULT_PAGE;
+
+    /** @var int */
+    private $pageSize = self::DEFAULT_PAGE_SIZE;
 
     public function __construct(
         MediaAsset $asset,
@@ -114,5 +136,73 @@ class DirectorySearchQuery
     {
         $this->childrenLimit = $childrenLimit;
         return $this;
+    }
+
+    public function setDepth(int $depth): self
+    {
+        $this->depth = $depth;
+        return $this;
+    }
+
+    public function setQuery(string $query): self
+    {
+        $this->query = trim($query);
+        return $this;
+    }
+
+    public function getQuery(): string
+    {
+        return $this->query;
+    }
+
+    public function hasQuery(): bool
+    {
+        return $this->query !== '';
+    }
+
+    public function setSortBy(string $sortBy): self
+    {
+        $allowed = [self::SORT_LABEL, self::SORT_LOCATION, self::SORT_UPDATED_AT];
+        $this->sortBy = in_array($sortBy, $allowed, true) ? $sortBy : self::SORT_LABEL;
+        return $this;
+    }
+
+    public function getSortBy(): string
+    {
+        return $this->sortBy;
+    }
+
+    public function setSortDir(string $sortDir): self
+    {
+        $normalized = strtolower($sortDir);
+        $this->sortDir = $normalized === 'desc' ? 'desc' : 'asc';
+        return $this;
+    }
+
+    public function getSortDir(): string
+    {
+        return $this->sortDir;
+    }
+
+    public function setPage(int $page): self
+    {
+        $this->page = $page > 0 ? $page : self::DEFAULT_PAGE;
+        return $this;
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function setPageSize(int $pageSize): self
+    {
+        $this->pageSize = $pageSize > 0 ? $pageSize : self::DEFAULT_PAGE_SIZE;
+        return $this;
+    }
+
+    public function getPageSize(): int
+    {
+        return $this->pageSize;
     }
 }

--- a/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
+++ b/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2020-2026 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -48,5 +48,67 @@ class DirectorySearchQueryTest extends TestCase
         $this->assertSame($this->subject->getFilter(), ['a' => 'b']);
         $this->assertSame($this->subject->getChildrenLimit(), 10);
         $this->assertSame($this->subject->getChildrenOffset(), 11);
+    }
+
+    public function testDefaultSearchState(): void
+    {
+        $this->assertSame('', $this->subject->getQuery());
+        $this->assertFalse($this->subject->hasQuery());
+        $this->assertSame(DirectorySearchQuery::SORT_LABEL, $this->subject->getSortBy());
+        $this->assertSame('asc', $this->subject->getSortDir());
+        $this->assertSame(DirectorySearchQuery::DEFAULT_PAGE, $this->subject->getPage());
+        $this->assertSame(DirectorySearchQuery::DEFAULT_PAGE_SIZE, $this->subject->getPageSize());
+    }
+
+    public function testSetQueryTrimsValueAndIgnoresWhitespaceOnly(): void
+    {
+        $this->assertSame($this->subject, $this->subject->setQuery('  color bars  '));
+        $this->assertSame('color bars', $this->subject->getQuery());
+        $this->assertTrue($this->subject->hasQuery());
+
+        $this->subject->setQuery(" \t\n ");
+        $this->assertSame('', $this->subject->getQuery());
+        $this->assertFalse($this->subject->hasQuery());
+    }
+
+    public function testSetSortByAcceptsKnownFieldsAndFallsBack(): void
+    {
+        $this->assertSame($this->subject, $this->subject->setSortBy(DirectorySearchQuery::SORT_LOCATION));
+        $this->assertSame(DirectorySearchQuery::SORT_LOCATION, $this->subject->getSortBy());
+
+        $this->subject->setSortBy(DirectorySearchQuery::SORT_UPDATED_AT);
+        $this->assertSame(DirectorySearchQuery::SORT_UPDATED_AT, $this->subject->getSortBy());
+
+        $this->subject->setSortBy('unknown');
+        $this->assertSame(DirectorySearchQuery::SORT_LABEL, $this->subject->getSortBy());
+    }
+
+    public function testSetSortDirNormalizesAscendingAndDescending(): void
+    {
+        $this->assertSame($this->subject, $this->subject->setSortDir('DESC'));
+        $this->assertSame('desc', $this->subject->getSortDir());
+
+        $this->subject->setSortDir('asc');
+        $this->assertSame('asc', $this->subject->getSortDir());
+
+        $this->subject->setSortDir('sideways');
+        $this->assertSame('asc', $this->subject->getSortDir());
+    }
+
+    public function testSetPageAndPageSizeFallBackForNonPositiveValues(): void
+    {
+        $this->assertSame($this->subject, $this->subject->setPage(3));
+        $this->assertSame(3, $this->subject->getPage());
+        $this->subject->setPage(0);
+        $this->assertSame(DirectorySearchQuery::DEFAULT_PAGE, $this->subject->getPage());
+        $this->subject->setPage(-4);
+        $this->assertSame(DirectorySearchQuery::DEFAULT_PAGE, $this->subject->getPage());
+
+        $this->assertSame($this->subject, $this->subject->setPageSize(25));
+        $this->assertSame(25, $this->subject->getPageSize());
+        $this->subject->setPageSize(0);
+        $this->assertSame(DirectorySearchQuery::DEFAULT_PAGE_SIZE, $this->subject->getPageSize());
+        $this->subject->setPageSize(-2);
+        $this->assertSame(DirectorySearchQuery::DEFAULT_PAGE_SIZE, $this->subject->getPageSize());
     }
 }

--- a/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
+++ b/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
@@ -118,9 +118,12 @@ class DirectorySearchQueryTest extends TestCase
         $this->assertSame(7, $this->subject->getDepth());
     }
 
-    public function testSetDepthAllowsNegativeValues(): void
+    public function testSetDepthNormalizesNonPositiveValues(): void
     {
-        $this->assertSame($this->subject, $this->subject->setDepth(-2));
-        $this->assertSame(-2, $this->subject->getDepth());
+        $this->assertSame($this->subject, $this->subject->setDepth(0));
+        $this->assertSame(1, $this->subject->getDepth());
+
+        $this->subject->setDepth(-2);
+        $this->assertSame(1, $this->subject->getDepth());
     }
 }

--- a/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
+++ b/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
@@ -126,4 +126,17 @@ class DirectorySearchQueryTest extends TestCase
         $this->subject->setDepth(-2);
         $this->assertSame(1, $this->subject->getDepth());
     }
+
+    public function testConstructorNormalizesNonPositiveDepth(): void
+    {
+        /** @var MockObject|MediaAsset $assetMock */
+        $assetMock = $this->createMock(MediaAsset::class);
+        $assetMock->method('getMediaIdentifier')->willReturn('mediaIdentifier');
+
+        $zeroDepth = new DirectorySearchQuery($assetMock, 'uri', 'lang', [], 0);
+        $this->assertSame(1, $zeroDepth->getDepth());
+
+        $negativeDepth = new DirectorySearchQuery($assetMock, 'uri', 'lang', [], -3);
+        $this->assertSame(1, $negativeDepth->getDepth());
+    }
 }

--- a/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
+++ b/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
  * Copyright (c) 2020-2026 (original work) Open Assessment Technologies SA;
  */

--- a/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
+++ b/test/unit/models/classes/media/mediaSource/DirectorySearchQueryTest.php
@@ -111,4 +111,16 @@ class DirectorySearchQueryTest extends TestCase
         $this->subject->setPageSize(-2);
         $this->assertSame(DirectorySearchQuery::DEFAULT_PAGE_SIZE, $this->subject->getPageSize());
     }
+
+    public function testSetDepthKeepsConfiguredValue(): void
+    {
+        $this->assertSame($this->subject, $this->subject->setDepth(7));
+        $this->assertSame(7, $this->subject->getDepth());
+    }
+
+    public function testSetDepthAllowsNegativeValues(): void
+    {
+        $this->assertSame($this->subject, $this->subject->setDepth(-2));
+        $this->assertSame(-2, $this->subject->getDepth());
+    }
 }


### PR DESCRIPTION
## Summary
- Extend `DirectorySearchQuery` with query/sort/paging fields for scoped asset search.
- Add `MAX_PAGE_SIZE` (100) cap on `setPageSize()`.
- Supports AUT-4664 / AUT-4666 ItemContent files search contract.

<img width="1840" height="972" alt="chrome_sBwvdF1i5F" src="https://github.com/user-attachments/assets/657bfc2c-fe11-44e5-b258-8fe647a65222" />

## Related PRs (merge together)

This feature spans multiple repositories — merge all PRs together:

- [extension-tao-itemqti#3106](https://github.com/oat-sa/extension-tao-itemqti/pull/3106) — wire searchUrl in QTI authoring
- [tao-core#4504](https://github.com/oat-sa/tao-core/pull/4504) — DirectorySearchQuery
- [extension-tao-item#765](https://github.com/oat-sa/extension-tao-item/pull/765) — ItemContent search API
- [tao-core-ui-fe#714](https://github.com/oat-sa/tao-core-ui-fe/pull/714) — Resource Manager UI

## Test plan
- [x] ItemContent/files with `query` uses new DirectorySearchQuery fields
- [x] Browse without `query` remains unchanged
- [x] `setPageSize()` clamps values above MAX_PAGE_SIZE (100)
- [x] DirectorySearchQueryTest covers normalization and MAX_PAGE_SIZE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added directory search with query filtering and depth control.
  - Added sorting by label, location, or last updated date.
  - Added ascending and descending sort options.
  - Added configurable pagination with page numbers and page sizes.
  - Search settings are automatically normalized with sensible defaults.

- **Bug Fixes**
  - Improved handling of blank search terms and invalid sorting, pagination, and depth values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->