### PR TITLE
feat: NYSED-38 add TaskOrchestrator email notification adapter

### DIFF
--- a/actions/class.RestUser.php
+++ b/actions/class.RestUser.php
@@ -13,13 +13,16 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
  *
- * Copyright (c) 2017-2018 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2017-2026 (original work) Open Assessment Technologies SA;
  */
 
+declare(strict_types=1);
+
 use oat\generis\model\GenerisRdf;
+use oat\tao\model\http\HttpJsonResponseTrait;
+use oat\tao\model\user\CommentMentionUserSearchService;
 
 /**
  * Class tao_actions_RestUser
@@ -42,9 +45,93 @@ use oat\generis\model\GenerisRdf;
  *       'password1' => 'ctl789@CTL789@',
  *       'password2' => 'ctl789@CTL789@',
  * ]
+ *
+ * Mention search (authoring comments):
+ * - GET /tao/RestUser/searchUsers?resourceUri=&resourceType=&q=&limit=
+ *   Returns top-N autocomplete matches ({users, limit}); not a paginated catalog.
  */
 class tao_actions_RestUser extends tao_actions_RestResource
 {
+    use HttpJsonResponseTrait;
+
+    /**
+     * Mention autocomplete: eligible users filtered by login or display name.
+     * Response: {users: [{id, login, displayName}, ...], limit: int}.
+     */
+    public function searchUsers(): void
+    {
+        try {
+            if (!$this->isRequestGet()) {
+                $this->setErrorJsonResponse('Method not allowed', 405, [], 405);
+
+                return;
+            }
+
+            $query = $this->getPsrRequest()->getQueryParams();
+            $resourceUri = $this->requireStringParam($query['resourceUri'] ?? null, 'resourceUri');
+            if ($resourceUri === null) {
+                return;
+            }
+
+            $resourceType = $this->requireStringParam($query['resourceType'] ?? null, 'resourceType');
+            if ($resourceType === null) {
+                return;
+            }
+
+            $search = isset($query['q']) && is_string($query['q']) ? $query['q'] : '';
+            $limit = isset($query['limit']) ? (int) $query['limit'] : 20;
+
+            $this->setSuccessJsonResponse(
+                $this->getCommentMentionUserSearchService()->search(
+                    $resourceUri,
+                    $resourceType,
+                    $search,
+                    $limit
+                )
+            );
+        } catch (common_exception_Unauthorized $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 403, [], 403);
+        } catch (InvalidArgumentException $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 400, [], 400);
+        } catch (Throwable $exception) {
+            $this->logError($exception->getMessage());
+            $this->setErrorJsonResponse('Unable to search mention users', 500, [], 500);
+        }
+    }
+
+    /**
+     * Validate a required query/body parameter as a non-null string.
+     *
+     * On failure, writes a JSON 400 response and returns null so the caller
+     * can early-return without throwing (response is already sent).
+     *
+     * @param mixed $value Raw request value (typically from query params)
+     * @param string $name Parameter name used in the error message
+     */
+    private function requireStringParam($value, string $name): ?string
+    {
+        // Missing key / explicit null → 400 "is required"
+        if ($value === null) {
+            $this->setErrorJsonResponse(sprintf('%s is required', $name), 400, [], 400);
+
+            return null;
+        }
+
+        // Wrong PHP type (e.g. int from query casting) → 400 "must be a string"
+        if (!is_string($value)) {
+            $this->setErrorJsonResponse(sprintf('%s must be a string', $name), 400, [], 400);
+
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function getCommentMentionUserSearchService(): CommentMentionUserSearchService
+    {
+        return $this->getPsrContainer()->get(CommentMentionUserSearchService::class);
+    }
+
     /**
      * Return the form object to manage user edition or creation
      *

--- a/manifest.php
+++ b/manifest.php
@@ -348,6 +348,8 @@ return [
         [AccessRule::GRANT, TaoRoles::TAO_MANAGER, ['ext' => 'tao', 'mod' => 'PropertiesAuthoring']],
         [AccessRule::GRANT, TaoRoles::TAO_MANAGER, ['ext' => 'tao', 'mod' => 'QueueAction']],
         [AccessRule::GRANT, TaoRoles::TAO_MANAGER, ['ext' => 'tao', 'mod' => 'RestUser']],
+        // Mention autocomplete for authoring comments (does not expose user CRUD).
+        [AccessRule::GRANT, TaoRoles::BACK_OFFICE, ['ext' => 'tao', 'mod' => 'RestUser', 'act' => 'searchUsers']],
         [AccessRule::GRANT, TaoRoles::TAO_MANAGER, ['ext' => 'tao', 'mod' => 'Roles']],
         [AccessRule::GRANT, TaoRoles::TAO_MANAGER, ['ext' => 'tao', 'mod' => 'TaskQueue']],
         [AccessRule::GRANT, TaoRoles::TAO_MANAGER, ['ext' => 'tao', 'mod' => 'Users']],

--- a/migrations/Version202609081655312234_tao.php
+++ b/migrations/Version202609081655312234_tao.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\model\accessControl\func\AccessRule;
+use oat\tao\model\accessControl\func\AclProxy;
+use oat\tao\model\user\TaoRoles;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202609081655312234_tao extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Grant BACK_OFFICE access to RestUser@searchUsers for comment mention autocomplete';
+    }
+
+    public function up(Schema $schema): void
+    {
+        AclProxy::applyRule($this->getRule());
+    }
+
+    public function down(Schema $schema): void
+    {
+        AclProxy::revokeRule($this->getRule());
+    }
+
+    private function getRule(): AccessRule
+    {
+        return new AccessRule(
+            AccessRule::GRANT,
+            TaoRoles::BACK_OFFICE,
+            ['ext' => 'tao', 'mod' => 'RestUser', 'act' => 'searchUsers']
+        );
+    }
+}

--- a/models/classes/TaskOrchestrator/CommentMentionDeepLinkBuilder.php
+++ b/models/classes/TaskOrchestrator/CommentMentionDeepLinkBuilder.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\TaskOrchestrator;
+
+use InvalidArgumentException;
+use oat\tao\model\menu\MenuService;
+use oat\tao\model\menu\Perspective;
+use tao_helpers_Uri;
+
+/**
+ * Builds Backoffice deep links for comment-mention emails (FR8).
+ *
+ * Resolves structure/ext/section from MenuService by matching a tree rootNode
+ * to the given ontology root class URI. Callers own the wire type → class URI map.
+ *
+ * Example (item class URI):
+ * https://backoffice.ngs.test/tao/Main/index?structure=items&ext=taoItems&section=manage_items&uri=https%3A%2F%2F...
+ */
+final class CommentMentionDeepLinkBuilder
+{
+    private string $backofficeBaseUrl;
+
+    /** @var Perspective[] */
+    private array $perspectives;
+
+    /**
+     * @param Perspective[]|null $perspectives Defaults to MenuService::getAllPerspectives()
+     */
+    public function __construct(?string $backofficeBaseUrl = null, ?array $perspectives = null)
+    {
+        $this->backofficeBaseUrl = rtrim(
+            $backofficeBaseUrl ?? tao_helpers_Uri::getRootUrl(),
+            '/'
+        );
+        $this->perspectives = $perspectives ?? MenuService::getAllPerspectives();
+    }
+
+    /**
+     * @param string $rootClassUri Ontology root class URI of the resource tree (e.g. Item class)
+     */
+    public function build(string $rootClassUri, string $resourceUri): string
+    {
+        $rootClassUri = trim($rootClassUri);
+        if ($rootClassUri === '') {
+            throw new InvalidArgumentException(
+                'Root class URI is required to build comment-mention deep link'
+            );
+        }
+
+        $resourceUri = trim($resourceUri);
+        if ($resourceUri === '') {
+            throw new InvalidArgumentException(
+                'Resource URI is required to build comment-mention deep link'
+            );
+        }
+
+        $query = http_build_query(
+            array_merge($this->resolveRoute($rootClassUri), ['uri' => $resourceUri]),
+            '',
+            '&',
+            PHP_QUERY_RFC3986
+        );
+
+        return sprintf('%s/tao/Main/index?%s', $this->backofficeBaseUrl, $query);
+    }
+
+    /**
+     * @return array{structure: string, ext: string, section: string}
+     */
+    private function resolveRoute(string $rootClassUri): array
+    {
+        foreach ($this->perspectives as $perspective) {
+            foreach ($perspective->getChildren() as $section) {
+                foreach ($section->getTrees() as $tree) {
+                    if ($tree->get('rootNode') === $rootClassUri) {
+                        return [
+                            'structure' => $perspective->getId(),
+                            'ext' => $perspective->getExtension(),
+                            'section' => $section->getId(),
+                        ];
+                    }
+                }
+            }
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'No backoffice structure/section found for root class "%s".',
+            $rootClassUri
+        ));
+    }
+}

--- a/models/classes/TaskOrchestrator/CommentMentionEmailTemplatePayload.php
+++ b/models/classes/TaskOrchestrator/CommentMentionEmailTemplatePayload.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\TaskOrchestrator;
+
+use InvalidArgumentException;
+
+/**
+ * Template payload for tao-templates `comment-mention` (NYSED-38 / FR8).
+ *
+ * Templates worker requiredParams: resourceType, resourceLabel, resourceUrl.
+ * Also pass mentionedBy / username for product copy; optional name for greeting.
+ */
+final class CommentMentionEmailTemplatePayload
+{
+    public const TEMPLATE_ID = 'comment-mention';
+
+    private string $mentionedBy;
+    private string $username;
+    private string $resourceType;
+    private string $resourceUrl;
+    private string $resourceLabel;
+    private ?string $name;
+
+    public function __construct(
+        string $mentionedBy,
+        string $username,
+        string $resourceType,
+        string $resourceUrl,
+        string $resourceLabel,
+        ?string $name = null
+    ) {
+        $this->mentionedBy = $this->assertNonEmpty('mentionedBy', $mentionedBy);
+        $this->username = $this->assertNonEmpty('username', $username);
+        $this->resourceType = $this->assertNonEmpty('resourceType', $resourceType);
+        $this->resourceUrl = $this->assertNonEmpty('resourceUrl', $resourceUrl);
+        $this->resourceLabel = $this->assertNonEmpty('resourceLabel', $resourceLabel);
+        $this->name = $name !== null && trim($name) !== '' ? trim($name) : null;
+    }
+
+    /**
+     * @return array{
+     *     mentionedBy: string,
+     *     username: string,
+     *     resourceType: string,
+     *     resourceUrl: string,
+     *     resourceLabel: string,
+     *     name?: string
+     * }
+     */
+    public function toTemplateData(): array
+    {
+        $data = [
+            'mentionedBy' => $this->mentionedBy,
+            'username' => $this->username,
+            'resourceType' => $this->resourceType,
+            'resourceUrl' => $this->resourceUrl,
+            'resourceLabel' => $this->resourceLabel,
+        ];
+
+        if ($this->name !== null) {
+            $data['name'] = $this->name;
+        }
+
+        return $data;
+    }
+
+    private function assertNonEmpty(string $field, string $value): string
+    {
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            throw new InvalidArgumentException(sprintf('Comment mention email field "%s" is required', $field));
+        }
+
+        return $trimmed;
+    }
+}

--- a/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\TaskOrchestrator;
+
+use GuzzleHttp\Client as GuzzleHttpClient;
+use GuzzleHttp\Exception\GuzzleException;
+use InvalidArgumentException;
+use Psr\SimpleCache\CacheInterface;
+use RuntimeException;
+
+class TaskOrchestratorClient
+{
+    private string $baseUrl;
+    private string $authServerUri;
+    private string $clientId;
+    private string $clientSecret;
+    private GuzzleHttpClient $httpClient;
+    private ?string $accessToken = null;
+    private ?CacheInterface $cache = null;
+
+    public function __construct(
+        string $baseUrl,
+        string $authServerUri,
+        string $clientId,
+        string $clientSecret,
+        GuzzleHttpClient $httpClient,
+        ?CacheInterface $cache = null
+    ) {
+        $this->baseUrl = $baseUrl;
+        $this->authServerUri = $authServerUri;
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->httpClient = $httpClient;
+        $this->cache = $cache;
+    }
+
+    private function getAccessToken(): string
+    {
+        $cacheKey = 'task_orchestrator_access_token_' . md5($this->clientId);
+        if ($this->cache !== null) {
+            $cachedToken = $this->cache->get($cacheKey);
+            if (is_string($cachedToken) && $cachedToken !== '') {
+                $this->accessToken = $cachedToken;
+
+                return $cachedToken;
+            }
+        }
+
+        try {
+            $response = $this->httpClient->request('POST', $this->authServerUri . '/v1/oauth2/tokens', [
+                'headers' => ['Content-Type' => 'application/json'],
+                'json' => [
+                    'grant_type' => 'client_credentials',
+                    'client_id' => $this->clientId,
+                    'client_secret' => $this->clientSecret,
+                ],
+            ]);
+
+            $data = json_decode($response->getBody()->getContents(), true);
+            $accessToken = $data['access_token'] ?? null;
+            $expiresIn = $data['expires_in'] ?? 3600;
+
+            if (!$accessToken) {
+                throw new RuntimeException('Failed to obtain access_token from the authorization server.');
+            }
+
+            if ($this->cache) {
+                $this->cache->set($cacheKey, $accessToken, $expiresIn - 60);
+            }
+            $this->accessToken = $accessToken;
+
+            return $accessToken;
+        } catch (GuzzleException $e) {
+            throw new RuntimeException(
+                'Authorization server communication error: ' . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+    }
+
+    public function sendJob(string $jobId, array $jobPayload): array
+    {
+        $accessToken = $this->getAccessToken();
+        $url = sprintf('%s/api/v1/jobs/%s', $this->baseUrl, $jobId);
+
+        try {
+            $response = $this->httpClient->request('POST', $url, [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $accessToken,
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => $jobPayload,
+            ]);
+
+            $statusCode = $response->getStatusCode();
+            $responseBody = json_decode($response->getBody()->getContents(), true);
+
+            if ($statusCode === 400 && ($responseBody['error'] ?? null) === 'Invalid request') {
+                throw new InvalidArgumentException(
+                    'TO API: request validation failed: ' . json_encode($responseBody)
+                );
+            }
+            if ($statusCode === 400 && ($responseBody['message'] ?? null) === 'Missing token') {
+                throw new RuntimeException('TO API: missing or invalid authorization token.');
+            }
+            if ($statusCode >= 400) {
+                throw new RuntimeException(sprintf(
+                    'TO API: unexpected HTTP %d: %s',
+                    $statusCode,
+                    json_encode($responseBody)
+                ));
+            }
+
+            return $responseBody;
+        } catch (GuzzleException $e) {
+            throw new RuntimeException(
+                'Task Orchestrator API communication error: ' . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+    }
+}

--- a/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
@@ -30,6 +30,11 @@ use RuntimeException;
 
 class TaskOrchestratorClient
 {
+    public const ENV_API_URL = 'TASK_ORCHESTRATOR_API_URL';
+    public const ENV_AUTH_SERVER_URI = 'TASK_ORCHESTRATOR_AUTH_SERVER_URI';
+    public const ENV_CLIENT_ID = 'TASK_ORCHESTRATOR_CLIENT_ID';
+    public const ENV_CLIENT_SECRET = 'TASK_ORCHESTRATOR_CLIENT_SECRET';
+
     private string $baseUrl;
     private string $authServerUri;
     private string $clientId;

--- a/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
@@ -51,10 +51,10 @@ class TaskOrchestratorClient
         GuzzleHttpClient $httpClient,
         ?CacheInterface $cache = null
     ) {
-        $this->baseUrl = $baseUrl;
-        $this->authServerUri = $authServerUri;
-        $this->clientId = $clientId;
-        $this->clientSecret = $clientSecret;
+        $this->baseUrl = trim($baseUrl);
+        $this->authServerUri = trim($authServerUri);
+        $this->clientId = trim($clientId);
+        $this->clientSecret = trim($clientSecret);
         $this->httpClient = $httpClient;
         $this->cache = $cache;
     }
@@ -65,10 +65,10 @@ class TaskOrchestratorClient
      */
     public function isConfigured(): bool
     {
-        return trim($this->baseUrl) !== ''
-            && trim($this->authServerUri) !== ''
-            && trim($this->clientId) !== ''
-            && trim($this->clientSecret) !== '';
+        return $this->baseUrl !== ''
+            && $this->authServerUri !== ''
+            && $this->clientId !== ''
+            && $this->clientSecret !== '';
     }
 
     private function getAccessToken(): string

--- a/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
@@ -59,6 +59,18 @@ class TaskOrchestratorClient
         $this->cache = $cache;
     }
 
+    /**
+     * True when API URL and OAuth credentials are all non-empty.
+     * Empty DI defaults keep boot safe; callers should hide mention UI when false.
+     */
+    public function isConfigured(): bool
+    {
+        return trim($this->baseUrl) !== ''
+            && trim($this->authServerUri) !== ''
+            && trim($this->clientId) !== ''
+            && trim($this->clientSecret) !== '';
+    }
+
     private function getAccessToken(): string
     {
         $cacheKey = 'task_orchestrator_access_token_' . md5($this->clientId);

--- a/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
@@ -123,19 +123,19 @@ class TaskOrchestratorClient
             $statusCode = $response->getStatusCode();
             $responseBody = json_decode($response->getBody()->getContents(), true);
 
+            // Exception messages must not include TO response bodies (may contain PII).
             if ($statusCode === 400 && ($responseBody['error'] ?? null) === 'Invalid request') {
                 throw new InvalidArgumentException(
-                    'TO API: request validation failed: ' . json_encode($responseBody)
+                    'TO API: request validation failed (HTTP 400)'
                 );
             }
             if ($statusCode === 400 && ($responseBody['message'] ?? null) === 'Missing token') {
-                throw new RuntimeException('TO API: missing or invalid authorization token.');
+                throw new RuntimeException('TO API: missing or invalid authorization token (HTTP 400)');
             }
             if ($statusCode >= 400) {
                 throw new RuntimeException(sprintf(
-                    'TO API: unexpected HTTP %d: %s',
-                    $statusCode,
-                    json_encode($responseBody)
+                    'TO API: unexpected HTTP %d',
+                    $statusCode
                 ));
             }
 

--- a/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorClient.php
@@ -116,6 +116,8 @@ class TaskOrchestratorClient
                     'Content-Type' => 'application/json',
                 ],
                 'json' => $jobPayload,
+                // Let status-code mapping below handle 4xx (e.g. InvalidArgumentException for validation).
+                'http_errors' => false,
             ]);
 
             $statusCode = $response->getStatusCode();

--- a/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\TaskOrchestrator;
+
+use InvalidArgumentException;
+use oat\generis\Helper\UuidPrimaryKeyTrait;
+
+class TaskOrchestratorEmailService
+{
+    use UuidPrimaryKeyTrait;
+
+    private TaskOrchestratorClient $client;
+    private string $tenantId;
+    private string $actorLogin;
+
+    public function __construct(
+        TaskOrchestratorClient $client,
+        string $tenantId,
+        string $actorLogin
+    ) {
+        $this->client = $client;
+        $this->tenantId = $tenantId;
+        $this->actorLogin = $actorLogin;
+    }
+
+    /**
+     * @param array<string, mixed> $templateData
+     * @param string|null $emailAddress When set, TO delivers to this address and skips portal-user lookup
+     */
+    public function sendEmail(
+        string $templateId,
+        string $recipientUserLogin,
+        array $templateData = [],
+        ?string $emailAddress = null
+    ): string {
+        $jobId = $this->getUniquePrimaryKey();
+
+        $email = [
+            'templateId' => $templateId,
+            'recipientUserLogin' => $recipientUserLogin,
+            'data' => $templateData,
+        ];
+
+        if ($emailAddress !== null) {
+            $emailAddress = trim($emailAddress);
+            if ($emailAddress === '' || !filter_var($emailAddress, FILTER_VALIDATE_EMAIL)) {
+                throw new InvalidArgumentException('emailAddress must be a valid email when provided');
+            }
+            $email['emailAddress'] = $emailAddress;
+        }
+
+        $jobPayload = [
+            'type' => 'portalEmailNotification',
+            'tenantId' => $this->tenantId,
+            'status' => 'initial',
+            'progress' => 0,
+            'user' => [
+                'id' => sprintf('%s_%s', $this->tenantId, $this->actorLogin),
+                'login' => $this->actorLogin,
+            ],
+            'email' => $email,
+            'meta' => [
+                'labelKey' => 'tao_backoffice_email',
+            ],
+        ];
+
+        $this->client->sendJob($jobId, $jobPayload);
+
+        return $jobId;
+    }
+}

--- a/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
@@ -53,6 +53,15 @@ class TaskOrchestratorEmailService
     }
 
     /**
+     * True when the client is configured and TENANT_ID is non-empty.
+     * Use to gate @mention UI; empty env defaults keep boot safe.
+     */
+    public function isConfigured(): bool
+    {
+        return $this->client->isConfigured() && trim($this->tenantId) !== '';
+    }
+
+    /**
      * @param array<string, mixed> $templateData
      * @param string|null $emailAddress When set, TO delivers to this address and skips portal-user lookup
      * @param string $actorLogin Job actor (who ordered the job) — TO schema user.login; user.id = {tenantId}_{login}
@@ -110,5 +119,25 @@ class TaskOrchestratorEmailService
         $this->client->sendJob($jobId, $jobPayload);
 
         return $jobId;
+    }
+
+    /**
+     * @param string $recipientUserLogin RDF / Backoffice login (correlation; still required by TO schema)
+     * @param string $emailAddress RDF PROPERTY_USER_MAIL — delivery address
+     * @param string $actorLogin Comment author login (job actor); user.id = {tenantId}_{login}
+     */
+    public function sendCommentMention(
+        string $recipientUserLogin,
+        string $emailAddress,
+        CommentMentionEmailTemplatePayload $payload,
+        string $actorLogin
+    ): string {
+        return $this->sendEmail(
+            CommentMentionEmailTemplatePayload::TEMPLATE_ID,
+            $recipientUserLogin,
+            $payload->toTemplateData(),
+            $emailAddress,
+            $actorLogin
+        );
     }
 }

--- a/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
@@ -31,28 +31,32 @@ class TaskOrchestratorEmailService
 
     private TaskOrchestratorClient $client;
     private string $tenantId;
-    private string $actorLogin;
 
     public function __construct(
         TaskOrchestratorClient $client,
-        string $tenantId,
-        string $actorLogin
+        string $tenantId
     ) {
         $this->client = $client;
         $this->tenantId = $tenantId;
-        $this->actorLogin = $actorLogin;
     }
 
     /**
      * @param array<string, mixed> $templateData
      * @param string|null $emailAddress When set, TO delivers to this address and skips portal-user lookup
+     * @param string $actorLogin Job actor (who ordered the job) — TO schema user.login; user.id = {tenantId}_{login}
      */
     public function sendEmail(
         string $templateId,
         string $recipientUserLogin,
         array $templateData = [],
-        ?string $emailAddress = null
+        ?string $emailAddress = null,
+        string $actorLogin = ''
     ): string {
+        $actorLogin = trim($actorLogin);
+        if ($actorLogin === '') {
+            throw new InvalidArgumentException('actorLogin is required for Task Orchestrator job user.login');
+        }
+
         $jobId = $this->getUniquePrimaryKey();
 
         $email = [
@@ -75,8 +79,9 @@ class TaskOrchestratorEmailService
             'status' => 'initial',
             'progress' => 0,
             'user' => [
-                'id' => sprintf('%s_%s', $this->tenantId, $this->actorLogin),
-                'login' => $this->actorLogin,
+                // TO convention: tenant-scoped actor id + plain login
+                'id' => sprintf('%s_%s', $this->tenantId, $actorLogin),
+                'login' => $actorLogin,
             ],
             'email' => $email,
             'meta' => [

--- a/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
@@ -44,6 +44,15 @@ class TaskOrchestratorEmailService
     }
 
     /**
+     * True when the client is configured and TENANT_ID is non-empty.
+     * Use to gate @mention UI; empty env defaults keep boot safe.
+     */
+    public function isConfigured(): bool
+    {
+        return $this->client->isConfigured() && trim($this->tenantId) !== '';
+    }
+
+    /**
      * @param array<string, mixed> $templateData
      * @param string|null $emailAddress When set, TO delivers to this address and skips portal-user lookup
      * @param string $actorLogin Job actor (who ordered the job) — TO schema user.login; user.id = {tenantId}_{login}
@@ -55,6 +64,12 @@ class TaskOrchestratorEmailService
         ?string $emailAddress = null,
         string $actorLogin = ''
     ): string {
+        if (!$this->isConfigured()) {
+            throw new InvalidArgumentException(
+                'Task Orchestrator email is not configured (missing API URL, OAuth credentials, or TENANT_ID)'
+            );
+        }
+
         $actorLogin = trim($actorLogin);
         if ($actorLogin === '') {
             throw new InvalidArgumentException('actorLogin is required for Task Orchestrator job user.login');

--- a/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
@@ -40,7 +40,7 @@ class TaskOrchestratorEmailService
         string $tenantId
     ) {
         $this->client = $client;
-        $this->tenantId = $tenantId;
+        $this->tenantId = trim($tenantId);
     }
 
     /**
@@ -49,7 +49,7 @@ class TaskOrchestratorEmailService
      */
     public function isConfigured(): bool
     {
-        return $this->client->isConfigured() && trim($this->tenantId) !== '';
+        return $this->client->isConfigured() && $this->tenantId !== '';
     }
 
     /**

--- a/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
@@ -29,6 +29,9 @@ class TaskOrchestratorEmailService
 {
     use UuidPrimaryKeyTrait;
 
+    /** NGS / Backoffice tenant id used as job `tenantId` (see docker/apps/tao/config.libsonnet). */
+    public const ENV_TENANT_ID = 'TENANT_ID';
+
     private TaskOrchestratorClient $client;
     private string $tenantId;
 

--- a/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
+++ b/models/classes/TaskOrchestrator/TaskOrchestratorEmailService.php
@@ -53,15 +53,6 @@ class TaskOrchestratorEmailService
     }
 
     /**
-     * True when the client is configured and TENANT_ID is non-empty.
-     * Use to gate @mention UI; empty env defaults keep boot safe.
-     */
-    public function isConfigured(): bool
-    {
-        return $this->client->isConfigured() && trim($this->tenantId) !== '';
-    }
-
-    /**
      * @param array<string, mixed> $templateData
      * @param string|null $emailAddress When set, TO delivers to this address and skips portal-user lookup
      * @param string $actorLogin Job actor (who ordered the job) — TO schema user.login; user.id = {tenantId}_{login}

--- a/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
+++ b/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
@@ -26,6 +26,9 @@ use oat\oatbox\service\ServiceManager;
 use oat\tao\model\infrastructure\DataAccess\SharedCache;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use GuzzleHttp\Client as GuzzleHttpClient;
+use oat\tao\model\TaskOrchestrator\TaskOrchestratorClient;
+use oat\tao\model\TaskOrchestrator\TaskOrchestratorEmailService;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -39,5 +42,26 @@ class InfrastructureServiceProvider implements ContainerServiceProviderInterface
             ->set(SharedCache::class, SharedCache::class)
             ->public()
             ->call('setServiceManager', [service(ServiceManager::class)]);
+
+        $services
+            ->set('GuzzleClientForTaskOrchestrator', GuzzleHttpClient::class)
+            ->public();
+
+        $services
+            ->set(TaskOrchestratorClient::class)
+            ->public()
+            ->arg('$baseUrl', (string) (getenv('TASK_ORCHESTRATOR_API_URL') ?: ''))
+            ->arg('$authServerUri', (string) (getenv('TASK_ORCHESTRATOR_AUTH_SERVER_URI') ?: ''))
+            ->arg('$clientId', (string) (getenv('TASK_ORCHESTRATOR_CLIENT_ID') ?: ''))
+            ->arg('$clientSecret', (string) (getenv('TASK_ORCHESTRATOR_CLIENT_SECRET') ?: ''))
+            ->arg('$httpClient', service('GuzzleClientForTaskOrchestrator'))
+            ->arg('$cache', null);
+
+        $services
+            ->set(TaskOrchestratorEmailService::class)
+            ->public()
+            ->arg('$client', service(TaskOrchestratorClient::class))
+            ->arg('$tenantId', (string) (getenv('TAO_TENANT_ID') ?: ''))
+            ->arg('$actorLogin', (string) (getenv('TAO_TASK_ORCHESTRATOR_ACTOR_LOGIN') ?: ''));
     }
 }

--- a/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
+++ b/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
@@ -97,7 +97,7 @@ class InfrastructureServiceProvider implements ContainerServiceProviderInterface
                     ->string()
             )
             ->arg('$httpClient', service('GuzzleClientForTaskOrchestrator'))
-            ->arg('$cache', null);
+            ->arg('$cache', service(SharedCache::class));
 
         $services
             ->set(TaskOrchestratorEmailService::class)

--- a/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
+++ b/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
@@ -61,7 +61,6 @@ class InfrastructureServiceProvider implements ContainerServiceProviderInterface
             ->set(TaskOrchestratorEmailService::class)
             ->public()
             ->arg('$client', service(TaskOrchestratorClient::class))
-            ->arg('$tenantId', (string) (getenv('TAO_TENANT_ID') ?: ''))
-            ->arg('$actorLogin', (string) (getenv('TAO_TASK_ORCHESTRATOR_ACTOR_LOGIN') ?: ''));
+            ->arg('$tenantId', (string) (getenv('TENANT_ID') ?: ''));
     }
 }

--- a/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
+++ b/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
@@ -13,9 +13,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
- * Copyright (c) 2021-2023 (update and modification) Open Assessment Technologies SA;
+ * Copyright (c) 2021-2026 (update and modification) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -30,13 +30,31 @@ use GuzzleHttp\Client as GuzzleHttpClient;
 use oat\tao\model\TaskOrchestrator\TaskOrchestratorClient;
 use oat\tao\model\TaskOrchestrator\TaskOrchestratorEmailService;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 class InfrastructureServiceProvider implements ContainerServiceProviderInterface
 {
+    /**
+     * Empty-string defaults for Symfony env()->default() (parameter name, not literal).
+     * NGS sets real values via docker/apps/tao/config.libsonnet.
+     */
+    private const PARAM_TASK_ORCHESTRATOR_API_URL_DEFAULT = 'TASK_ORCHESTRATOR_API_URL_DEFAULT';
+    private const PARAM_TASK_ORCHESTRATOR_AUTH_SERVER_URI_DEFAULT = 'TASK_ORCHESTRATOR_AUTH_SERVER_URI_DEFAULT';
+    private const PARAM_TASK_ORCHESTRATOR_CLIENT_ID_DEFAULT = 'TASK_ORCHESTRATOR_CLIENT_ID_DEFAULT';
+    private const PARAM_TASK_ORCHESTRATOR_CLIENT_SECRET_DEFAULT = 'TASK_ORCHESTRATOR_CLIENT_SECRET_DEFAULT';
+    private const PARAM_TENANT_ID_DEFAULT = 'TENANT_ID_DEFAULT';
+
     public function __invoke(ContainerConfigurator $configurator): void
     {
         $services = $configurator->services();
+        $parameters = $configurator->parameters();
+
+        $parameters->set(self::PARAM_TASK_ORCHESTRATOR_API_URL_DEFAULT, '');
+        $parameters->set(self::PARAM_TASK_ORCHESTRATOR_AUTH_SERVER_URI_DEFAULT, '');
+        $parameters->set(self::PARAM_TASK_ORCHESTRATOR_CLIENT_ID_DEFAULT, '');
+        $parameters->set(self::PARAM_TASK_ORCHESTRATOR_CLIENT_SECRET_DEFAULT, '');
+        $parameters->set(self::PARAM_TENANT_ID_DEFAULT, '');
 
         $services
             ->set(SharedCache::class, SharedCache::class)
@@ -54,10 +72,30 @@ class InfrastructureServiceProvider implements ContainerServiceProviderInterface
         $services
             ->set(TaskOrchestratorClient::class)
             ->public()
-            ->arg('$baseUrl', (string) (getenv('TASK_ORCHESTRATOR_API_URL') ?: ''))
-            ->arg('$authServerUri', (string) (getenv('TASK_ORCHESTRATOR_AUTH_SERVER_URI') ?: ''))
-            ->arg('$clientId', (string) (getenv('TASK_ORCHESTRATOR_CLIENT_ID') ?: ''))
-            ->arg('$clientSecret', (string) (getenv('TASK_ORCHESTRATOR_CLIENT_SECRET') ?: ''))
+            ->arg(
+                '$baseUrl',
+                env(TaskOrchestratorClient::ENV_API_URL)
+                    ->default(self::PARAM_TASK_ORCHESTRATOR_API_URL_DEFAULT)
+                    ->string()
+            )
+            ->arg(
+                '$authServerUri',
+                env(TaskOrchestratorClient::ENV_AUTH_SERVER_URI)
+                    ->default(self::PARAM_TASK_ORCHESTRATOR_AUTH_SERVER_URI_DEFAULT)
+                    ->string()
+            )
+            ->arg(
+                '$clientId',
+                env(TaskOrchestratorClient::ENV_CLIENT_ID)
+                    ->default(self::PARAM_TASK_ORCHESTRATOR_CLIENT_ID_DEFAULT)
+                    ->string()
+            )
+            ->arg(
+                '$clientSecret',
+                env(TaskOrchestratorClient::ENV_CLIENT_SECRET)
+                    ->default(self::PARAM_TASK_ORCHESTRATOR_CLIENT_SECRET_DEFAULT)
+                    ->string()
+            )
             ->arg('$httpClient', service('GuzzleClientForTaskOrchestrator'))
             ->arg('$cache', null);
 
@@ -65,6 +103,11 @@ class InfrastructureServiceProvider implements ContainerServiceProviderInterface
             ->set(TaskOrchestratorEmailService::class)
             ->public()
             ->arg('$client', service(TaskOrchestratorClient::class))
-            ->arg('$tenantId', (string) (getenv('TENANT_ID') ?: ''));
+            ->arg(
+                '$tenantId',
+                env(TaskOrchestratorEmailService::ENV_TENANT_ID)
+                    ->default(self::PARAM_TENANT_ID_DEFAULT)
+                    ->string()
+            );
     }
 }

--- a/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
+++ b/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
@@ -45,7 +45,11 @@ class InfrastructureServiceProvider implements ContainerServiceProviderInterface
 
         $services
             ->set('GuzzleClientForTaskOrchestrator', GuzzleHttpClient::class)
-            ->public();
+            ->public()
+            ->args([[
+                'timeout' => 30.0,
+                'connect_timeout' => 5.0,
+            ]]);
 
         $services
             ->set(TaskOrchestratorClient::class)

--- a/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
+++ b/models/classes/infrastructure/ServiceProvider/InfrastructureServiceProvider.php
@@ -29,6 +29,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use GuzzleHttp\Client as GuzzleHttpClient;
 use oat\tao\model\TaskOrchestrator\TaskOrchestratorClient;
 use oat\tao\model\TaskOrchestrator\TaskOrchestratorEmailService;
+use oat\tao\model\TaskOrchestrator\CommentMentionDeepLinkBuilder;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -109,5 +110,9 @@ class InfrastructureServiceProvider implements ContainerServiceProviderInterface
                     ->default(self::PARAM_TENANT_ID_DEFAULT)
                     ->string()
             );
+
+        $services
+            ->set(CommentMentionDeepLinkBuilder::class)
+            ->public();
     }
 }

--- a/models/classes/user/CommentMentionUserSearchService.php
+++ b/models/classes/user/CommentMentionUserSearchService.php
@@ -1,0 +1,354 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\user;
+
+use common_exception_Unauthorized;
+use core_kernel_classes_Container;
+use core_kernel_classes_Literal;
+use core_kernel_classes_Resource;
+use InvalidArgumentException;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\GenerisRdf;
+use oat\generis\model\OntologyRdfs;
+use oat\tao\model\accessControl\PermissionCheckerInterface;
+use oat\tao\model\TaskOrchestrator\TaskOrchestratorEmailService;
+use tao_models_classes_UserService;
+
+/**
+ * Search users for comment @mentions (login OR display name).
+ * Eligibility scope comes from MentionEligibleUsersProviderInterface.
+ *
+ * Contract is autocomplete top-N, not a paginated catalog: response has
+ * `users` + echoed `limit` only (no `total` / `offset`). Open / large-eligible
+ * mode scans at most CANDIDATE_BATCH name matches from UserService.
+ */
+class CommentMentionUserSearchService
+{
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 50;
+    private const CANDIDATE_BATCH = 100;
+    private const IN_MEMORY_ELIGIBLE_THRESHOLD = 200;
+
+    /**
+     * Authoring resource types accepted by the mention search API.
+     *
+     * @var list<string>
+     */
+    private const RESOURCE_TYPES = ['item', 'test', 'asset'];
+
+    private Ontology $ontology;
+    private PermissionCheckerInterface $permissionChecker;
+    private tao_models_classes_UserService $userService;
+    private MentionEligibleUsersProviderInterface $eligibleUsersProvider;
+    private TaskOrchestratorEmailService $emailService;
+
+    public function __construct(
+        Ontology $ontology,
+        PermissionCheckerInterface $permissionChecker,
+        tao_models_classes_UserService $userService,
+        MentionEligibleUsersProviderInterface $eligibleUsersProvider,
+        TaskOrchestratorEmailService $emailService
+    ) {
+        $this->ontology = $ontology;
+        $this->permissionChecker = $permissionChecker;
+        $this->userService = $userService;
+        $this->eligibleUsersProvider = $eligibleUsersProvider;
+        $this->emailService = $emailService;
+    }
+
+    /**
+     * @return array{
+     *     users: array<int, array{id: string, login: string, displayName: string}>,
+     *     limit: int
+     * }
+     */
+    public function search(
+        string $resourceUri,
+        string $resourceType,
+        string $query,
+        int $limit = self::DEFAULT_LIMIT
+    ): array {
+        $resourceUri = trim($resourceUri);
+        $this->assertValidResourceType(trim($resourceType));
+        $query = trim($query);
+
+        if ($resourceUri === '') {
+            throw new InvalidArgumentException('resourceUri is required');
+        }
+
+        $limit = max(1, min($limit, self::MAX_LIMIT));
+
+        if (!$this->emailService->isConfigured()) {
+            return [
+                'users' => [],
+                'limit' => $limit,
+            ];
+        }
+
+        if (!$this->permissionChecker->hasReadAccess($resourceUri)) {
+            throw new common_exception_Unauthorized('Read access required to mention users on this resource');
+        }
+
+        $eligibleUris = $this->eligibleUsersProvider->getEligibleUserUris($resourceUri);
+
+        if (is_array($eligibleUris) && $eligibleUris === []) {
+            return $this->emptyResult($limit);
+        }
+
+        if (is_array($eligibleUris) && count($eligibleUris) <= self::IN_MEMORY_ELIGIBLE_THRESHOLD) {
+            $matched = $this->matchFromEligibleSet($eligibleUris, $query);
+        } else {
+            $matched = $this->matchFromUserSearch($query, $eligibleUris);
+        }
+
+        usort(
+            $matched,
+            static function (array $left, array $right): int {
+                return strcasecmp($left['login'], $right['login']);
+            }
+        );
+
+        return [
+            'users' => array_values(array_slice($matched, 0, $limit)),
+            'limit' => $limit,
+        ];
+    }
+
+    private function assertValidResourceType(string $resourceType): string
+    {
+        if (!in_array($resourceType, self::RESOURCE_TYPES, true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'resourceType must be one of: %s',
+                    implode(', ', self::RESOURCE_TYPES)
+                )
+            );
+        }
+
+        return $resourceType;
+    }
+
+    /**
+     * @param list<string> $eligibleUris
+     * @return list<array{id: string, login: string, displayName: string}>
+     */
+    private function matchFromEligibleSet(array $eligibleUris, string $query): array
+    {
+        $matched = [];
+
+        foreach ($eligibleUris as $userUri) {
+            $userResource = $this->ontology->getResource($userUri);
+            if (!$userResource->exists()) {
+                continue;
+            }
+
+            $row = $this->mapUserRow($userResource);
+            if ($row === null) {
+                continue;
+            }
+
+            if ($query !== '' && !$this->matchesQuery($row, $query)) {
+                continue;
+            }
+
+            $matched[] = $row;
+        }
+
+        return $matched;
+    }
+
+    /**
+     * @param list<string>|null $eligibleUris null = unrestricted
+     * @return list<array{id: string, login: string, displayName: string}>
+     */
+    private function matchFromUserSearch(string $query, ?array $eligibleUris): array
+    {
+        $eligibleSet = $eligibleUris === null ? null : array_fill_keys($eligibleUris, true);
+        $candidates = $this->userService->getAllUsers(
+            [
+                'recursive' => true,
+                'like' => true,
+                'chaining' => 'or',
+                'limit' => self::CANDIDATE_BATCH,
+                'offset' => 0,
+                'order' => GenerisRdf::PROPERTY_USER_LOGIN,
+            ],
+            $this->buildNameFilters($query)
+        );
+
+        $matched = [];
+        foreach ($candidates as $userResource) {
+            if (!$userResource instanceof core_kernel_classes_Resource) {
+                continue;
+            }
+
+            if ($eligibleSet !== null && !isset($eligibleSet[$userResource->getUri()])) {
+                continue;
+            }
+
+            $row = $this->mapUserRow($userResource);
+            if ($row === null) {
+                continue;
+            }
+
+            if ($query !== '' && !$this->matchesQuery($row, $query)) {
+                continue;
+            }
+
+            $matched[] = $row;
+        }
+
+        return $matched;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildNameFilters(string $query): array
+    {
+        if ($query === '') {
+            return [
+                GenerisRdf::PROPERTY_USER_LOGIN => '*',
+            ];
+        }
+
+        return [
+            GenerisRdf::PROPERTY_USER_LOGIN => $query,
+            OntologyRdfs::RDFS_LABEL => $query,
+            GenerisRdf::PROPERTY_USER_FIRSTNAME => $query,
+            GenerisRdf::PROPERTY_USER_LASTNAME => $query,
+        ];
+    }
+
+    /**
+     * @param array{id: string, login: string, displayName: string} $row
+     */
+    private function matchesQuery(array $row, string $query): bool
+    {
+        return stripos($row['login'], $query) !== false
+            || stripos($row['displayName'], $query) !== false;
+    }
+
+    /**
+     * @return array{id: string, login: string, displayName: string}|null
+     */
+    private function mapUserRow(core_kernel_classes_Resource $userResource): ?array
+    {
+        $login = $this->resolveLogin($userResource);
+        if ($login === null) {
+            return null;
+        }
+
+        if (!$this->hasValidEmail($userResource)) {
+            return null;
+        }
+
+        return [
+            'id' => $userResource->getUri(),
+            'login' => $login,
+            'displayName' => $this->resolveDisplayName($userResource, $login),
+        ];
+    }
+
+    private function resolveLogin(core_kernel_classes_Resource $userResource): ?string
+    {
+        $login = $this->propertyValueAsString(
+            $userResource->getOnePropertyValue(
+                $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_LOGIN)
+            )
+        );
+
+        return $login !== '' ? $login : null;
+    }
+
+    /**
+     * Mention candidates must have a usable account email (same rule as notification send).
+     */
+    private function hasValidEmail(core_kernel_classes_Resource $userResource): bool
+    {
+        $email = $this->propertyValueAsString(
+            $userResource->getOnePropertyValue(
+                $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_MAIL)
+            )
+        );
+
+        return $email !== '' && filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+    }
+
+    /**
+     * Same semantics as UserHelper::getUserName($user, true): first+last, else label, else login.
+     */
+    private function resolveDisplayName(core_kernel_classes_Resource $userResource, string $login): string
+    {
+        $firstName = $this->propertyValueAsString(
+            $userResource->getOnePropertyValue(
+                $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_FIRSTNAME)
+            )
+        );
+        $lastName = $this->propertyValueAsString(
+            $userResource->getOnePropertyValue(
+                $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_LASTNAME)
+            )
+        );
+        $displayName = trim($firstName . ' ' . $lastName);
+
+        if ($displayName === '') {
+            $displayName = $this->propertyValueAsString(
+                $userResource->getOnePropertyValue(
+                    $this->ontology->getProperty(OntologyRdfs::RDFS_LABEL)
+                )
+            );
+        }
+
+        return $displayName !== '' ? $displayName : $login;
+    }
+
+    /**
+     * Safely stringify ontology property values for PHPStan (cast.string).
+     *
+     * getOnePropertyValue() is typed as Container|null; only Literal/Resource are usable.
+     */
+    private function propertyValueAsString(?core_kernel_classes_Container $value): string
+    {
+        if ($value instanceof core_kernel_classes_Literal) {
+            return trim((string) $value->literal);
+        }
+
+        if ($value instanceof core_kernel_classes_Resource) {
+            return trim($value->getLabel());
+        }
+
+        return '';
+    }
+
+    /**
+     * @return array{users: array{}, limit: int}
+     */
+    private function emptyResult(int $limit): array
+    {
+        return [
+            'users' => [],
+            'limit' => $limit,
+        ];
+    }
+}

--- a/models/classes/user/CommentMentionUserSearchService.php
+++ b/models/classes/user/CommentMentionUserSearchService.php
@@ -250,83 +250,69 @@ class CommentMentionUserSearchService
     }
 
     /**
+     * Batch-load login/mail/name/label in one persistence round-trip per user.
+     *
      * @return array{id: string, login: string, displayName: string}|null
      */
     private function mapUserRow(core_kernel_classes_Resource $userResource): ?array
     {
-        $login = $this->resolveLogin($userResource);
-        if ($login === null) {
+        $properties = $userResource->getPropertiesValues([
+            $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_LOGIN),
+            $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_MAIL),
+            $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_FIRSTNAME),
+            $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_LASTNAME),
+            $this->ontology->getProperty(OntologyRdfs::RDFS_LABEL),
+        ]);
+
+        $login = $this->firstPropertyValueAsString($properties, GenerisRdf::PROPERTY_USER_LOGIN);
+        if ($login === '') {
             return null;
         }
 
-        if (!$this->hasValidEmail($userResource)) {
+        // Mention candidates must have a usable account email (same rule as notification send).
+        $email = $this->firstPropertyValueAsString($properties, GenerisRdf::PROPERTY_USER_MAIL);
+        if ($email === '' || filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
             return null;
+        }
+
+        // Same semantics as UserHelper::getUserName($user, true): first+last, else label, else login.
+        $displayName = trim(
+            $this->firstPropertyValueAsString($properties, GenerisRdf::PROPERTY_USER_FIRSTNAME)
+            . ' '
+            . $this->firstPropertyValueAsString($properties, GenerisRdf::PROPERTY_USER_LASTNAME)
+        );
+
+        if ($displayName === '') {
+            $displayName = $this->firstPropertyValueAsString($properties, OntologyRdfs::RDFS_LABEL);
         }
 
         return [
             'id' => $userResource->getUri(),
             'login' => $login,
-            'displayName' => $this->resolveDisplayName($userResource, $login),
+            'displayName' => $displayName !== '' ? $displayName : $login,
         ];
     }
 
-    private function resolveLogin(core_kernel_classes_Resource $userResource): ?string
-    {
-        $login = $this->propertyValueAsString(
-            $userResource->getOnePropertyValue(
-                $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_LOGIN)
-            )
-        );
-
-        return $login !== '' ? $login : null;
-    }
-
     /**
-     * Mention candidates must have a usable account email (same rule as notification send).
+     * @param array<string, list<core_kernel_classes_Container|null>> $properties
      */
-    private function hasValidEmail(core_kernel_classes_Resource $userResource): bool
+    private function firstPropertyValueAsString(array $properties, string $propertyUri): string
     {
-        $email = $this->propertyValueAsString(
-            $userResource->getOnePropertyValue(
-                $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_MAIL)
-            )
-        );
-
-        return $email !== '' && filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
-    }
-
-    /**
-     * Same semantics as UserHelper::getUserName($user, true): first+last, else label, else login.
-     */
-    private function resolveDisplayName(core_kernel_classes_Resource $userResource, string $login): string
-    {
-        $firstName = $this->propertyValueAsString(
-            $userResource->getOnePropertyValue(
-                $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_FIRSTNAME)
-            )
-        );
-        $lastName = $this->propertyValueAsString(
-            $userResource->getOnePropertyValue(
-                $this->ontology->getProperty(GenerisRdf::PROPERTY_USER_LASTNAME)
-            )
-        );
-        $displayName = trim($firstName . ' ' . $lastName);
-
-        if ($displayName === '') {
-            $displayName = $this->propertyValueAsString(
-                $userResource->getOnePropertyValue(
-                    $this->ontology->getProperty(OntologyRdfs::RDFS_LABEL)
-                )
-            );
+        if (empty($properties[$propertyUri])) {
+            return '';
         }
 
-        return $displayName !== '' ? $displayName : $login;
+        $value = current($properties[$propertyUri]);
+
+        return $value instanceof core_kernel_classes_Container
+            ? $this->propertyValueAsString($value)
+            : '';
     }
 
     /**
      * Safely stringify ontology property values for PHPStan (cast.string).
      *
-     * getOnePropertyValue() is typed as Container|null; only Literal/Resource are usable.
+     * Property values are typed as Container|null; only Literal/Resource are usable.
      */
     private function propertyValueAsString(?core_kernel_classes_Container $value): string
     {

--- a/models/classes/user/MentionEligibleUsersProviderInterface.php
+++ b/models/classes/user/MentionEligibleUsersProviderInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\user;
+
+/**
+ * Provides the set of users that may be @mentioned on a resource.
+ *
+ * Default (open) implementation returns null = no restriction.
+ * ACL extensions (e.g. taoDacSimple) may override the DI binding.
+ */
+interface MentionEligibleUsersProviderInterface
+{
+    /**
+     * @return list<string>|null null = unrestricted; list = eligible user URIs
+     */
+    public function getEligibleUserUris(string $resourceUri): ?array;
+}

--- a/models/classes/user/OpenMentionEligibleUsersProvider.php
+++ b/models/classes/user/OpenMentionEligibleUsersProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\model\user;
+
+/**
+ * Default (open) mention eligibility: no ACL restriction on candidates.
+ *
+ * Null Object for {@see MentionEligibleUsersProviderInterface} so the platform can
+ * bind the interface without depending on taoDacSimple. Returns null = unrestricted.
+ * When DAC is installed, taoDacSimple rebinds the interface alias to
+ * DacMentionEligibleUsersProvider.
+ */
+final class OpenMentionEligibleUsersProvider implements MentionEligibleUsersProviderInterface
+{
+    public function getEligibleUserUris(string $resourceUri): ?array
+    {
+        return null;
+    }
+}

--- a/models/classes/user/UserSettingsServiceProvider.php
+++ b/models/classes/user/UserSettingsServiceProvider.php
@@ -25,7 +25,9 @@ namespace oat\tao\model\user;
 use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\oatbox\user\UserTimezoneServiceInterface;
+use oat\tao\model\accessControl\PermissionChecker;
 use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\TaskOrchestrator\TaskOrchestratorEmailService;
 use oat\tao\model\user\implementation\UserSettingsService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use tao_models_classes_LanguageService;
@@ -59,5 +61,24 @@ class UserSettingsServiceProvider implements ContainerServiceProviderInterface
                     service(tao_models_classes_LanguageService::class),
                 ]
             );
+
+        $services
+            ->set(OpenMentionEligibleUsersProvider::class, OpenMentionEligibleUsersProvider::class)
+            ->public();
+
+        $services
+            ->alias(MentionEligibleUsersProviderInterface::class, OpenMentionEligibleUsersProvider::class)
+            ->public();
+
+        $services
+            ->set(CommentMentionUserSearchService::class, CommentMentionUserSearchService::class)
+            ->public()
+            ->args([
+                service(Ontology::SERVICE_ID),
+                service(PermissionChecker::class),
+                service(tao_models_classes_UserService::SERVICE_ID),
+                service(MentionEligibleUsersProviderInterface::class),
+                service(TaskOrchestratorEmailService::class),
+            ]);
     }
 }

--- a/test/unit/model/TaskOrchestrator/CommentMentionDeepLinkBuilderTest.php
+++ b/test/unit/model/TaskOrchestrator/CommentMentionDeepLinkBuilderTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\model\TaskOrchestrator;
+
+use InvalidArgumentException;
+use oat\tao\model\menu\Perspective;
+use oat\tao\model\menu\Section;
+use oat\tao\model\menu\Tree;
+use oat\tao\model\TaskOrchestrator\CommentMentionDeepLinkBuilder;
+use oat\tao\model\TaoOntology;
+use PHPUnit\Framework\TestCase;
+
+class CommentMentionDeepLinkBuilderTest extends TestCase
+{
+    private const CLASS_URI_ASSET = 'http://www.tao.lu/Ontologies/TAOMedia.rdf#Media';
+
+    private CommentMentionDeepLinkBuilder $sut;
+
+    protected function setUp(): void
+    {
+        $this->sut = new CommentMentionDeepLinkBuilder(
+            'https://backoffice.ngs.test',
+            [
+                $this->perspective('items', 'taoItems', 'manage_items', TaoOntology::CLASS_URI_ITEM),
+                $this->perspective('tests', 'taoTests', 'manage_tests', TaoOntology::CLASS_URI_TEST),
+                $this->perspective(
+                    'taoMediaManager',
+                    'taoMediaManager',
+                    'media_manager',
+                    self::CLASS_URI_ASSET
+                ),
+            ]
+        );
+    }
+
+    public function testBuildItemDeepLinkMatchesBackofficeShape(): void
+    {
+        $uri = 'https://backoffice.ngs.test/ontologies/tao.rdf#i6a96e3923cff32026090116391476b0b622';
+
+        $url = $this->sut->build(TaoOntology::CLASS_URI_ITEM, $uri);
+
+        $this->assertSame(
+            'https://backoffice.ngs.test/tao/Main/index'
+            . '?structure=items'
+            . '&ext=taoItems'
+            . '&section=manage_items'
+            . '&uri=' . rawurlencode($uri),
+            $url
+        );
+    }
+
+    public function testBuildResolvesTestAndAssetByRootClass(): void
+    {
+        $uri = 'https://backoffice.ngs.test/ontologies/tao.rdf#iTEST';
+
+        $testUrl = $this->sut->build(TaoOntology::CLASS_URI_TEST, $uri);
+        $assetUrl = $this->sut->build(self::CLASS_URI_ASSET, $uri);
+
+        $this->assertStringContainsString('structure=tests', $testUrl);
+        $this->assertStringContainsString('ext=taoTests', $testUrl);
+        $this->assertStringContainsString('section=manage_tests', $testUrl);
+
+        $this->assertStringContainsString('structure=taoMediaManager', $assetUrl);
+        $this->assertStringContainsString('ext=taoMediaManager', $assetUrl);
+        $this->assertStringContainsString('section=media_manager', $assetUrl);
+    }
+
+    public function testRejectsUnknownRootClass(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No backoffice structure/section found');
+
+        $this->sut->build('http://example.test/Unknown#Class', 'https://example/rdf#i1');
+    }
+
+    public function testRejectsEmptyRootClassUri(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->sut->build('  ', 'https://example/rdf#i1');
+    }
+
+    public function testRejectsEmptyResourceUri(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Resource URI is required to build comment-mention deep link');
+
+        $this->sut->build(TaoOntology::CLASS_URI_ITEM, '  ');
+    }
+
+    private function perspective(
+        string $id,
+        string $ext,
+        string $sectionId,
+        string $rootNode
+    ): Perspective {
+        $tree = new Tree(['rootNode' => $rootNode, 'name' => 'tree']);
+        $section = new Section(
+            [
+                'id' => $sectionId,
+                'name' => $sectionId,
+                'url' => '/',
+                'extension' => $ext,
+                'controller' => 'X',
+                'action' => 'index',
+                'binding' => null,
+                'policy' => Section::POLICY_MERGE,
+                'disabled' => false,
+            ],
+            [$tree],
+            []
+        );
+
+        return new Perspective(
+            [
+                'id' => $id,
+                'extension' => $ext,
+                'name' => $id,
+                'group' => Perspective::GROUP_DEFAULT,
+                'level' => '0',
+                'description' => '',
+                'binding' => null,
+                'icon' => null,
+            ],
+            [$section]
+        );
+    }
+}

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
@@ -107,4 +107,92 @@ class TaskOrchestratorClientTest extends TestCase
             $this->assertStringNotContainsString('bob@example.test', $exception->getMessage());
         }
     }
+
+    public function testSendJobReturnsDecodedBodyOnSuccess(): void
+    {
+        $successBody = ['status' => 'ok', 'id' => 'job-1'];
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                'http://to.example/api/v1/jobs/job-1',
+                $this->callback(static function (array $options): bool {
+                    return ($options['http_errors'] ?? true) === false
+                        && ($options['headers']['Authorization'] ?? null) === 'Bearer cached-access-token';
+                })
+            )
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($successBody)));
+
+        $result = $this->sut->sendJob('job-1', ['type' => 'portalEmailNotification']);
+
+        $this->assertSame($successBody, $result);
+    }
+
+    public function testSendJobFetchesAccessTokenWhenCacheMisses(): void
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache
+            ->expects($this->once())
+            ->method('get')
+            ->with('task_orchestrator_access_token_' . md5('client-id'))
+            ->willReturn(null);
+        $cache
+            ->expects($this->once())
+            ->method('set')
+            ->with(
+                'task_orchestrator_access_token_' . md5('client-id'),
+                'fresh-token',
+                3540
+            );
+
+        $httpClient = $this->createMock(GuzzleHttpClient::class);
+        $httpClient
+            ->expects($this->exactly(2))
+            ->method('request')
+            ->willReturnCallback(function (string $method, string $url, array $options = []): Response {
+                $this->assertSame('POST', $method);
+
+                if ($url === 'http://auth.example/v1/oauth2/tokens') {
+                    $this->assertSame(
+                        [
+                            'grant_type' => 'client_credentials',
+                            'client_id' => 'client-id',
+                            'client_secret' => 'client-secret',
+                        ],
+                        $options['json'] ?? null
+                    );
+
+                    return new Response(
+                        200,
+                        ['Content-Type' => 'application/json'],
+                        json_encode(['access_token' => 'fresh-token', 'expires_in' => 3600])
+                    );
+                }
+
+                $this->assertSame('http://to.example/api/v1/jobs/job-2', $url);
+                $this->assertSame('Bearer fresh-token', $options['headers']['Authorization'] ?? null);
+                $this->assertFalse($options['http_errors'] ?? true);
+
+                return new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['status' => 'accepted'])
+                );
+            });
+
+        $sut = new TaskOrchestratorClient(
+            'http://to.example',
+            'http://auth.example',
+            'client-id',
+            'client-secret',
+            $httpClient,
+            $cache
+        );
+
+        $result = $sut->sendJob('job-2', ['type' => 'portalEmailNotification']);
+
+        $this->assertSame(['status' => 'accepted'], $result);
+    }
 }

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
@@ -72,6 +72,33 @@ class TaskOrchestratorClientTest extends TestCase
         $this->assertFalse($empty->isConfigured());
     }
 
+    public function testConstructorTrimsConfigurationValues(): void
+    {
+        $sut = new TaskOrchestratorClient(
+            '  http://to.example  ',
+            "\thttp://auth.example\n",
+            '  client-id  ',
+            '  client-secret  ',
+            $this->httpClient,
+            $this->cache
+        );
+        $this->assertTrue($sut->isConfigured());
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                'http://to.example/api/v1/jobs/job-1',
+                $this->callback(static function (array $options): bool {
+                    return ($options['headers']['Authorization'] ?? null) === 'Bearer cached-access-token';
+                })
+            )
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], '{"ok":true}'));
+
+        $this->assertSame(['ok' => true], $sut->sendJob('job-1', ['type' => 'portalEmailNotification']));
+    }
+
     public function testSendJobMapsInvalidRequest400ToInvalidArgumentException(): void
     {
         $errorBody = [

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\model\TaskOrchestrator;
+
+use GuzzleHttp\Client as GuzzleHttpClient;
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use oat\tao\model\TaskOrchestrator\TaskOrchestratorClient;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
+
+class TaskOrchestratorClientTest extends TestCase
+{
+    /** @var GuzzleHttpClient&MockObject */
+    private GuzzleHttpClient $httpClient;
+
+    /** @var CacheInterface&MockObject */
+    private CacheInterface $cache;
+
+    private TaskOrchestratorClient $sut;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(GuzzleHttpClient::class);
+        $this->cache = $this->createMock(CacheInterface::class);
+        $this->cache->method('get')->willReturn('cached-access-token');
+
+        $this->sut = new TaskOrchestratorClient(
+            'http://to.example',
+            'http://auth.example',
+            'client-id',
+            'client-secret',
+            $this->httpClient,
+            $this->cache
+        );
+    }
+
+    public function testSendJobMapsInvalidRequest400ToInvalidArgumentException(): void
+    {
+        $errorBody = ['error' => 'Invalid request', 'details' => ['field' => 'email']];
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->with(
+                'POST',
+                'http://to.example/api/v1/jobs/job-1',
+                $this->callback(static function (array $options): bool {
+                    return ($options['http_errors'] ?? true) === false
+                        && ($options['headers']['Authorization'] ?? null) === 'Bearer cached-access-token';
+                })
+            )
+            ->willReturn(new Response(400, ['Content-Type' => 'application/json'], json_encode($errorBody)));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('TO API: request validation failed:');
+
+        $this->sut->sendJob('job-1', ['type' => 'portalEmailNotification']);
+    }
+}

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
@@ -57,6 +57,21 @@ class TaskOrchestratorClientTest extends TestCase
         );
     }
 
+    public function testIsConfiguredRequiresAllCredentials(): void
+    {
+        $this->assertTrue($this->sut->isConfigured());
+
+        $empty = new TaskOrchestratorClient(
+            '',
+            'http://auth.example',
+            'client-id',
+            'client-secret',
+            $this->httpClient,
+            $this->cache
+        );
+        $this->assertFalse($empty->isConfigured());
+    }
+
     public function testSendJobMapsInvalidRequest400ToInvalidArgumentException(): void
     {
         $errorBody = [

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorClientTest.php
@@ -29,6 +29,7 @@ use oat\tao\model\TaskOrchestrator\TaskOrchestratorClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
+use RuntimeException;
 
 class TaskOrchestratorClientTest extends TestCase
 {
@@ -58,7 +59,10 @@ class TaskOrchestratorClientTest extends TestCase
 
     public function testSendJobMapsInvalidRequest400ToInvalidArgumentException(): void
     {
-        $errorBody = ['error' => 'Invalid request', 'details' => ['field' => 'email']];
+        $errorBody = [
+            'error' => 'Invalid request',
+            'details' => ['email' => 'alice@example.test', 'actorLogin' => 'alice'],
+        ];
 
         $this->httpClient
             ->expects($this->once())
@@ -73,9 +77,34 @@ class TaskOrchestratorClientTest extends TestCase
             )
             ->willReturn(new Response(400, ['Content-Type' => 'application/json'], json_encode($errorBody)));
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('TO API: request validation failed:');
+        try {
+            $this->sut->sendJob('job-1', ['type' => 'portalEmailNotification']);
+            $this->fail('Expected InvalidArgumentException');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('TO API: request validation failed (HTTP 400)', $exception->getMessage());
+            $this->assertStringNotContainsString('alice@example.test', $exception->getMessage());
+            $this->assertStringNotContainsString('alice', $exception->getMessage());
+        }
+    }
 
-        $this->sut->sendJob('job-1', ['type' => 'portalEmailNotification']);
+    public function testSendJobMapsUnexpected4xxWithoutResponseBodyInMessage(): void
+    {
+        $errorBody = [
+            'error' => 'Forbidden',
+            'recipient' => 'bob@example.test',
+        ];
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('request')
+            ->willReturn(new Response(403, ['Content-Type' => 'application/json'], json_encode($errorBody)));
+
+        try {
+            $this->sut->sendJob('job-1', ['type' => 'portalEmailNotification']);
+            $this->fail('Expected RuntimeException');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('TO API: unexpected HTTP 403', $exception->getMessage());
+            $this->assertStringNotContainsString('bob@example.test', $exception->getMessage());
+        }
     }
 }

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\model\TaskOrchestrator;
+
+use InvalidArgumentException;
+use oat\tao\model\TaskOrchestrator\TaskOrchestratorClient;
+use oat\tao\model\TaskOrchestrator\TaskOrchestratorEmailService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TaskOrchestratorEmailServiceTest extends TestCase
+{
+    /** @var TaskOrchestratorClient|MockObject */
+    private $client;
+
+    private TaskOrchestratorEmailService $sut;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(TaskOrchestratorClient::class);
+        $this->sut = new TaskOrchestratorEmailService(
+            $this->client,
+            'local-dev-acc.nextgen-stack-local',
+            'tao-backoffice-bot'
+        );
+    }
+
+    public function testSendEmailBuildsPortalEmailNotificationJob(): void
+    {
+        $this->client
+            ->expects($this->once())
+            ->method('sendJob')
+            ->with(
+                $this->callback(static function (string $jobId): bool {
+                    return $jobId !== '';
+                }),
+                $this->callback(static function (array $job): bool {
+                    return $job['type'] === 'portalEmailNotification'
+                        && $job['tenantId'] === 'local-dev-acc.nextgen-stack-local'
+                        && $job['user']['login'] === 'tao-backoffice-bot'
+                        && $job['email']['templateId'] === 'generic.template'
+                        && $job['email']['recipientUserLogin'] === 'jdoe'
+                        && $job['email']['data'] === ['foo' => 'bar']
+                        && !isset($job['email']['emailAddress']);
+                })
+            )
+            ->willReturn(['status' => 'ok']);
+
+        $jobId = $this->sut->sendEmail('generic.template', 'jdoe', ['foo' => 'bar']);
+
+        $this->assertNotSame('', $jobId);
+    }
+
+    public function testSendEmailIncludesOptionalEmailAddress(): void
+    {
+        $this->client
+            ->expects($this->once())
+            ->method('sendJob')
+            ->with(
+                $this->callback(static function (string $jobId): bool {
+                    return $jobId !== '';
+                }),
+                $this->callback(static function (array $job): bool {
+                    return $job['email']['templateId'] === 'generic.template'
+                        && $job['email']['recipientUserLogin'] === 'jdoe'
+                        && $job['email']['emailAddress'] === 'jdoe@example.com'
+                        && $job['email']['data'] === [];
+                })
+            )
+            ->willReturn(['status' => 'ok']);
+
+        $jobId = $this->sut->sendEmail('generic.template', 'jdoe', [], 'jdoe@example.com');
+
+        $this->assertNotSame('', $jobId);
+    }
+
+    public function testSendEmailRejectsInvalidEmailAddress(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('emailAddress');
+
+        $this->sut->sendEmail('generic.template', 'jdoe', [], 'not-an-email');
+    }
+}

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
@@ -40,8 +40,7 @@ class TaskOrchestratorEmailServiceTest extends TestCase
         $this->client = $this->createMock(TaskOrchestratorClient::class);
         $this->sut = new TaskOrchestratorEmailService(
             $this->client,
-            'local-dev-acc.nextgen-stack-local',
-            'tao-backoffice-bot'
+            'local-dev-acc.nextgen-stack-local'
         );
     }
 
@@ -57,7 +56,8 @@ class TaskOrchestratorEmailServiceTest extends TestCase
                 $this->callback(static function (array $job): bool {
                     return $job['type'] === 'portalEmailNotification'
                         && $job['tenantId'] === 'local-dev-acc.nextgen-stack-local'
-                        && $job['user']['login'] === 'tao-backoffice-bot'
+                        && $job['user']['login'] === 'alice.author'
+                        && $job['user']['id'] === 'local-dev-acc.nextgen-stack-local_alice.author'
                         && $job['email']['templateId'] === 'generic.template'
                         && $job['email']['recipientUserLogin'] === 'jdoe'
                         && $job['email']['data'] === ['foo' => 'bar']
@@ -66,7 +66,7 @@ class TaskOrchestratorEmailServiceTest extends TestCase
             )
             ->willReturn(['status' => 'ok']);
 
-        $jobId = $this->sut->sendEmail('generic.template', 'jdoe', ['foo' => 'bar']);
+        $jobId = $this->sut->sendEmail('generic.template', 'jdoe', ['foo' => 'bar'], null, 'alice.author');
 
         $this->assertNotSame('', $jobId);
     }
@@ -84,14 +84,23 @@ class TaskOrchestratorEmailServiceTest extends TestCase
                     return $job['email']['templateId'] === 'generic.template'
                         && $job['email']['recipientUserLogin'] === 'jdoe'
                         && $job['email']['emailAddress'] === 'jdoe@example.com'
-                        && $job['email']['data'] === [];
+                        && $job['email']['data'] === []
+                        && $job['user']['login'] === 'alice.author';
                 })
             )
             ->willReturn(['status' => 'ok']);
 
-        $jobId = $this->sut->sendEmail('generic.template', 'jdoe', [], 'jdoe@example.com');
+        $jobId = $this->sut->sendEmail('generic.template', 'jdoe', [], 'jdoe@example.com', 'alice.author');
 
         $this->assertNotSame('', $jobId);
+    }
+
+    public function testSendEmailRejectsMissingActorLogin(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('actorLogin');
+
+        $this->sut->sendEmail('generic.template', 'jdoe', []);
     }
 
     public function testSendEmailRejectsInvalidEmailAddress(): void
@@ -99,6 +108,6 @@ class TaskOrchestratorEmailServiceTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('emailAddress');
 
-        $this->sut->sendEmail('generic.template', 'jdoe', [], 'not-an-email');
+        $this->sut->sendEmail('generic.template', 'jdoe', [], 'not-an-email', 'alice.author');
     }
 }

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace oat\tao\test\unit\model\TaskOrchestrator;
 
 use InvalidArgumentException;
+use oat\tao\model\TaskOrchestrator\CommentMentionEmailTemplatePayload;
 use oat\tao\model\TaskOrchestrator\TaskOrchestratorClient;
 use oat\tao\model\TaskOrchestrator\TaskOrchestratorEmailService;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -158,5 +159,75 @@ class TaskOrchestratorEmailServiceTest extends TestCase
         $this->expectExceptionMessage('emailAddress');
 
         $this->sut->sendEmail('generic.template', 'jdoe', [], 'not-an-email', 'alice.author');
+    }
+
+    public function testSendCommentMentionBuildsPortalEmailNotificationJobWithRdfEmail(): void
+    {
+        $payload = new CommentMentionEmailTemplatePayload(
+            'John Doe',
+            'jdoe',
+            'item',
+            'https://backoffice.example/items/123',
+            'Item ABC',
+            'Jane'
+        );
+
+        $this->client
+            ->expects($this->once())
+            ->method('sendJob')
+            ->with(
+                $this->callback(static function (string $jobId): bool {
+                    return $jobId !== '';
+                }),
+                $this->callback(static function (array $job): bool {
+                    return $job['type'] === 'portalEmailNotification'
+                        && $job['tenantId'] === 'local-dev-acc.nextgen-stack-local'
+                        && $job['user']['login'] === 'john.author'
+                        && $job['user']['id'] === 'local-dev-acc.nextgen-stack-local_john.author'
+                        && $job['email']['templateId'] === CommentMentionEmailTemplatePayload::TEMPLATE_ID
+                        && $job['email']['recipientUserLogin'] === 'jdoe'
+                        && $job['email']['emailAddress'] === 'jdoe@example.com'
+                        && $job['email']['data'] === [
+                            'mentionedBy' => 'John Doe',
+                            'username' => 'jdoe',
+                            'resourceType' => 'item',
+                            'resourceUrl' => 'https://backoffice.example/items/123',
+                            'resourceLabel' => 'Item ABC',
+                            'name' => 'Jane',
+                        ];
+                })
+            )
+            ->willReturn(['status' => 'ok']);
+
+        $jobId = $this->sut->sendCommentMention('jdoe', 'jdoe@example.com', $payload, 'john.author');
+
+        $this->assertNotSame('', $jobId);
+    }
+
+    public function testCommentMentionPayloadRejectsEmptyRequiredField(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('resourceUrl');
+
+        new CommentMentionEmailTemplatePayload('John', 'jdoe', 'item', '  ', 'Item ABC');
+    }
+
+    public function testSendCommentMentionRejectsInvalidEmailAddress(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('emailAddress');
+
+        $this->sut->sendCommentMention(
+            'jdoe',
+            'not-an-email',
+            new CommentMentionEmailTemplatePayload(
+                'John Doe',
+                'jdoe',
+                'item',
+                'https://backoffice.example/items/123',
+                'Item ABC'
+            ),
+            'john.author'
+        );
     }
 }

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
@@ -38,10 +38,38 @@ class TaskOrchestratorEmailServiceTest extends TestCase
     protected function setUp(): void
     {
         $this->client = $this->createMock(TaskOrchestratorClient::class);
+        $this->client->method('isConfigured')->willReturn(true);
         $this->sut = new TaskOrchestratorEmailService(
             $this->client,
             'local-dev-acc.nextgen-stack-local'
         );
+    }
+
+    public function testIsConfiguredRequiresClientAndTenant(): void
+    {
+        $this->assertTrue($this->sut->isConfigured());
+
+        $unconfiguredClient = $this->createMock(TaskOrchestratorClient::class);
+        $unconfiguredClient->method('isConfigured')->willReturn(false);
+        $withoutClient = new TaskOrchestratorEmailService($unconfiguredClient, 'tenant');
+        $this->assertFalse($withoutClient->isConfigured());
+
+        $configuredClient = $this->createMock(TaskOrchestratorClient::class);
+        $configuredClient->method('isConfigured')->willReturn(true);
+        $withoutTenant = new TaskOrchestratorEmailService($configuredClient, '  ');
+        $this->assertFalse($withoutTenant->isConfigured());
+    }
+
+    public function testSendEmailRejectsWhenNotConfigured(): void
+    {
+        $client = $this->createMock(TaskOrchestratorClient::class);
+        $client->method('isConfigured')->willReturn(false);
+        $sut = new TaskOrchestratorEmailService($client, 'tenant');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not configured');
+
+        $sut->sendEmail('generic.template', 'jdoe', [], null, 'alice.author');
     }
 
     public function testSendEmailBuildsPortalEmailNotificationJob(): void

--- a/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
+++ b/test/unit/model/TaskOrchestrator/TaskOrchestratorEmailServiceTest.php
@@ -60,6 +60,27 @@ class TaskOrchestratorEmailServiceTest extends TestCase
         $this->assertFalse($withoutTenant->isConfigured());
     }
 
+    public function testConstructorTrimsTenantIdInPayload(): void
+    {
+        $client = $this->createMock(TaskOrchestratorClient::class);
+        $client->method('isConfigured')->willReturn(true);
+        $client
+            ->expects($this->once())
+            ->method('sendJob')
+            ->with(
+                $this->anything(),
+                $this->callback(static function (array $job): bool {
+                    return $job['tenantId'] === 'tenant-a'
+                        && $job['user']['id'] === 'tenant-a_alice.author';
+                })
+            )
+            ->willReturn(['status' => 'ok']);
+
+        $sut = new TaskOrchestratorEmailService($client, '  tenant-a  ');
+        $this->assertTrue($sut->isConfigured());
+        $sut->sendEmail('generic.template', 'jdoe', [], null, 'alice.author');
+    }
+
     public function testSendEmailRejectsWhenNotConfigured(): void
     {
         $client = $this->createMock(TaskOrchestratorClient::class);

--- a/test/unit/models/classes/user/CommentMentionUserSearchServiceTest.php
+++ b/test/unit/models/classes/user/CommentMentionUserSearchServiceTest.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\user;
+
+use common_exception_Unauthorized;
+use core_kernel_classes_Literal;
+use core_kernel_classes_Property;
+use core_kernel_classes_Resource;
+use InvalidArgumentException;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\GenerisRdf;
+use oat\generis\model\OntologyRdfs;
+use oat\tao\model\accessControl\PermissionCheckerInterface;
+use oat\tao\model\TaskOrchestrator\TaskOrchestratorEmailService;
+use oat\tao\model\user\CommentMentionUserSearchService;
+use oat\tao\model\user\MentionEligibleUsersProviderInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use tao_models_classes_UserService;
+
+class CommentMentionUserSearchServiceTest extends TestCase
+{
+    private Ontology|MockObject $ontology;
+    private PermissionCheckerInterface|MockObject $permissionChecker;
+    private tao_models_classes_UserService|MockObject $userService;
+    private MentionEligibleUsersProviderInterface|MockObject $eligibleUsersProvider;
+    private TaskOrchestratorEmailService|MockObject $emailService;
+    private CommentMentionUserSearchService $sut;
+
+    protected function setUp(): void
+    {
+        $this->ontology = $this->createMock(Ontology::class);
+        $this->permissionChecker = $this->createMock(PermissionCheckerInterface::class);
+        $this->userService = $this->createMock(tao_models_classes_UserService::class);
+        $this->eligibleUsersProvider = $this->createMock(MentionEligibleUsersProviderInterface::class);
+        $this->emailService = $this->createMock(TaskOrchestratorEmailService::class);
+        $this->emailService->method('isConfigured')->willReturn(true);
+        $this->sut = new CommentMentionUserSearchService(
+            $this->ontology,
+            $this->permissionChecker,
+            $this->userService,
+            $this->eligibleUsersProvider,
+            $this->emailService
+        );
+    }
+
+    public function testSearchReturnsEmptyWhenEmailNotConfigured(): void
+    {
+        $emailService = $this->createMock(TaskOrchestratorEmailService::class);
+        $emailService->method('isConfigured')->willReturn(false);
+        $sut = new CommentMentionUserSearchService(
+            $this->ontology,
+            $this->permissionChecker,
+            $this->userService,
+            $this->eligibleUsersProvider,
+            $emailService
+        );
+
+        $this->permissionChecker->expects($this->never())->method('hasReadAccess');
+        $this->eligibleUsersProvider->expects($this->never())->method('getEligibleUserUris');
+
+        $result = $sut->search('http://example.test/item#1', 'item', 'ali');
+
+        $this->assertSame([], $result['users']);
+        $this->assertSame(20, $result['limit']);
+    }
+
+    public function testSearchThrowsWhenCurrentUserLacksReadAccess(): void
+    {
+        $this->permissionChecker
+            ->expects($this->once())
+            ->method('hasReadAccess')
+            ->with('http://example.test/item#1')
+            ->willReturn(false);
+
+        $this->eligibleUsersProvider->expects($this->never())->method('getEligibleUserUris');
+
+        $this->expectException(common_exception_Unauthorized::class);
+
+        $this->sut->search('http://example.test/item#1', 'item', 'ali');
+    }
+
+    public function testSearchThrowsOnInvalidResourceType(): void
+    {
+        $this->permissionChecker
+            ->method('hasReadAccess')
+            ->willReturn(true);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->sut->search('http://example.test/item#1', 'delivery', 'ali');
+    }
+
+    public function testSearchReturnsEmptyWhenProviderReturnsEmptyList(): void
+    {
+        $this->permissionChecker
+            ->expects($this->once())
+            ->method('hasReadAccess')
+            ->with('http://example.test/item#1')
+            ->willReturn(true);
+
+        $this->eligibleUsersProvider
+            ->method('getEligibleUserUris')
+            ->with('http://example.test/item#1')
+            ->willReturn([]);
+
+        $this->userService->expects($this->never())->method('getAllUsers');
+
+        $result = $this->sut->search('http://example.test/item#1', 'item', 'ali', 10);
+
+        $this->assertSame([], $result['users']);
+        $this->assertSame(10, $result['limit']);
+        $this->assertArrayNotHasKey('total', $result);
+        $this->assertArrayNotHasKey('offset', $result);
+    }
+
+    public function testOpenModeMatchesLoginViaGetAllUsers(): void
+    {
+        $this->permissionChecker
+            ->expects($this->once())
+            ->method('hasReadAccess')
+            ->with('http://example.test/item#1')
+            ->willReturn(true);
+
+        $this->eligibleUsersProvider
+            ->method('getEligibleUserUris')
+            ->willReturn(null);
+
+        $user = $this->createUserResourceMock(
+            'http://example.test/user#alice',
+            'alice',
+            'Alice',
+            'Smith'
+        );
+
+        $this->userService
+            ->expects($this->once())
+            ->method('getAllUsers')
+            ->willReturn([$user]);
+
+        $result = $this->sut->search('http://example.test/item#1', 'item', 'ali');
+
+        $this->assertCount(1, $result['users']);
+        $this->assertSame(20, $result['limit']);
+        $this->assertSame('http://example.test/user#alice', $result['users'][0]['id']);
+        $this->assertSame('alice', $result['users'][0]['login']);
+        $this->assertSame('Alice Smith', $result['users'][0]['displayName']);
+    }
+
+    public function testRestrictedModeMatchesDisplayName(): void
+    {
+        $this->permissionChecker
+            ->method('hasReadAccess')
+            ->willReturn(true);
+
+        $this->eligibleUsersProvider
+            ->method('getEligibleUserUris')
+            ->willReturn(['http://example.test/user#bob']);
+
+        $user = $this->createUserResourceMock(
+            'http://example.test/user#bob',
+            'bob',
+            'Robert',
+            'Jones'
+        );
+
+        $this->ontology
+            ->method('getResource')
+            ->with('http://example.test/user#bob')
+            ->willReturn($user);
+
+        $this->userService->expects($this->never())->method('getAllUsers');
+
+        $result = $this->sut->search('http://example.test/item#1', 'item', 'robert');
+
+        $this->assertCount(1, $result['users']);
+        $this->assertSame('bob', $result['users'][0]['login']);
+        $this->assertSame('Robert Jones', $result['users'][0]['displayName']);
+    }
+
+    public function testRestrictedModeExcludesNonMatchingQuery(): void
+    {
+        $this->permissionChecker
+            ->method('hasReadAccess')
+            ->willReturn(true);
+
+        $this->eligibleUsersProvider
+            ->method('getEligibleUserUris')
+            ->willReturn(['http://example.test/user#bob']);
+
+        $user = $this->createUserResourceMock(
+            'http://example.test/user#bob',
+            'bob',
+            'Robert',
+            'Jones',
+            'bob@example.test'
+        );
+
+        $this->ontology
+            ->method('getResource')
+            ->willReturn($user);
+
+        $result = $this->sut->search('http://example.test/item#1', 'item', 'zzz');
+
+        $this->assertSame([], $result['users']);
+    }
+
+    public function testExcludesUsersWithoutValidEmail(): void
+    {
+        $this->permissionChecker
+            ->method('hasReadAccess')
+            ->willReturn(true);
+
+        $this->eligibleUsersProvider
+            ->method('getEligibleUserUris')
+            ->willReturn(['http://example.test/user#no-mail']);
+
+        $user = $this->createUserResourceMock(
+            'http://example.test/user#no-mail',
+            'nomail',
+            'No',
+            'Mail',
+            ''
+        );
+
+        $this->ontology
+            ->method('getResource')
+            ->willReturn($user);
+
+        $result = $this->sut->search('http://example.test/item#1', 'item', 'nomail');
+
+        $this->assertSame([], $result['users']);
+    }
+
+    /**
+     * @return core_kernel_classes_Resource&MockObject
+     */
+    private function createUserResourceMock(
+        string $uri,
+        string $login,
+        string $firstName,
+        string $lastName,
+        string $email = 'user@example.test'
+    ): core_kernel_classes_Resource {
+        $loginProperty = $this->createMock(core_kernel_classes_Property::class);
+        $firstNameProperty = $this->createMock(core_kernel_classes_Property::class);
+        $lastNameProperty = $this->createMock(core_kernel_classes_Property::class);
+        $labelProperty = $this->createMock(core_kernel_classes_Property::class);
+        $mailProperty = $this->createMock(core_kernel_classes_Property::class);
+
+        $this->ontology
+            ->method('getProperty')
+            ->willReturnMap([
+                [GenerisRdf::PROPERTY_USER_LOGIN, $loginProperty],
+                [GenerisRdf::PROPERTY_USER_FIRSTNAME, $firstNameProperty],
+                [GenerisRdf::PROPERTY_USER_LASTNAME, $lastNameProperty],
+                [OntologyRdfs::RDFS_LABEL, $labelProperty],
+                [GenerisRdf::PROPERTY_USER_MAIL, $mailProperty],
+            ]);
+
+        $user = $this->createMock(core_kernel_classes_Resource::class);
+        $user->method('getUri')->willReturn($uri);
+        $user->method('exists')->willReturn(true);
+        $user->method('getOnePropertyValue')->willReturnCallback(
+            static function ($property) use (
+                $loginProperty,
+                $firstNameProperty,
+                $lastNameProperty,
+                $labelProperty,
+                $mailProperty,
+                $login,
+                $firstName,
+                $lastName,
+                $email
+            ) {
+                if ($property === $loginProperty) {
+                    return new core_kernel_classes_Literal($login);
+                }
+                if ($property === $firstNameProperty) {
+                    return new core_kernel_classes_Literal($firstName);
+                }
+                if ($property === $lastNameProperty) {
+                    return new core_kernel_classes_Literal($lastName);
+                }
+                if ($property === $labelProperty) {
+                    return new core_kernel_classes_Literal('');
+                }
+                if ($property === $mailProperty) {
+                    return new core_kernel_classes_Literal($email);
+                }
+
+                return null;
+            }
+        );
+
+        return $user;
+    }
+}

--- a/test/unit/models/classes/user/CommentMentionUserSearchServiceTest.php
+++ b/test/unit/models/classes/user/CommentMentionUserSearchServiceTest.php
@@ -262,56 +262,27 @@ class CommentMentionUserSearchServiceTest extends TestCase
         string $lastName,
         string $email = 'user@example.test'
     ): core_kernel_classes_Resource {
-        $loginProperty = $this->createMock(core_kernel_classes_Property::class);
-        $firstNameProperty = $this->createMock(core_kernel_classes_Property::class);
-        $lastNameProperty = $this->createMock(core_kernel_classes_Property::class);
-        $labelProperty = $this->createMock(core_kernel_classes_Property::class);
-        $mailProperty = $this->createMock(core_kernel_classes_Property::class);
-
         $this->ontology
             ->method('getProperty')
-            ->willReturnMap([
-                [GenerisRdf::PROPERTY_USER_LOGIN, $loginProperty],
-                [GenerisRdf::PROPERTY_USER_FIRSTNAME, $firstNameProperty],
-                [GenerisRdf::PROPERTY_USER_LASTNAME, $lastNameProperty],
-                [OntologyRdfs::RDFS_LABEL, $labelProperty],
-                [GenerisRdf::PROPERTY_USER_MAIL, $mailProperty],
-            ]);
+            ->willReturnCallback(
+                function (string $uri): core_kernel_classes_Property {
+                    $property = $this->createMock(core_kernel_classes_Property::class);
+                    $property->method('getUri')->willReturn($uri);
+
+                    return $property;
+                }
+            );
 
         $user = $this->createMock(core_kernel_classes_Resource::class);
         $user->method('getUri')->willReturn($uri);
         $user->method('exists')->willReturn(true);
-        $user->method('getOnePropertyValue')->willReturnCallback(
-            static function ($property) use (
-                $loginProperty,
-                $firstNameProperty,
-                $lastNameProperty,
-                $labelProperty,
-                $mailProperty,
-                $login,
-                $firstName,
-                $lastName,
-                $email
-            ) {
-                if ($property === $loginProperty) {
-                    return new core_kernel_classes_Literal($login);
-                }
-                if ($property === $firstNameProperty) {
-                    return new core_kernel_classes_Literal($firstName);
-                }
-                if ($property === $lastNameProperty) {
-                    return new core_kernel_classes_Literal($lastName);
-                }
-                if ($property === $labelProperty) {
-                    return new core_kernel_classes_Literal('');
-                }
-                if ($property === $mailProperty) {
-                    return new core_kernel_classes_Literal($email);
-                }
-
-                return null;
-            }
-        );
+        $user->method('getPropertiesValues')->willReturn([
+            GenerisRdf::PROPERTY_USER_LOGIN => [new core_kernel_classes_Literal($login)],
+            GenerisRdf::PROPERTY_USER_FIRSTNAME => [new core_kernel_classes_Literal($firstName)],
+            GenerisRdf::PROPERTY_USER_LASTNAME => [new core_kernel_classes_Literal($lastName)],
+            OntologyRdfs::RDFS_LABEL => [new core_kernel_classes_Literal('')],
+            GenerisRdf::PROPERTY_USER_MAIL => [new core_kernel_classes_Literal($email)],
+        ]);
 
         return $user;
     }

--- a/test/unit/models/classes/user/OpenMentionEligibleUsersProviderTest.php
+++ b/test/unit/models/classes/user/OpenMentionEligibleUsersProviderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\user;
+
+use oat\tao\model\user\OpenMentionEligibleUsersProvider;
+use PHPUnit\Framework\TestCase;
+
+class OpenMentionEligibleUsersProviderTest extends TestCase
+{
+    public function testGetEligibleUserUrisReturnsNull(): void
+    {
+        $provider = new OpenMentionEligibleUsersProvider();
+
+        $this->assertNull($provider->getEligibleUserUris('http://example.test/item#1'));
+    }
+}


### PR DESCRIPTION
## Summary

Generic Task Orchestrator (TO) email notification adapter for tao-core (NYSED-38 infrastructure only):

- `TaskOrchestratorClient` — portal auth + email job submission
- `TaskOrchestratorEmailService` — thin service wrapper over the client
- DI registration via `InfrastructureServiceProvider`
- Unit coverage for the email service

This PR replaces the **infrastructure portion** of the mixed-scope PR #4524. Comment-mention deep links, template payload, `sendCommentMention`, and RestUser mention search live in the stacked follow-up PR.

## Test plan

- [ ] Unit: `TaskOrchestratorEmailServiceTest`
- [ ] Confirm DI registers `TaskOrchestratorEmailService` / client correctly
- [ ] Smoke against local TO (optional): submit a generic email job via the adapter

## Related

- Replaces mixed scope of: https://github.com/oat-sa/tao-core/pull/4524 (infrastructure part)
- Follow-up (stacked): comment mention email + RestUser mention search
- Jira: NYSED-38


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Task Orchestrator integration for background jobs and portal email notifications.
  - Added comment-mention autocomplete with permission-aware user search and email validation.
  - Added deep links to referenced back-office resources in comment-mention notifications.
  - Added configurable tenant and service settings with token caching.

- **Bug Fixes**
  - Improved handling of invalid requests, authentication failures, service errors, and communication failures.
  - Prevented sensitive response details from appearing in error messages.

- **Tests**
  - Expanded coverage for notifications, user search, deep links, configuration, authentication, caching, and API errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->