### PR TITLE
Feat/ep 764/content bank event logs

### DIFF
--- a/actions/class.Main.php
+++ b/actions/class.Main.php
@@ -46,6 +46,7 @@ use oat\tao\model\menu\SectionVisibilityFilterInterface;
 use oat\tao\model\mvc\DefaultUrlService;
 use oat\tao\model\notification\Notification;
 use oat\tao\model\notification\NotificationServiceInterface;
+use oat\tao\model\session\source\SessionSource;
 use oat\tao\model\user\UserLocks;
 use tao_helpers_Display as DisplayHelper;
 
@@ -212,7 +213,10 @@ class tao_actions_Main extends tao_actions_CommonModule
                         if (LoginService::login($form->getValue('login'), $form->getValue('password'))) {
                             $logins = $this->getSession()->getUser()->getPropertyValues(UserRdf::PROPERTY_LOGIN);
 
-                            $eventManager->trigger(new LoginSucceedEvent(current($logins)));
+                            $eventManager->trigger(new LoginSucceedEvent(
+                                login: current($logins),
+                                source: SessionSource::INTERNAL_BACKOFFICE->value
+                            ));
 
                             $this->logInfo("Successful login of user '" . $form->getValue('login') . "'.");
 
@@ -239,7 +243,7 @@ class tao_actions_Main extends tao_actions_CommonModule
                                     if ($remainingAttempts === 0) {
                                         // phpcs:disable Generic.Files.LineLength
                                         $msg = __('Invalid login or password. Your account has been locked, please contact your administrator.');
-                                    // phpcs:enable Generic.Files.LineLength
+                                        // phpcs:enable Generic.Files.LineLength
                                     } else {
                                         $msg .= ' ' . (
                                             $remainingAttempts === 1

--- a/manifest.php
+++ b/manifest.php
@@ -22,7 +22,7 @@
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor
  *                         (under the project TAO-SUSTAIN & TAO-DEV);
  *               2013-     (update and modification) Open Assessment Technologies SA;
- *               2021-2022 (original work) Open Assessment Technologies SA.
+ *               2021-2026 (original work) Open Assessment Technologies SA.
  */
 
 declare(strict_types=1);
@@ -62,6 +62,7 @@ use oat\tao\model\routing\ApiRoute;
 use oat\tao\model\routing\TaoRoute;
 use oat\tao\model\routing\ServiceProvider\RoutingServiceProvider;
 use oat\tao\model\search\ServiceProvider\SearchServiceProvider;
+use oat\tao\model\session\source\ServiceProvider\SessionSourceServiceProvider;
 use oat\tao\model\StatisticalMetadata\StatisticalMetadataServiceProvider;
 use oat\tao\model\Translation\ServiceProvider\TranslationServiceProvider;
 use oat\tao\model\user\TaoRoles;
@@ -444,6 +445,7 @@ return [
         CookiePolicyServiceProvider::class,
         DataPolicyServiceProvider::class,
         InfrastructureServiceProvider::class,
+        SessionSourceServiceProvider::class,
         FrontendActionServiceProvider::class,
     ],
     'middlewares' => [

--- a/models/classes/event/LoginSucceedEvent.php
+++ b/models/classes/event/LoginSucceedEvent.php
@@ -15,52 +15,39 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA
- *
+ * Copyright (c) 2015-2026 (original work) Open Assessment Technologies SA
  */
+
+declare(strict_types=1);
 
 namespace oat\tao\model\event;
 
 use JsonSerializable;
 use oat\oatbox\event\Event;
+use oat\tao\model\session\source\SessionSource;
 
 class LoginSucceedEvent implements Event, JsonSerializable
 {
-    private $login = '';
-    private $time;
+    private readonly int $time;
 
-    /**
-     * LoginEvent constructor.
-     * @param $login
-     */
-    public function __construct($login = '')
-    {
-        $this->login = $login;
+    public function __construct(
+        private readonly string $login = '',
+        private readonly ?string $source = SessionSource::INTERNAL_BACKOFFICE->value
+    ) {
         $this->time = time();
     }
 
-    /**
-     * @return string
-     */
-    public function getLogin()
+    public function getLogin(): string
     {
         return $this->login;
     }
 
-    /**
-     * Return a unique name for this event
-     * @see \oat\oatbox\event\Event::getName()
-     */
-    public function getName()
+    public function getName(): string
     {
         return __CLASS__;
     }
 
-
-    /**
-     * @return \DateTime
-     */
-    public function getTime()
+    public function getTime(): int
     {
         return $this->time;
     }
@@ -68,7 +55,8 @@ class LoginSucceedEvent implements Event, JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            'login' => $this->getLogin()
+            'login' => $this->login,
+            'source' => $this->source,
         ];
     }
 }

--- a/models/classes/event/LoginSucceedEvent.php
+++ b/models/classes/event/LoginSucceedEvent.php
@@ -32,7 +32,7 @@ class LoginSucceedEvent implements Event, JsonSerializable
 
     public function __construct(
         private readonly string $login = '',
-        private readonly ?string $source = SessionSource::INTERNAL_BACKOFFICE->value
+        private readonly string $source = SessionSource::INTERNAL_BACKOFFICE->value
     ) {
         $this->time = time();
     }

--- a/models/classes/session/source/ServiceProvider/SessionSourceServiceProvider.php
+++ b/models/classes/session/source/ServiceProvider/SessionSourceServiceProvider.php
@@ -22,12 +22,22 @@ declare(strict_types=1);
 
 namespace oat\tao\model\session\source\ServiceProvider;
 
+use Laminas\ServiceManager\ServiceLocatorAwareInterface;
+use Laminas\ServiceManager\ServiceLocatorAwareTrait;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\tao\model\session\source\SessionSourceMatcher;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-class SessionSourceServiceProvider implements ContainerServiceProviderInterface
+/**
+ * Registers session source matcher services.
+ *
+ * @codeCoverageIgnore
+ * @license GPL-2.0
+ */
+class SessionSourceServiceProvider implements ContainerServiceProviderInterface, ServiceLocatorAwareInterface
 {
+    use ServiceLocatorAwareTrait;
+
     public function __invoke(ContainerConfigurator $configurator): void
     {
         $services = $configurator->services();

--- a/models/classes/session/source/ServiceProvider/SessionSourceServiceProvider.php
+++ b/models/classes/session/source/ServiceProvider/SessionSourceServiceProvider.php
@@ -22,8 +22,6 @@ declare(strict_types=1);
 
 namespace oat\tao\model\session\source\ServiceProvider;
 
-use Laminas\ServiceManager\ServiceLocatorAwareInterface;
-use Laminas\ServiceManager\ServiceLocatorAwareTrait;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\tao\model\session\source\SessionSourceMatcher;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -34,10 +32,8 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
  * @codeCoverageIgnore
  * @license GPL-2.0
  */
-class SessionSourceServiceProvider implements ContainerServiceProviderInterface, ServiceLocatorAwareInterface
+class SessionSourceServiceProvider implements ContainerServiceProviderInterface
 {
-    use ServiceLocatorAwareTrait;
-
     public function __invoke(ContainerConfigurator $configurator): void
     {
         $services = $configurator->services();

--- a/models/classes/session/source/ServiceProvider/SessionSourceServiceProvider.php
+++ b/models/classes/session/source/ServiceProvider/SessionSourceServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\session\source\ServiceProvider;
+
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\tao\model\session\source\SessionSourceMatcher;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+class SessionSourceServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services
+            ->set(SessionSourceMatcher::class, SessionSourceMatcher::class)
+            ->public();
+    }
+}

--- a/models/classes/session/source/SessionSource.php
+++ b/models/classes/session/source/SessionSource.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\session\source;
+
+enum SessionSource: string
+{
+    case INTERNAL_BACKOFFICE = 'internal:backoffice';
+    case EXTERNAL_PORTAL = 'external:portal';
+}

--- a/models/classes/session/source/SessionSourceMatcher.php
+++ b/models/classes/session/source/SessionSourceMatcher.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\session\source;
+
+use common_session_Session;
+use InvalidArgumentException;
+
+class SessionSourceMatcher
+{
+    public const SOURCE_PORTAL = 'portal';
+
+    /** @var array<string, SessionSourceMatcherInterface[]> */
+    private array $sourceMatchers = [];
+
+    public function addSessionSourceMatcher(string $source, SessionSourceMatcherInterface $matcher): void
+    {
+        $source = strtolower($source);
+
+        if ($this->hasMatcher($source, $matcher)) {
+            throw new InvalidArgumentException(
+                sprintf('Matcher "%s" is already registered for source "%s".', $matcher::class, $source)
+            );
+        }
+
+        $this->sourceMatchers[$source][] = $matcher;
+    }
+
+    public function matchesSource(string $source, common_session_Session $session): bool
+    {
+        $source = strtolower($source);
+
+        if (empty($this->sourceMatchers[$source])) {
+            return false;
+        }
+
+        foreach ($this->sourceMatchers[$source] as $matcher) {
+            if ($matcher->matchesSource($session)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasMatcher(string $source, SessionSourceMatcherInterface $matcher): bool
+    {
+        foreach ($this->sourceMatchers[$source] ?? [] as $registeredMatcher) {
+            if ($registeredMatcher::class === $matcher::class) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/models/classes/session/source/SessionSourceMatcher.php
+++ b/models/classes/session/source/SessionSourceMatcher.php
@@ -32,8 +32,6 @@ use InvalidArgumentException;
  */
 class SessionSourceMatcher
 {
-    public const SOURCE_PORTAL = 'portal';
-
     /** @var array<string, SessionSourceMatcherInterface[]> */
     private array $sourceMatchers = [];
 

--- a/models/classes/session/source/SessionSourceMatcher.php
+++ b/models/classes/session/source/SessionSourceMatcher.php
@@ -65,6 +65,11 @@ class SessionSourceMatcher
         return false;
     }
 
+    public function isPortalSession(common_session_Session $session): bool
+    {
+        return $this->matchesSource(SessionSource::EXTERNAL_PORTAL->value, $session);
+    }
+
     private function hasMatcher(string $source, SessionSourceMatcherInterface $matcher): bool
     {
         foreach ($this->sourceMatchers[$source] ?? [] as $registeredMatcher) {

--- a/models/classes/session/source/SessionSourceMatcher.php
+++ b/models/classes/session/source/SessionSourceMatcher.php
@@ -25,6 +25,11 @@ namespace oat\tao\model\session\source;
 use common_session_Session;
 use InvalidArgumentException;
 
+/**
+ * Matches a session against registered source matchers.
+ *
+ * @license GPL-2.0
+ */
 class SessionSourceMatcher
 {
     public const SOURCE_PORTAL = 'portal';

--- a/models/classes/session/source/SessionSourceMatcherInterface.php
+++ b/models/classes/session/source/SessionSourceMatcherInterface.php
@@ -24,6 +24,11 @@ namespace oat\tao\model\session\source;
 
 use common_session_Session;
 
+/**
+ * Determines whether a session belongs to a given source.
+ *
+ * @license GPL-2.0
+ */
 interface SessionSourceMatcherInterface
 {
     public function matchesSource(common_session_Session $session): bool;

--- a/models/classes/session/source/SessionSourceMatcherInterface.php
+++ b/models/classes/session/source/SessionSourceMatcherInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\session\source;
+
+use common_session_Session;
+
+interface SessionSourceMatcherInterface
+{
+    public function matchesSource(common_session_Session $session): bool;
+}

--- a/test/unit/models/classes/event/LoginSucceedEventTest.php
+++ b/test/unit/models/classes/event/LoginSucceedEventTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\model\event;
+
+use oat\tao\model\event\LoginSucceedEvent;
+use oat\tao\model\session\source\SessionSource;
+use PHPUnit\Framework\TestCase;
+
+class LoginSucceedEventTest extends TestCase
+{
+    public function testJsonSerializeUsesInternalBackofficeSourceByDefault(): void
+    {
+        $event = new LoginSucceedEvent('john.doe');
+
+        $this->assertSame(
+            [
+                'login' => 'john.doe',
+                'source' => SessionSource::INTERNAL_BACKOFFICE->value,
+            ],
+            $event->jsonSerialize()
+        );
+    }
+
+    public function testJsonSerializeUsesProvidedSource(): void
+    {
+        $event = new LoginSucceedEvent('john.doe', SessionSource::EXTERNAL_PORTAL->value);
+
+        $this->assertSame(
+            [
+                'login' => 'john.doe',
+                'source' => SessionSource::EXTERNAL_PORTAL->value,
+            ],
+            $event->jsonSerialize()
+        );
+    }
+
+    public function testGetNameAndGetTime(): void
+    {
+        $event = new LoginSucceedEvent('john.doe');
+
+        $this->assertSame(LoginSucceedEvent::class, $event->getName());
+        $this->assertIsInt($event->getTime());
+        $this->assertGreaterThan(0, $event->getTime());
+    }
+}

--- a/test/unit/models/classes/session/source/SessionSourceMatcherTest.php
+++ b/test/unit/models/classes/session/source/SessionSourceMatcherTest.php
@@ -127,4 +127,24 @@ class SessionSourceMatcherTest extends TestCase
 
         $this->assertTrue($service->matchesSource(SessionSource::EXTERNAL_PORTAL->value, $session));
     }
+
+    public function testIsPortalSessionReturnsTrueWhenPortalMatcherMatches(): void
+    {
+        $session = $this->createMock(common_session_Session::class);
+        $matcher = $this->createMock(SessionSourceMatcherInterface::class);
+        $matcher->expects($this->once())->method('matchesSource')->with($session)->willReturn(true);
+
+        $service = new SessionSourceMatcher();
+        $service->addSessionSourceMatcher(SessionSource::EXTERNAL_PORTAL->value, $matcher);
+
+        $this->assertTrue($service->isPortalSession($session));
+    }
+
+    public function testIsPortalSessionReturnsFalseWhenPortalMatcherIsMissing(): void
+    {
+        $session = $this->createMock(common_session_Session::class);
+        $service = new SessionSourceMatcher();
+
+        $this->assertFalse($service->isPortalSession($session));
+    }
 }

--- a/test/unit/models/classes/session/source/SessionSourceMatcherTest.php
+++ b/test/unit/models/classes/session/source/SessionSourceMatcherTest.php
@@ -55,6 +55,22 @@ class SessionSourceMatcherTest extends TestCase
         $this->assertTrue($service->matchesSource('portal', $session));
     }
 
+    public function testReturnsFalseWhenMatcherReturnsFalse(): void
+    {
+        $session = $this->createMock(common_session_Session::class);
+        $matcher = $this->createMock(SessionSourceMatcherInterface::class);
+        $matcher
+            ->expects($this->once())
+            ->method('matchesSource')
+            ->with($session)
+            ->willReturn(false);
+
+        $service = new SessionSourceMatcher();
+        $service->addSessionSourceMatcher('portal', $matcher);
+
+        $this->assertFalse($service->matchesSource('portal', $session));
+    }
+
     public function testSourceComparisonIsCaseInsensitive(): void
     {
         $session = $this->createMock(common_session_Session::class);

--- a/test/unit/models/classes/session/source/SessionSourceMatcherTest.php
+++ b/test/unit/models/classes/session/source/SessionSourceMatcherTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\session\source;
+
+use common_session_Session;
+use InvalidArgumentException;
+use oat\tao\model\session\source\SessionSourceMatcher;
+use oat\tao\model\session\source\SessionSourceMatcherInterface;
+use PHPUnit\Framework\TestCase;
+
+class SessionSourceMatcherTest extends TestCase
+{
+    public function testReturnsFalseWhenNoMatchersRegisteredForSource(): void
+    {
+        $service = new SessionSourceMatcher();
+
+        $this->assertFalse(
+            $service->matchesSource('portal', $this->createMock(common_session_Session::class))
+        );
+    }
+
+    public function testMatchesSourceWhenMatcherReturnsTrue(): void
+    {
+        $session = $this->createMock(common_session_Session::class);
+        $matcher = $this->createMock(SessionSourceMatcherInterface::class);
+        $matcher
+            ->expects($this->once())
+            ->method('matchesSource')
+            ->with($session)
+            ->willReturn(true);
+
+        $service = new SessionSourceMatcher();
+        $service->addSessionSourceMatcher('portal', $matcher);
+
+        $this->assertTrue($service->matchesSource('portal', $session));
+    }
+
+    public function testSourceComparisonIsCaseInsensitive(): void
+    {
+        $session = $this->createMock(common_session_Session::class);
+        $matcher = $this->createMock(SessionSourceMatcherInterface::class);
+        $matcher->method('matchesSource')->willReturn(true);
+
+        $service = new SessionSourceMatcher();
+        $service->addSessionSourceMatcher('PoRtAl', $matcher);
+
+        $this->assertTrue($service->matchesSource('PORTAL', $session));
+    }
+
+    public function testThrowsExceptionWhenSameMatcherClassRegisteredTwiceForSource(): void
+    {
+        $matcher = $this->createMock(SessionSourceMatcherInterface::class);
+        $matcher->method('matchesSource')->willReturn(true);
+
+        $service = new SessionSourceMatcher();
+        $service->addSessionSourceMatcher('portal', $matcher);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('already registered for source "portal"');
+
+        $service->addSessionSourceMatcher('PORTAL', $matcher);
+    }
+
+    public function testStopsCheckingMatchersAfterFirstPositiveMatch(): void
+    {
+        $session = $this->createMock(common_session_Session::class);
+
+        $service = new SessionSourceMatcher();
+        $service->addSessionSourceMatcher(
+            'portal',
+            new class () implements SessionSourceMatcherInterface {
+                public function matchesSource(common_session_Session $session): bool
+                {
+                    return true;
+                }
+            }
+        );
+        $service->addSessionSourceMatcher(
+            'portal',
+            new class () implements SessionSourceMatcherInterface {
+                public function matchesSource(common_session_Session $session): bool
+                {
+                    throw new \RuntimeException('This matcher should not be called');
+                }
+            }
+        );
+
+        $this->assertTrue($service->matchesSource('portal', $session));
+    }
+}

--- a/test/unit/models/classes/session/source/SessionSourceMatcherTest.php
+++ b/test/unit/models/classes/session/source/SessionSourceMatcherTest.php
@@ -24,6 +24,7 @@ namespace oat\tao\test\unit\models\classes\session\source;
 
 use common_session_Session;
 use InvalidArgumentException;
+use oat\tao\model\session\source\SessionSource;
 use oat\tao\model\session\source\SessionSourceMatcher;
 use oat\tao\model\session\source\SessionSourceMatcherInterface;
 use PHPUnit\Framework\TestCase;
@@ -35,7 +36,10 @@ class SessionSourceMatcherTest extends TestCase
         $service = new SessionSourceMatcher();
 
         $this->assertFalse(
-            $service->matchesSource('portal', $this->createMock(common_session_Session::class))
+            $service->matchesSource(
+                SessionSource::EXTERNAL_PORTAL->value,
+                $this->createMock(common_session_Session::class)
+            )
         );
     }
 
@@ -50,9 +54,9 @@ class SessionSourceMatcherTest extends TestCase
             ->willReturn(true);
 
         $service = new SessionSourceMatcher();
-        $service->addSessionSourceMatcher('portal', $matcher);
+        $service->addSessionSourceMatcher(SessionSource::EXTERNAL_PORTAL->value, $matcher);
 
-        $this->assertTrue($service->matchesSource('portal', $session));
+        $this->assertTrue($service->matchesSource(SessionSource::EXTERNAL_PORTAL->value, $session));
     }
 
     public function testReturnsFalseWhenMatcherReturnsFalse(): void
@@ -66,9 +70,9 @@ class SessionSourceMatcherTest extends TestCase
             ->willReturn(false);
 
         $service = new SessionSourceMatcher();
-        $service->addSessionSourceMatcher('portal', $matcher);
+        $service->addSessionSourceMatcher(SessionSource::EXTERNAL_PORTAL->value, $matcher);
 
-        $this->assertFalse($service->matchesSource('portal', $session));
+        $this->assertFalse($service->matchesSource(SessionSource::EXTERNAL_PORTAL->value, $session));
     }
 
     public function testSourceComparisonIsCaseInsensitive(): void
@@ -78,9 +82,9 @@ class SessionSourceMatcherTest extends TestCase
         $matcher->method('matchesSource')->willReturn(true);
 
         $service = new SessionSourceMatcher();
-        $service->addSessionSourceMatcher('PoRtAl', $matcher);
+        $service->addSessionSourceMatcher(strtoupper(SessionSource::EXTERNAL_PORTAL->value), $matcher);
 
-        $this->assertTrue($service->matchesSource('PORTAL', $session));
+        $this->assertTrue($service->matchesSource(strtoupper(SessionSource::EXTERNAL_PORTAL->value), $session));
     }
 
     public function testThrowsExceptionWhenSameMatcherClassRegisteredTwiceForSource(): void
@@ -89,12 +93,12 @@ class SessionSourceMatcherTest extends TestCase
         $matcher->method('matchesSource')->willReturn(true);
 
         $service = new SessionSourceMatcher();
-        $service->addSessionSourceMatcher('portal', $matcher);
+        $service->addSessionSourceMatcher(SessionSource::EXTERNAL_PORTAL->value, $matcher);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('already registered for source "portal"');
+        $this->expectExceptionMessage('already registered for source "external:portal"');
 
-        $service->addSessionSourceMatcher('PORTAL', $matcher);
+        $service->addSessionSourceMatcher(strtoupper(SessionSource::EXTERNAL_PORTAL->value), $matcher);
     }
 
     public function testStopsCheckingMatchersAfterFirstPositiveMatch(): void
@@ -103,7 +107,7 @@ class SessionSourceMatcherTest extends TestCase
 
         $service = new SessionSourceMatcher();
         $service->addSessionSourceMatcher(
-            'portal',
+            SessionSource::EXTERNAL_PORTAL->value,
             new class () implements SessionSourceMatcherInterface {
                 public function matchesSource(common_session_Session $session): bool
                 {
@@ -112,7 +116,7 @@ class SessionSourceMatcherTest extends TestCase
             }
         );
         $service->addSessionSourceMatcher(
-            'portal',
+            SessionSource::EXTERNAL_PORTAL->value,
             new class () implements SessionSourceMatcherInterface {
                 public function matchesSource(common_session_Session $session): bool
                 {
@@ -121,6 +125,6 @@ class SessionSourceMatcherTest extends TestCase
             }
         );
 
-        $this->assertTrue($service->matchesSource('portal', $session));
+        $this->assertTrue($service->matchesSource(SessionSource::EXTERNAL_PORTAL->value, $session));
     }
 }


### PR DESCRIPTION
## Ticket: https://oat-sa.atlassian.net/browse/EP-764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added source-aware session matching for internal back-office and external portal sessions.
  * Login success events now include the session source.
  * Session source matching is case-insensitive and supports multiple matching rules.
  * Unknown or unmatched sources are handled safely.
  * Duplicate matching rules are rejected, and matching stops after the first successful result.

* **Chores**
  * Updated the copyright period through 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Companion PRs
- https://github.com/oat-sa/extension-tao-lti/pull/464
- https://github.com/oat-sa/extension-tao-eventlog/pull/178