### PR TITLE
fix: INF-579 return bool from StateMigration::archive on Flysystem

### DIFF
--- a/models/classes/state/StateMigration.php
+++ b/models/classes/state/StateMigration.php
@@ -13,7 +13,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
  *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
@@ -57,19 +57,21 @@ class StateMigration extends ConfigurableService
      *
      * @param string $userId
      * @param string $callId
-     * @return boolean
+     * @return bool true when archived; false when no state exists for the callId
      */
     public function archive($userId, $callId)
     {
-
         /** @var StateStorage $stateStorage */
         $stateStorage = $this->getServiceManager()->get(StateStorage::SERVICE_ID);
 
         $state = $stateStorage->get($userId, $callId);
+        if (is_null($state)) {
+            return false;
+        }
 
-        return (!is_null($state))
-            ? $this->getFileSystem()->write($this->generateSerial($userId, $callId), $state)
-            : false;
+        $this->getFileSystem()->write($this->generateSerial($userId, $callId), $state);
+
+        return true;
     }
 
     public function restore($userId, $callId)
@@ -94,6 +96,11 @@ class StateMigration extends ConfigurableService
     public function removeBackup($userId, $callId)
     {
         $this->getFileSystem()->delete($this->generateSerial($userId, $callId));
+    }
+
+    public function hasBackup(string $userId, string $callId): bool
+    {
+        return $this->getFileSystem()->fileExists($this->generateSerial($userId, $callId));
     }
 
     private function generateSerial($userId, $callId)

--- a/models/classes/state/StateMigration.php
+++ b/models/classes/state/StateMigration.php
@@ -59,7 +59,7 @@ class StateMigration extends ConfigurableService
      * @param string $callId
      * @return bool true when archived; false when no state exists for the callId
      */
-    public function archive($userId, $callId)
+    public function archive(string $userId, string $callId): bool
     {
         /** @var StateStorage $stateStorage */
         $stateStorage = $this->getServiceManager()->get(StateStorage::SERVICE_ID);

--- a/test/unit/models/classes/state/StateMigrationTest.php
+++ b/test/unit/models/classes/state/StateMigrationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 31 Milk St # 960789 Boston, MA 02196 USA
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\tao\test\unit\models\classes\state;
+
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\oatbox\filesystem\FileSystem;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\tao\model\state\StateMigration;
+use oat\tao\model\state\StateStorage;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class StateMigrationTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+
+    private const FILESYSTEM_ID = 'stateBackup';
+    private const USER_ID = 'd250fc6f:S_XX99929000004:01925ab3-7497-478e-8f2f-626d267a3eea';
+    private const CALL_ID = 'kve_de_http://example.org#i6a98';
+
+    /** @var StateStorage|MockObject */
+    private $stateStorage;
+
+    /** @var FileSystem|MockObject */
+    private $fileSystem;
+
+    private StateMigration $subject;
+
+    protected function setUp(): void
+    {
+        $this->stateStorage = $this->createMock(StateStorage::class);
+        $this->fileSystem = $this->createMock(FileSystem::class);
+
+        $fileSystemService = $this->createMock(FileSystemService::class);
+        $fileSystemService
+            ->method('getFileSystem')
+            ->with(self::FILESYSTEM_ID)
+            ->willReturn($this->fileSystem);
+
+        $this->subject = new StateMigration([
+            StateMigration::OPTION_FILESYSTEM => self::FILESYSTEM_ID,
+        ]);
+        $this->subject->setServiceLocator($this->getServiceManagerMock([
+            StateStorage::SERVICE_ID => $this->stateStorage,
+            FileSystemService::SERVICE_ID => $fileSystemService,
+        ]));
+    }
+
+    public function testArchiveReturnsFalseWhenStateIsMissing(): void
+    {
+        $this->stateStorage
+            ->expects($this->once())
+            ->method('get')
+            ->with(self::USER_ID, self::CALL_ID)
+            ->willReturn(null);
+
+        $this->fileSystem->expects($this->never())->method('write');
+
+        $this->assertFalse($this->subject->archive(self::USER_ID, self::CALL_ID));
+    }
+
+    public function testArchiveReturnsTrueWhenWriteSucceedsWithVoidReturn(): void
+    {
+        $state = '{"item":"response"}';
+        $serial = md5(self::USER_ID . self::CALL_ID);
+
+        $this->stateStorage
+            ->expects($this->once())
+            ->method('get')
+            ->with(self::USER_ID, self::CALL_ID)
+            ->willReturn($state);
+
+        // Flysystem 3 write(): void — must not be used as the archive() return value.
+        $this->fileSystem
+            ->expects($this->once())
+            ->method('write')
+            ->with($serial, $state);
+
+        $this->assertTrue($this->subject->archive(self::USER_ID, self::CALL_ID));
+    }
+
+    public function testArchivePropagatesWriteFailure(): void
+    {
+        $this->stateStorage
+            ->method('get')
+            ->willReturn('{"item":"response"}');
+
+        $this->fileSystem
+            ->method('write')
+            ->willThrowException(new RuntimeException('unable to write'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('unable to write');
+
+        $this->subject->archive(self::USER_ID, self::CALL_ID);
+    }
+
+    public function testHasBackupDelegatesToFileExists(): void
+    {
+        $serial = md5(self::USER_ID . self::CALL_ID);
+
+        $this->fileSystem
+            ->expects($this->once())
+            ->method('fileExists')
+            ->with($serial)
+            ->willReturn(true);
+
+        $this->assertTrue($this->subject->hasBackup(self::USER_ID, self::CALL_ID));
+    }
+
+    public function testHasBackupReturnsFalseWhenMissing(): void
+    {
+        $this->fileSystem
+            ->method('fileExists')
+            ->willReturn(false);
+
+        $this->assertFalse($this->subject->hasBackup(self::USER_ID, self::CALL_ID));
+    }
+}


### PR DESCRIPTION
## Summary
- Stop treating successful Flysystem 3 `write()` as failure: `archive()` now returns `true` after a successful write and `false` when no KV state exists (write failures still throw).
- Add `hasBackup()` for callers that need to check whether an archive object exists.
- Cover missing-state / successful void write / write failure / `hasBackup` with unit tests.
## Context
On Flysystem 1, `write()` returned `true`. On Flysystem 3 it returns `void`, so `return $fs->write(...)` yielded `null`. `StateOffloadTask` then skipped `StateRemovalTask`, leaving `tao:state:*` keys in Redis/ElastiCache after closed sessions.
Companion change: `oat-sa/extension-tao-testqti` (`StateOffloadTask` distinguishes missing state vs write failure).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * State archiving now clearly reports whether a backup was created successfully.
  * Added checks to determine whether saved state data has an available backup.
  * Preserved filesystem errors when backup writes fail.
  * Missing state is handled without creating an archive.

* **Tests**
  * Added coverage for missing state, successful backups, write failures, backup availability checks, and archived state identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->