### PR TITLE
fix: restore Crowdin locale language for RDF PO sync after pluralization

### DIFF
--- a/helpers/translation/class.POFileReader.php
+++ b/helpers/translation/class.POFileReader.php
@@ -63,6 +63,11 @@ class tao_helpers_translation_POFileReader extends tao_helpers_translation_Trans
         $fc = implode('', file($file));
 
         $entries = preg_split("/(?:\r?\n){2,}/", trim($fc));
+
+        // Resolve languages before adding units: addTranslationUnit() copies the
+        // file's current target language onto each unit. Crowdin PO headers often
+        // claim en-US while the real locale is the parent folder name.
+        $bodyEntries = [];
         foreach ($entries as $entry) {
             $parsedEntry = $this->parseEntry($entry);
             if ($parsedEntry === null) {
@@ -77,24 +82,7 @@ class tao_helpers_translation_POFileReader extends tao_helpers_translation_Trans
                 continue;
             }
 
-            $tu = new tao_helpers_translation_POTranslationUnit();
-            $tu->setSource($parsedEntry['msgid']);
-            if ($parsedEntry['msgctxt'] !== '') {
-                $tu->setContext($parsedEntry['msgctxt']);
-            }
-            if ($parsedEntry['msgid_plural'] !== '') {
-                $tu->setSourcePlural($parsedEntry['msgid_plural']);
-                $tu->setTargets($parsedEntry['msgstr_plural']);
-            } elseif ($parsedEntry['msgstr'] !== '') {
-                $tu->setTarget($parsedEntry['msgstr']);
-            }
-
-            $annotations = tao_helpers_translation_POUtils::unserializeAnnotations($parsedEntry['annotations']);
-            foreach ($annotations as $name => $value) {
-                $tu->addAnnotation($name, $value);
-            }
-
-            $tf->addTranslationUnit($tu);
+            $bodyEntries[] = $parsedEntry;
         }
 
         $sourceLanguage = $tf->getHeaders()['sourceLanguage'] ?? '';
@@ -121,6 +109,27 @@ class tao_helpers_translation_POFileReader extends tao_helpers_translation_Trans
         }
         if ($matchedTargetLanguage !== '') {
             $tf->setTargetLanguage(substr($matchedTargetLanguage, 0, 5));
+        }
+
+        foreach ($bodyEntries as $parsedEntry) {
+            $tu = new tao_helpers_translation_POTranslationUnit();
+            $tu->setSource($parsedEntry['msgid']);
+            if ($parsedEntry['msgctxt'] !== '') {
+                $tu->setContext($parsedEntry['msgctxt']);
+            }
+            if ($parsedEntry['msgid_plural'] !== '') {
+                $tu->setSourcePlural($parsedEntry['msgid_plural']);
+                $tu->setTargets($parsedEntry['msgstr_plural']);
+            } elseif ($parsedEntry['msgstr'] !== '') {
+                $tu->setTarget($parsedEntry['msgstr']);
+            }
+
+            $annotations = tao_helpers_translation_POUtils::unserializeAnnotations($parsedEntry['annotations']);
+            foreach ($annotations as $name => $value) {
+                $tu->addAnnotation($name, $value);
+            }
+
+            $tf->addTranslationUnit($tu);
         }
 
         $this->setTranslationFile($tf);

--- a/helpers/translation/rdf/RdfPack.php
+++ b/helpers/translation/rdf/RdfPack.php
@@ -106,7 +106,7 @@ class RdfPack implements \IteratorAggregate
                 $triple->subject = $about;
                 $triple->predicate = $tu->getContext();
                 $triple->object = $tu->getTarget() ? $tu->getTarget() : $tu->getSource();
-                $triple->lg = $tu->getTargetLanguage();
+                $triple->lg = $this->langCode;
                 $triple->modelid = $modelId;
                 $triples[] = $triple;
             }

--- a/migrations/Version202609101019002234_tao.php
+++ b/migrations/Version202609101019002234_tao.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\tao\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\generis\model\OntologyRdfs;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\update\OntologyUpdater;
+
+/**
+ * Fix Crowdin RDF translations wrongly stored as en-US after pluralization PO reader regression.
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202609101019002234_tao extends AbstractMigration
+{
+    private const DELETE_CHUNK_SIZE = 500;
+
+    public function getDescription(): string
+    {
+        return 'Remove RDF label/comment triples wrongly tagged as en-US and re-sync ontology locales'
+            . ' (irreversible down)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $deleted = $this->deleteWronglyTaggedEnUsRdfLiterals();
+        OntologyUpdater::syncModels();
+
+        $this->addReport(Report::createSuccess(
+            sprintf('Deleted %d polluted en-US RDF literals and synced models', $deleted)
+        ));
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addReport(Report::createInfo(
+            'Irreversible: polluted en-US RDF literals were deleted; re-sync after code fix if needed'
+        ));
+    }
+
+    private function deleteWronglyTaggedEnUsRdfLiterals(): int
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT id, subject, predicate, object, l_language
+             FROM statements
+             WHERE predicate IN (?, ?)
+               AND (l_language = ? OR l_language IS NULL OR l_language = ?)',
+            [
+                OntologyRdfs::RDFS_LABEL,
+                OntologyRdfs::RDFS_COMMENT,
+                'en-US',
+                '',
+            ]
+        );
+
+        $baselines = [];
+        foreach ($rows as $row) {
+            $lang = (string) ($row['l_language'] ?? '');
+            if ($lang !== '') {
+                continue;
+            }
+            $baselines[$row['subject'] . "\0" . $row['predicate']] = (string) $row['object'];
+        }
+
+        $idsToDelete = [];
+        foreach ($rows as $row) {
+            if ((string) ($row['l_language'] ?? '') !== 'en-US') {
+                continue;
+            }
+
+            $object = (string) $row['object'];
+            $key = $row['subject'] . "\0" . $row['predicate'];
+            $hasNonAscii = (bool) preg_match('/[^\x00-\x7F]/u', $object);
+            $differsFromBaseline = isset($baselines[$key]) && $baselines[$key] !== $object;
+
+            if ($hasNonAscii || $differsFromBaseline) {
+                $idsToDelete[] = $row['id'];
+            }
+        }
+
+        foreach (array_chunk($idsToDelete, self::DELETE_CHUNK_SIZE) as $chunk) {
+            $placeholders = implode(',', array_fill(0, count($chunk), '?'));
+            $this->connection->executeStatement(
+                "DELETE FROM statements WHERE id IN ({$placeholders})",
+                $chunk
+            );
+        }
+
+        return count($idsToDelete);
+    }
+}

--- a/migrations/Version202609101019002234_tao.php
+++ b/migrations/Version202609101019002234_tao.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
 declare(strict_types=1);
 
 namespace oat\tao\migrations;
@@ -44,52 +62,75 @@ final class Version202609101019002234_tao extends AbstractMigration
 
     private function deleteWronglyTaggedEnUsRdfLiterals(): int
     {
-        $rows = $this->connection->fetchAllAssociative(
+        // Pass 1: collect empty-lang baselines (needed before deciding deletes).
+        $baselines = [];
+        $afterId = 0;
+        while (($rows = $this->fetchMatchingLiteralBatch($afterId)) !== []) {
+            $afterId = (int) $rows[array_key_last($rows)]['id'];
+            foreach ($rows as $row) {
+                if ((string) ($row['l_language'] ?? '') !== '') {
+                    continue;
+                }
+                $baselines[$row['subject'] . "\0" . $row['predicate']] = (string) $row['object'];
+            }
+        }
+
+        // Pass 2: page en-US/empty matches again and delete polluted en-US rows per batch.
+        $deleted = 0;
+        $afterId = 0;
+        while (($rows = $this->fetchMatchingLiteralBatch($afterId)) !== []) {
+            $afterId = (int) $rows[array_key_last($rows)]['id'];
+            $idsToDelete = [];
+            foreach ($rows as $row) {
+                if ((string) ($row['l_language'] ?? '') !== 'en-US') {
+                    continue;
+                }
+
+                $object = (string) $row['object'];
+                $key = $row['subject'] . "\0" . $row['predicate'];
+                $hasNonAscii = (bool) preg_match('/[^\x00-\x7F]/u', $object);
+                $differsFromBaseline = isset($baselines[$key]) && $baselines[$key] !== $object;
+
+                if ($hasNonAscii || $differsFromBaseline) {
+                    $idsToDelete[] = $row['id'];
+                }
+            }
+
+            if ($idsToDelete === []) {
+                continue;
+            }
+
+            $placeholders = implode(',', array_fill(0, count($idsToDelete), '?'));
+            $this->connection->executeStatement(
+                "DELETE FROM statements WHERE id IN ({$placeholders})",
+                $idsToDelete
+            );
+            $deleted += count($idsToDelete);
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fetchMatchingLiteralBatch(int $afterId): array
+    {
+        return $this->connection->fetchAllAssociative(
             'SELECT id, subject, predicate, object, l_language
              FROM statements
              WHERE predicate IN (?, ?)
-               AND (l_language = ? OR l_language IS NULL OR l_language = ?)',
+               AND (l_language = ? OR l_language IS NULL OR l_language = ?)
+               AND id > ?
+             ORDER BY id ASC
+             LIMIT ' . self::DELETE_CHUNK_SIZE,
             [
                 OntologyRdfs::RDFS_LABEL,
                 OntologyRdfs::RDFS_COMMENT,
                 'en-US',
                 '',
+                $afterId,
             ]
         );
-
-        $baselines = [];
-        foreach ($rows as $row) {
-            $lang = (string) ($row['l_language'] ?? '');
-            if ($lang !== '') {
-                continue;
-            }
-            $baselines[$row['subject'] . "\0" . $row['predicate']] = (string) $row['object'];
-        }
-
-        $idsToDelete = [];
-        foreach ($rows as $row) {
-            if ((string) ($row['l_language'] ?? '') !== 'en-US') {
-                continue;
-            }
-
-            $object = (string) $row['object'];
-            $key = $row['subject'] . "\0" . $row['predicate'];
-            $hasNonAscii = (bool) preg_match('/[^\x00-\x7F]/u', $object);
-            $differsFromBaseline = isset($baselines[$key]) && $baselines[$key] !== $object;
-
-            if ($hasNonAscii || $differsFromBaseline) {
-                $idsToDelete[] = $row['id'];
-            }
-        }
-
-        foreach (array_chunk($idsToDelete, self::DELETE_CHUNK_SIZE) as $chunk) {
-            $placeholders = implode(',', array_fill(0, count($chunk), '?'));
-            $this->connection->executeStatement(
-                "DELETE FROM statements WHERE id IN ({$placeholders})",
-                $chunk
-            );
-        }
-
-        return count($idsToDelete);
     }
 }

--- a/test/unit/helpers/translation/POFileReaderTest.php
+++ b/test/unit/helpers/translation/POFileReaderTest.php
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA.
  *
  * Copyright (c) 2026 (original work) Open Assessment Technologies SA
  */

--- a/test/unit/helpers/translation/POFileReaderTest.php
+++ b/test/unit/helpers/translation/POFileReaderTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\helpers\translation;
+
+use common_ext_Extension;
+use common_persistence_InMemoryKvDriver;
+use common_persistence_KeyValuePersistence;
+use core_kernel_classes_Triple;
+use oat\generis\model\OntologyRdfs;
+use oat\oatbox\service\ServiceManager;
+use oat\tao\helpers\translation\rdf\RdfPack;
+use oat\tao\model\service\ApplicationService;
+use PHPUnit\Framework\TestCase;
+use tao_helpers_translation_POFileReader;
+
+/**
+ * @package tao
+ */
+class POFileReaderTest extends TestCase
+{
+    private string $tmpRoot;
+    private ?ServiceManager $previousServiceManager = null;
+
+    protected function setUp(): void
+    {
+        if (!defined('DEFAULT_LANG')) {
+            define('DEFAULT_LANG', 'en-US');
+        }
+
+        $this->previousServiceManager = ServiceManager::getServiceManager();
+        $config = new common_persistence_KeyValuePersistence(new common_persistence_InMemoryKvDriver(), []);
+        $applicationService = $this->createMock(ApplicationService::class);
+        $applicationService->method('getDefaultEncoding')->willReturn('UTF-8');
+        $config->set(ApplicationService::SERVICE_ID, $applicationService);
+        ServiceManager::setServiceManager(new ServiceManager($config));
+
+        $this->tmpRoot = sys_get_temp_dir() . '/tao-po-reader-' . uniqid('', true);
+        mkdir($this->tmpRoot);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousServiceManager !== null) {
+            ServiceManager::setServiceManager($this->previousServiceManager);
+        }
+        $this->removeTree($this->tmpRoot);
+    }
+
+    public function testCrowdinHeaderUsesLocaleFolderAsTargetLanguage(): void
+    {
+        $poPath = $this->writePo(
+            'ja-JP',
+            'foo.rdf.po',
+            <<<'PO'
+msgid ""
+msgstr ""
+"sourceLanguage: en-US\n"
+"targetLanguage: en-US\n"
+
+# http://www.tao.lu/Ontologies/TAOItem.rdf#Item
+msgctxt "http://www.w3.org/2000/01/rdf-schema#label"
+msgid "Item"
+msgstr "アイテム"
+PO
+        );
+
+        $reader = new tao_helpers_translation_POFileReader($poPath);
+        $reader->read();
+        $tf = $reader->getTranslationFile();
+        $tus = $tf->getTranslationUnits();
+
+        $this->assertSame('ja-JP', $tf->getTargetLanguage());
+        $this->assertCount(1, $tus);
+        $this->assertSame('ja-JP', $tus[0]->getTargetLanguage());
+        $this->assertSame('アイテム', $tus[0]->getTarget());
+    }
+
+    public function testCorrectTargetLanguageHeaderIsPreserved(): void
+    {
+        $poPath = $this->writePo(
+            'zh-TW',
+            'foo.rdf.po',
+            <<<'PO'
+msgid ""
+msgstr ""
+"sourceLanguage: en-US\n"
+"targetLanguage: zh-TW\n"
+
+msgctxt "http://www.w3.org/2000/01/rdf-schema#label"
+msgid "Item"
+msgstr "題目"
+PO
+        );
+
+        $reader = new tao_helpers_translation_POFileReader($poPath);
+        $reader->read();
+        $tf = $reader->getTranslationFile();
+        $tus = $tf->getTranslationUnits();
+
+        $this->assertSame('zh-TW', $tf->getTargetLanguage());
+        $this->assertCount(1, $tus);
+        $this->assertSame('zh-TW', $tus[0]->getTargetLanguage());
+    }
+
+    public function testPluralEntriesAreParsed(): void
+    {
+        $poPath = $this->writePo(
+            'sk-SK',
+            'messages.po',
+            <<<'PO'
+msgid ""
+msgstr ""
+"sourceLanguage: en-US\n"
+"targetLanguage: sk-SK\n"
+"Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 3;\n"
+
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] "%d den"
+msgstr[1] "%d dni"
+msgstr[2] "%d dni"
+msgstr[3] "%d dni"
+PO
+        );
+
+        $reader = new tao_helpers_translation_POFileReader($poPath);
+        $reader->read();
+        $tus = $reader->getTranslationFile()->getTranslationUnits();
+
+        $this->assertCount(1, $tus);
+        $this->assertSame('%d days', $tus[0]->getSourcePlural());
+        $this->assertSame('%d den', $tus[0]->getTargetByIndex(0));
+        $this->assertSame('%d dni', $tus[0]->getTargetByIndex(3));
+        $this->assertSame('sk-SK', $tus[0]->getTargetLanguage());
+    }
+
+    public function testRdfPackUsesConstructorLangCodeForTripleLanguage(): void
+    {
+        $poPath = $this->writePo(
+            'hu-HU',
+            'item.rdf.po',
+            <<<'PO'
+msgid ""
+msgstr ""
+"sourceLanguage: en-US\n"
+"targetLanguage: en-US\n"
+
+# http://www.tao.lu/Ontologies/TAOItem.rdf#Item
+msgctxt "http://www.w3.org/2000/01/rdf-schema#label"
+msgid "Item"
+msgstr "Elem"
+PO
+        );
+
+        $extension = $this->createMock(common_ext_Extension::class);
+        $pack = new class ('hu-HU', $extension) extends RdfPack {
+            public function exposeTriplesFromFile(string $file, int $modelId): \ArrayIterator
+            {
+                return $this->getTriplesFromFile($file, $modelId);
+            }
+        };
+
+        $triples = iterator_to_array($pack->exposeTriplesFromFile($poPath, 1));
+
+        $this->assertCount(1, $triples);
+        /** @var core_kernel_classes_Triple $triple */
+        $triple = $triples[0];
+        $this->assertSame('hu-HU', $triple->lg);
+        $this->assertSame(OntologyRdfs::RDFS_LABEL, $triple->predicate);
+        $this->assertSame('Elem', $triple->object);
+    }
+
+    private function writePo(string $locale, string $filename, string $content): string
+    {
+        $dir = $this->tmpRoot . '/locales/' . $locale;
+        mkdir($dir, 0777, true);
+        $path = $dir . '/' . $filename;
+        file_put_contents($path, $content);
+
+        return $path;
+    }
+
+    private function removeTree(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $full = $path . '/' . $entry;
+            if (is_dir($full)) {
+                $this->removeTree($full);
+            } else {
+                unlink($full);
+            }
+        }
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Ticket:
1. POFileReader  has flipped the order of steps
Before: set targetLanguage on the file first, then addTranslationUnit()
After: addTranslationUnit() first, then set targetLanguage on the file.
addTranslationUnit() copies the file language onto each unit at add time

2. $triple->lg = $tu->getTargetLanguage(); this value is always set to en-US
Crowdin puts the translated text in the right folder (locales/hu-HU/…), but the PO metadata still says targetLanguage: en-US.

TAO already knew that. Old POFileReader had a workaround.
Now its:

1. Crowdin sets fake targetLanguage: en-US.
2. Env update runs OntologyUpdater -> RdfPack reads those POs.
3. After [PR #4513](https://github.com/oat-sa/tao-core/pull/4513), units are created before the folder-name fix runs -> each unit keeps default en-US.
4. RdfPack stores $tu->getTargetLanguage() -> DB gets Hungarian/Japanese/Chinese strings tagged as en-US.

## What's Changed
- Regression from #4513 / AUT-4679
- Crowdin `targetLanguage: en-US` + unit-before-language order
- Code fix + migration cleanup + sync
- Irreversible migration `down`

Before:
<img width="1197" height="410" alt="image" src="https://github.com/user-attachments/assets/2cdb969c-3ef9-410c-8fc8-8a2ffcce8379" />

After:
`[notice] Deleted 4831 polluted en-US RDF literals and synced models
[warning] Migration oat\tao\migrations\Version202609101019002234_tao was executed but did not result in any SQL statements.
[notice] finished in 4328.1ms, used 44M memory, 1 migrations executed, 0 sql queries`
<img width="1185" height="419" alt="image" src="https://github.com/user-attachments/assets/1e95dec3-10d8-4db1-866c-2d7cdbe93d6a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PO translation imports to correctly apply languages from file headers and locale folders, including plural entries.
  * Ensured RDF translation data uses the configured language consistently.
  * Corrected existing RDF labels and comments that were incorrectly tagged as `en-US`.

* **Data Maintenance**
  * Added a database migration to clean up affected translation metadata in batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->