### PR TITLE
fix: Bump TAO version to 2026.10

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -381,9 +381,9 @@ return [
     ],
     'constants' => [
         #TAO version number
-        'TAO_VERSION' => '2026.09',
+        'TAO_VERSION' => '2026.10',
         #TAO version label
-        'TAO_VERSION_NAME' => '2026.09',
+        'TAO_VERSION_NAME' => '2026.10',
         #the name to display
         'PRODUCT_NAME' => 'TAO',
         #TAO release status, use to add specific footer to TAO, available alpha, beta, demo, stable


### PR DESCRIPTION
Update manifest version 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to **2026.10**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->