### PR TITLE
fix: INF-581 backport tao-core-shared-libs 1.12.1 to v56.7.3

### DIFF
--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -12,7 +12,7 @@
                 "@babel/polyfill": "^7.4.4",
                 "@oat-sa/tao-core-libs": "^1.2.1",
                 "@oat-sa/tao-core-sdk": "^3.5.0",
-                "@oat-sa/tao-core-shared-libs": "^1.12.0",
+                "@oat-sa/tao-core-shared-libs": "^1.12.1",
                 "@oat-sa/tao-core-ui": "^3.21.0",
                 "codemirror": "^5.54.0",
                 "dompurify": "^2.4.0",
@@ -78,10 +78,9 @@
             }
         },
         "node_modules/@oat-sa/tao-core-shared-libs": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.12.0.tgz",
-            "integrity": "sha512-5o6icg+PxsBHI4kihIxp1G7RAmEya7WbJhOdfPG5HNQnRwxjd18l4ThsvGG23V8cDaVk1p9rasXN1zgxC7r5tg==",
-            "license": "GPL-2.0"
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@oat-sa/tao-core-shared-libs/-/tao-core-shared-libs-1.12.1.tgz",
+            "integrity": "sha512-UWauF0iz7bN+AYD7S5Ak/bD14a/brPb4we/uY4a0LeyWDEs+HVPBoB6uaq/Bf9raD4xdq4Ewf2iE0q1adVVLGQ=="
         },
         "node_modules/@oat-sa/tao-core-ui": {
             "version": "3.21.0",

--- a/views/package.json
+++ b/views/package.json
@@ -12,7 +12,7 @@
         "@babel/polyfill": "^7.4.4",
         "@oat-sa/tao-core-libs": "^1.2.1",
         "@oat-sa/tao-core-sdk": "^3.5.0",
-        "@oat-sa/tao-core-shared-libs": "^1.12.0",
+        "@oat-sa/tao-core-shared-libs": "^1.12.1",
         "@oat-sa/tao-core-ui": "^3.21.0",
         "codemirror": "^5.54.0",
         "dompurify": "^2.4.0",


### PR DESCRIPTION
## Summary
- Backport bump of `@oat-sa/tao-core-shared-libs` from `^1.12.0` / lock `1.12.0` to `^1.12.1` (lock `1.12.1`) onto `v56.7.2` → target `release-56.7.3`
- Ships the null-guard fix for ruby-as-last-child in authoring (`ensureZwsAnchorsAfterRuby` / CKEditor revision `5c7646c80`), so the toolbar no longer dies and edits are not silently discarded
- Same dependency bump pattern as [INF-529](https://oat-sa.atlassian.net/browse/INF-529) / [#4501](https://github.com/oat-sa/tao-core/pull/4501) on the February line

## Context
- [INF-581](https://oat-sa.atlassian.net/browse/INF-581)
- Base: `release-56.7.3` (from tag `v56.7.2`)
- CKEditor is resolved from `node_modules` via requirejs (`tao-core-shared-libs`); `grunt taobundle` was attempted locally but failed on unrelated mathjax output cleanup — loader hashes unchanged, so no bundle files in this PR

## Test plan
- [ ] Confirm `views/package.json` / lock resolve to `@oat-sa/tao-core-shared-libs@1.12.1`
- [ ] Confirm installed `ckeditor.js` revision is `5c7646c80` (or newer with `e&&e.getFirst` guard)
- [ ] Repro from INF-581: ruby as last child of editable prompt — toolbar stays usable; Save persists edits
- [ ] Tag `v56.7.3` after merge (release owner)

[INF-529]: https://oat-sa.atlassian.net/browse/INF-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INF-581]: https://oat-sa.atlassian.net/browse/INF-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a shared library dependency to version 1.12.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->